### PR TITLE
Use the project.scm.url as Implementation-URL in the jar manifests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
                             <Implementation-Title>twelvemonkeys-${project.artifactId}</Implementation-Title>
                             <Implementation-Vendor>TwelveMonkeys</Implementation-Vendor>
                             <Implementation-Version>${project.version}</Implementation-Version>
-                            <Implementation-URL>http://github.com/haraldk/TwelveMonkeys</Implementation-URL>
+                            <Implementation-URL>${project.scm.url}</Implementation-URL>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Main idea here is to avoid duplication.

Also, in my current project where I'm using the twelvemonkeys library I build local "releases" for internal consumption from the snapshots, and so would like to be able to identify those by looking into the jar files. My local releases are based on a fork from github, with the version and SCM information adjusted to point back to our repository.

This is purely a "nice to have" however.
