### PR TITLE
Fix conditions in #showEm()

### DIFF
--- a/common/common-image/src/test/java/com/twelvemonkeys/image/ImageUtilTestCase.java
+++ b/common/common-image/src/test/java/com/twelvemonkeys/image/ImageUtilTestCase.java
@@ -439,7 +439,11 @@ public class ImageUtilTestCase extends TestCase {
     }
 
     private void showEm(final BufferedImage pOriginal, final BufferedImage pNotSharpened, final BufferedImage pSharpened, final BufferedImage pSharpenedDefault, final BufferedImage pSharpenedMore, final String pTitle) {
-        if (pOriginal != null) {
+        if (pOriginal == null) {
+            return;
+        }
+
+        if (GraphicsEnvironment.isHeadless()) {
             return;
         }
 


### PR DESCRIPTION
- return when the pOriginal is null, not when it is non-null
  (Eclipse noticed a definitive NPE)
- return when running in headless mode (unit tests via maven)
