### PR TITLE
Fixed an issue with long runlengths in CCITTFax writing

### DIFF
--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxEncoderStream.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxEncoderStream.java
@@ -219,7 +219,7 @@ public class CCITTFaxEncoderStream extends OutputStream {
         while (nonterm > 0) {
             if (nonterm >= codes.length) {
                 write(codes[codes.length - 1].code, codes[codes.length - 1].length);
-                nonterm -= codes.length - 1;
+                nonterm -= codes.length;
             }
             else {
                 write(codes[nonterm - 1].code, codes[nonterm - 1].length);


### PR DESCRIPTION
When a runLength had more than 2560 pixels the remaining runLength part was miscalculated.