### PR TITLE
Support Modified and custom tags

### DIFF
--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageMetadata.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageMetadata.java
@@ -1338,4 +1338,31 @@ public final class TIFFImageMetadata extends AbstractMetadata {
     public Entry getTIFFField(final int tagNumber) {
         return ifd.getEntryById(tagNumber);
     }
+
+    public Iterable<Entry> getTIFFFields() {
+        return new Iterable<Entry>() {
+            @Override
+            public Iterator<Entry> iterator() {
+                return new Iterator<Entry>() {
+
+                    private final Iterator<Entry> iterator = ifd.iterator();
+
+                    @Override
+                    public boolean hasNext() {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public Entry next() {
+                        return iterator.next();
+                    }
+
+                    @Override
+                    public void remove() {
+
+                    }
+                };
+            }
+        };
+    }
 }

--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriteParam.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriteParam.java
@@ -28,8 +28,12 @@
 
 package com.twelvemonkeys.imageio.plugins.tiff;
 
+import com.twelvemonkeys.imageio.metadata.Entry;
+
 import javax.imageio.ImageWriteParam;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * TIFFImageWriteParam
@@ -53,6 +57,8 @@ public final class TIFFImageWriteParam extends ImageWriteParam {
     // Support PackBits compression (32773)
     // Support LZW compression (5)?
     // Support JPEG compression (7)
+
+    private final Map<Object, Entry> tags = new HashMap<Object, Entry>();
 
     TIFFImageWriteParam() {
         this(Locale.getDefault());
@@ -125,5 +131,9 @@ public final class TIFFImageWriteParam extends ImageWriteParam {
 //        }
 
         throw new IllegalArgumentException(String.format("Unsupported compression type: %s", param.getCompressionType()));
+    }
+
+    public Map<Object, Entry> getTags() {
+        return tags;
     }
 }

--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriter.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriter.java
@@ -303,6 +303,19 @@ public final class TIFFImageWriter extends ImageWriterBase {
         Entry resUnit = metadata.getIFD().getEntryById(TIFF.TAG_RESOLUTION_UNIT);
         entries.put(TIFF.TAG_RESOLUTION_UNIT, resUnit != null ? resUnit : new TIFFEntry(TIFF.TAG_RESOLUTION_UNIT, TIFFBaseline.RESOLUTION_UNIT_DPI));
 
+        if(param instanceof TIFFImageWriteParam) {
+            TIFFImageWriteParam tiffParam = (TIFFImageWriteParam) param;
+            for (Map.Entry<Object, Entry> entry : tiffParam.getTags().entrySet()) {
+                Integer identifier = (Integer) entry.getKey();
+                if (entry.getValue() == null) {
+                    entries.remove(identifier);
+                } else {
+                    entries.put(identifier, entry.getValue());
+                }
+            }
+        }
+
+
         // TODO: RowsPerStrip - can be entire image (or even 2^32 -1), but it's recommended to write "about 8K bytes" per strip
         entries.put(TIFF.TAG_ROWS_PER_STRIP, new TIFFEntry(TIFF.TAG_ROWS_PER_STRIP, renderedImage.getHeight()));
         // - StripByteCounts - for no compression, entire image data... (TODO: How to know the byte counts prior to writing data?)
@@ -457,12 +470,27 @@ public final class TIFFImageWriter extends ImageWriterBase {
         output.length: 12600399
          */
 
-        int samplesPerPixel = (Integer) entries.get(TIFF.TAG_SAMPLES_PER_PIXEL).getValue();
-        int bitPerSample = ((short[]) entries.get(TIFF.TAG_BITS_PER_SAMPLE).getValue())[0];
+        int samplesPerPixel = 1;
+        int bitPerSample = 1;
+
+        if (entries.get(TIFF.TAG_SAMPLES_PER_PIXEL) != null) {
+            samplesPerPixel = (Integer) entries.get(TIFF.TAG_SAMPLES_PER_PIXEL).getValue();
+        }
+        if (entries.get(TIFF.TAG_BITS_PER_SAMPLE) != null) {
+            Object value = entries.get(TIFF.TAG_BITS_PER_SAMPLE).getValue();
+            if (value.getClass().isArray()) {
+                bitPerSample = ((short[]) value)[0];
+            } else {
+                bitPerSample = (Integer) value;
+            }
+        }
 
         // Use predictor by default for LZW and ZLib/Deflate
         // TODO: Unless explicitly disabled in TIFFImageWriteParam
-        int compression = ((Number) entries.get(TIFF.TAG_COMPRESSION).getValue()).intValue();
+        int compression = TIFFBaseline.COMPRESSION_NONE;
+        if (entries.get(TIFF.TAG_COMPRESSION).getValue() != null) {
+            compression = ((Number) entries.get(TIFF.TAG_COMPRESSION).getValue()).intValue();
+        }
         OutputStream stream;
 
         switch (compression) {


### PR DESCRIPTION
Allows to customize tags in the generated tiff file. It allows, for example, to modify only the image of an existing tiff image with custom fields. 