### PR TITLE
Merging of TIFF Pages with Sub-IFDs caused a NPE

### DIFF
--- a/contrib/src/main/java/com/twelvemonkeys/contrib/tiff/TIFFUtilities.java
+++ b/contrib/src/main/java/com/twelvemonkeys/contrib/tiff/TIFFUtilities.java
@@ -477,12 +477,13 @@ public final class TIFFUtilities {
             }
 
             Entry compressionEntry = IFD.getEntryById(TIFF.TAG_COMPRESSION);
-            Number compression = (Number) compressionEntry.getValue();
-            if (compression.shortValue() == TIFFExtension.COMPRESSION_OLD_JPEG) {
-                newIFD.remove(compressionEntry);
-                newIFD.add(new TIFFEntry(TIFF.TAG_COMPRESSION, TIFF.TYPE_SHORT, TIFFExtension.COMPRESSION_JPEG));
+            if(compressionEntry != null) {
+                Number compression = (Number) compressionEntry.getValue();
+                if (compression.shortValue() == TIFFExtension.COMPRESSION_OLD_JPEG) {
+                    newIFD.remove(compressionEntry);
+                    newIFD.add(new TIFFEntry(TIFF.TAG_COMPRESSION, TIFF.TYPE_SHORT, TIFFExtension.COMPRESSION_JPEG));
+                }
             }
-
             return newIFD;
         }
 

--- a/contrib/src/test/java/com/twelvemonkeys/contrib/tiff/TIFFUtilitiesTest.java
+++ b/contrib/src/test/java/com/twelvemonkeys/contrib/tiff/TIFFUtilitiesTest.java
@@ -233,6 +233,34 @@ public class TIFFUtilitiesTest {
         }
     }
 
+    @Test
+    public void testMergeWithSubIFD() throws IOException {
+        String testFile = "/tiff/cmyk_jpeg.tif";
+
+        File output = File.createTempFile("imageiotest", ".tif");
+        ImageOutputStream outputStream = ImageIO.createImageOutputStream(output);
+        InputStream inputStream1 = getClassLoaderResource(testFile).openStream();
+        ImageInputStream imageInput1 = ImageIO.createImageInputStream(inputStream1);
+        InputStream inputStream2 = getClassLoaderResource(testFile).openStream();
+        ImageInputStream imageInput2 = ImageIO.createImageInputStream(inputStream2);
+        ArrayList<TIFFUtilities.TIFFPage> pages = new ArrayList<>();
+        pages.addAll(TIFFUtilities.getPages(imageInput1));
+        pages.addAll(TIFFUtilities.getPages(imageInput2));
+        TIFFUtilities.writePages(outputStream, pages);
+
+        ImageInputStream testOutput = ImageIO.createImageInputStream(output);
+        ImageReader reader = ImageIO.getImageReaders(testOutput).next();
+        reader.setInput(testOutput);
+        int numImages = reader.getNumImages(true);
+        for (int i = 0; i < numImages; i++) {
+            reader.read(i);
+        }
+
+        imageInput1.close();
+        imageInput2.close();
+        outputStream.close();
+    }
+
     protected URL getClassLoaderResource(final String pName) {
         return getClass().getResource(pName);
     }


### PR DESCRIPTION
Merging of TIFF Pages with Sub IFDs failed when there's no TIFF.TAG_COMPRESSION in the Sub IFD:
java.lang.NullPointerException
	at com.twelvemonkeys.contrib.tiff.TIFFUtilities$TIFFPage.writeDirectoryData(TIFFUtilities.java:481)
	at com.twelvemonkeys.contrib.tiff.TIFFUtilities$TIFFPage.writeDirectoryData(TIFFUtilities.java:335)
	at com.twelvemonkeys.contrib.tiff.TIFFUtilities$TIFFPage.write(TIFFUtilities.java:325)