### PR TITLE
Added an extra mark to match the reset call in the finally block

### DIFF
--- a/imageio/imageio-pict/src/main/java/com/twelvemonkeys/imageio/plugins/pict/PICTImageReaderSpi.java
+++ b/imageio/imageio-pict/src/main/java/com/twelvemonkeys/imageio/plugins/pict/PICTImageReaderSpi.java
@@ -69,6 +69,12 @@ public final class PICTImageReaderSpi extends ImageReaderSpiBase {
             else {
                 // Skip header 512 bytes for file-based streams
                 stream.reset();
+
+                // If we don't mark again here, the reset call in the finally block will:
+                // A) do nothing
+                // B) eat marks created in the stream previously
+                stream.mark();
+
                 skipNullHeader(stream);
             }
 


### PR DESCRIPTION
The finally block is always called, so previously this was calling reset twice and marking only once.

This caused an issue with some of my dependencies that had set marks on the stream before `canDecodeInput` was called, this would eat the marks and when their code called reset it would not do was it was expected.