### PR TITLE
Fix ResampleOp for ExtraSamplesColorModel

### DIFF
--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/ExtraSamplesColorModel.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/ExtraSamplesColorModel.java
@@ -8,6 +8,7 @@ import java.awt.image.ComponentColorModel;
 import java.awt.image.ComponentSampleModel;
 import java.awt.image.SampleModel;
 import java.awt.image.WritableRaster;
+import java.awt.image.DataBuffer;
 
 /**
  * ExtraSamplesColorModel.
@@ -23,7 +24,7 @@ final class ExtraSamplesColorModel extends ComponentColorModel {
     private final int numComponents;
 
     ExtraSamplesColorModel(ColorSpace cs, boolean isAlphaPremultiplied, int dataType, int extraComponents) {
-        super(cs, true, isAlphaPremultiplied, Transparency.TRANSLUCENT, dataType);
+        super(cs, bitsArrayHelper(dataType, cs, extraComponents), true, isAlphaPremultiplied, Transparency.TRANSLUCENT, dataType);
         Validate.isTrue(extraComponents > 0, "Extra components must be > 0");
         this.numComponents = super.getNumComponents() + extraComponents;
     }
@@ -56,5 +57,15 @@ final class ExtraSamplesColorModel extends ComponentColorModel {
         return raster.createWritableChild(x, y, raster.getWidth(),
                 raster.getHeight(), x, y,
                 band);
+    }
+
+    private static int[] bitsArrayHelper(int transferType, ColorSpace colorSpace, int extraComponents) {
+        int numBits = DataBuffer.getDataTypeSize(transferType);
+        int numComponents = colorSpace.getNumComponents() + 1 + extraComponents;
+        int[] bits = new int[numComponents];
+        for (int i = 0; i < numComponents; i++) {
+            bits[i] = numBits;
+        }
+        return bits;
     }
 }

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/ExtraSamplesColorModelTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/ExtraSamplesColorModelTest.java
@@ -1,0 +1,44 @@
+package com.twelvemonkeys.imageio.plugins.tiff;
+
+import com.twelvemonkeys.image.ResampleOp;
+import org.junit.Test;
+
+import javax.imageio.ImageTypeSpecifier;
+import java.awt.color.ColorSpace;
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBuffer;
+import java.awt.image.PixelInterleavedSampleModel;
+
+import static org.junit.Assert.assertEquals;
+
+public class ExtraSamplesColorModelTest {
+
+    private ImageTypeSpecifier createImageTypeSpecifier() {
+        ColorSpace cs = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+        int samplesPerPixel = 5;
+        int significantSamples = cs.getNumComponents() + 1;
+
+        return new ImageTypeSpecifier(
+                new ExtraSamplesColorModel(cs, true, DataBuffer.TYPE_BYTE, samplesPerPixel - significantSamples),
+                new PixelInterleavedSampleModel(DataBuffer.TYPE_BYTE, 1, 1, samplesPerPixel, samplesPerPixel, createOffsets(samplesPerPixel))
+        );
+    }
+
+    private static int[] createOffsets(int samplesPerPixel) {
+        int[] offsets = new int[samplesPerPixel];
+        for (int i = 0; i < samplesPerPixel; i++) {
+            offsets[i] = i;
+        }
+        return offsets;
+    }
+
+    @Test
+    public void testImageWithExtraSamplesCanBeResampled() {
+        ImageTypeSpecifier imageTypeSpecifier = createImageTypeSpecifier();
+        BufferedImage bufferedImage = imageTypeSpecifier.createBufferedImage(100, 100);
+        BufferedImage resampled = new ResampleOp(50, 50, ResampleOp.FILTER_LANCZOS).filter(bufferedImage, null);
+
+        assertEquals(50, resampled.getWidth());
+        assertEquals(50, resampled.getHeight());
+    }
+}


### PR DESCRIPTION
The default way of computing significant bits in ComponentColorModel does not take into account extra components. This leads to ArrayIndexOutOfBoundsException in `getComponentSize` method when trying to resample image with ResampleOp#filter.

Don't know whether this fix is conceptually correct. Does it make sense to resample extra components?
At least provided test illustrates the issue.