### PR TITLE
 Use Document as Input in the SVGImageReader 

### DIFF
--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
@@ -32,6 +32,7 @@ package com.twelvemonkeys.imageio.plugins.svg;
 
 import com.twelvemonkeys.imageio.spi.ImageReaderSpiBase;
 import com.twelvemonkeys.lang.SystemUtil;
+import org.w3c.dom.Document;
 
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ServiceRegistry;
@@ -62,7 +63,7 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
     }
 
     public boolean canDecodeInput(final Object pSource) throws IOException {
-        return pSource instanceof ImageInputStream && canDecode((ImageInputStream) pSource);
+        return (pSource instanceof Document) || (pSource instanceof ImageInputStream && canDecode((ImageInputStream) pSource));
     }
 
     @SuppressWarnings("StatementWithEmptyBody")

--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGProviderInfo.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGProviderInfo.java
@@ -31,6 +31,9 @@
 package com.twelvemonkeys.imageio.plugins.svg;
 
 import com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfo;
+import org.w3c.dom.Document;
+
+import javax.imageio.stream.ImageInputStream;
 
 /**
  * SVGProviderInfo.
@@ -40,6 +43,13 @@ import com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfo;
  * @version $Id: SVGProviderInfo.java,v 1.0 20/03/15 harald.kuhr Exp$
  */
 final class SVGProviderInfo extends ReaderWriterProviderInfo {
+    private final Class[] inputTypes = new Class[] {ImageInputStream.class, Document.class};
+    
+    @Override
+    public Class[] inputTypes() {
+        return inputTypes;
+    }
+    
     SVGProviderInfo() {
         super(
                 SVGProviderInfo.class,


### PR DESCRIPTION
So, here it is. What we discussed here:
https://github.com/haraldk/TwelveMonkeys/issues/451

I included the method to also allow using a simple org.w3c.dom.Document. You can remove it if you don't like ; )

As a note, the base URI will be set if the passed documents have it properly set. However, if also using default reading parameters, like `reader.read(0, reader.getDefaultReadParam());` the URI that will be used is always the one set in the parameters, which will be null by default (ignoring the valid one in the document).

Hope this helps. 
(I'm not used to GitHub, I hope I'm not doing anything wrong)
