### PR TITLE
Fix test that doesn't compile when the JDK is Java 11 and remove a few tests that are only testing java.util classes.

### DIFF
--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionAbstractTest.java
@@ -1136,7 +1136,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         verifyAll();
 
         try {
-            array = collection.toArray(null);
+            array = collection.toArray((Object[])null);
             fail("toArray(null) should raise NPE");
         } catch (NullPointerException e) {
             // expected

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionAbstractTest.java
@@ -1136,7 +1136,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         verifyAll();
 
         try {
-            array = collection.toArray((Object[])null);
+            array = collection.toArray((Object[]) null);
             fail("toArray(null) should raise NPE");
         } catch (NullPointerException e) {
             // expected

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionUtilTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionUtilTest.java
@@ -228,34 +228,12 @@ public class CollectionUtilTest {
         assertCorrectListIterator(CollectionUtil.iterator(new String[] {"foo", "bar", "baz", "boo"}, 1, 2), new String[] {"bar", "baz"});
     }
 
-    @Test
-    public void testArrayListIteratorSanityCheckArraysAsList() {
-        assertCorrectListIterator(Arrays.asList(new String[] {"foo", "bar", "baz"}).listIterator(), stringObjects);
-    }
-
-    @Test
-    public void testArrayListIteratorSanityCheckArraysAsListRange() {
-        // NOTE: sublist(fromInc, toExcl) vs iterator(start, length)
-        assertCorrectListIterator(Arrays.asList(new String[] {"foo", "bar", "baz", "boo"}).subList(1, 3).listIterator(0), new String[] {"bar", "baz"}, false, true);
-    }
-
-    @Test
-    public void testArrayListIteratorSanityCheckArraysList() {
-        assertCorrectListIterator(new ArrayList<String>(Arrays.asList(new String[] {"foo", "bar", "baz"})).listIterator(), stringObjects, true, true);
-    }
-
-    @Test
-    public void testArrayListIteratorSanityCheckArraysListRange() {
-        // NOTE: sublist(fromInc, toExcl) vs iterator(start, length)
-        assertCorrectListIterator(new ArrayList<String>(Arrays.asList(new String[] {"foo", "bar", "baz", "boo"})).subList(1, 3).listIterator(0), new String[] {"bar", "baz"}, true, true);
-    }
-
-    private void assertCorrectListIterator(ListIterator<String> iterator, final Object[] elements) {
+    private static void assertCorrectListIterator(ListIterator<String> iterator, final Object[] elements) {
         assertCorrectListIterator(iterator, elements, false, false);
     }
 
     // NOTE: The test is can only test list iterators with a starting index == 0
-    private void assertCorrectListIterator(ListIterator<String> iterator, final Object[] elements, boolean skipRemove, boolean skipAdd) {
+    private static void assertCorrectListIterator(ListIterator<String> iterator, final Object[] elements, boolean skipRemove, boolean skipAdd) {
         // Index is now "before 0"
         assertEquals(-1, iterator.previousIndex());
         assertEquals(0, iterator.nextIndex());


### PR DESCRIPTION
Fix test that doesn't compile when the JDK is Java 11 and above and remove a few tests that are only testing java.util classes.

The few tests removed seem that they are no longer testing custom collection classes and are now simply testing java.util collections.