### PR TITLE
Fix JPEG component ID array size reference

### DIFF
--- a/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGSegmentImageInputStream.java
+++ b/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGSegmentImageInputStream.java
@@ -275,7 +275,7 @@ final class JPEGSegmentImageInputStream extends ImageInputStreamImpl {
                 processWarningOccured(String.format("Duplicate component ID %d in SOF", id));
 
                 id++;
-                while (!componentIds.add(id) && componentIds.size() <= 16) {
+                while (!componentIds.add(id) && componentIds.size() < 4) {
                     id++;
                 }
 


### PR DESCRIPTION
Changed the size value to be in line with the defined array size in `ComponentIdSet`.

Unfortunately I can't provide a sample that was causing the issue, but the JPEG image in question was malformed in some way. The software using this library was caught waiting for the iteration through the `int` range - appeared to be frozen.

Changing the expected size here "fixed" the problem for me, however rewriting the (int) id value back to the byte buffer may be a potential problem?