### PR TITLE
Svg scale by ViewBox

### DIFF
--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReader.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReader.java
@@ -46,6 +46,7 @@ import org.apache.batik.gvt.renderer.ImageRendererFactory;
 import org.apache.batik.transcoder.*;
 import org.apache.batik.transcoder.image.ImageTranscoder;
 import org.apache.batik.util.ParsedURL;
+import org.apache.batik.util.SVGConstants;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.svg.SVGSVGElement;
@@ -326,13 +327,21 @@ public class SVGImageReader extends ImageReaderBase {
 
             // get the 'width' and 'height' attributes of the SVG document
             Dimension2D docSize = ctx.getDocumentSize();
-            if (docSize != null)  {
+            if (docSize != null) {
                 defaultWidth = (float) docSize.getWidth();
                 defaultHeight = (float) docSize.getHeight();
             }
             else {
                 defaultWidth = 200;
                 defaultHeight = 200;
+            }
+            SVGSVGElement rootElement = svgDoc.getRootElement();
+            String viewBoxStr = rootElement.getAttributeNS
+                    (null, SVGConstants.SVG_VIEW_BOX_ATTRIBUTE);
+            if (viewBoxStr.length() != 0) {
+                float[] rect = ViewBox.parseViewBoxAttribute(rootElement, viewBoxStr, null);
+                defaultWidth = rect[2];
+                defaultHeight = rect[3];
             }
 
             // Hack to work around exception above

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
@@ -35,6 +35,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.imageio.IIOException;
+import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.event.IIOReadWarningListener;
@@ -43,9 +44,12 @@ import javax.imageio.stream.ImageInputStream;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImagingOpException;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.Buffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -97,6 +101,57 @@ public class SVGImageReaderTest extends ImageReaderAbstractTest<SVGImageReader> 
 
     protected List<String> getMIMETypes() {
         return Collections.singletonList("image/svg+xml");
+    }
+
+    @Test
+    public void testScaleViewBox() throws IOException {
+        URL svgUrl = getClassLoaderResource("/svg/quadrants.svg");
+
+        File tmpDir = new File(System.getProperty("java.io.tmpdir"));
+
+        SVGImageReader reader = createReader();
+        SVGReadParam param = new SVGReadParam();
+
+        int[] sizes = new int[]{16, 32, 64, 128};
+        for (int size : sizes) {
+            try (InputStream svgStream = svgUrl.openStream(); ImageInputStream iis = ImageIO.createImageInputStream(svgStream)) {
+                reader.reset();
+                reader.setInput(iis);
+
+
+                param.setSourceRenderSize(new Dimension(size, size));
+                BufferedImage image = reader.read(0, param);
+                checkQuadrantColors(image);
+            }
+            finally {
+                reader.dispose();
+            }
+        }
+    }
+
+    private void checkQuadrantColors(BufferedImage image) {
+        int quadPoint = image.getWidth() / 2;
+        for (int x = 0; x < image.getWidth(); x++) {
+            for (int y = 0; y < image.getHeight(); y++) {
+                int current = image.getRGB(x, y);
+                if (x < quadPoint) {
+                    if (y < quadPoint) {
+                        assertEquals("x=" + x + " y=" + y + " q=" + quadPoint, 0xFF0000FF, current);
+                    }
+                    else {
+                        assertEquals("x=" + x + " y=" + y + " q=" + quadPoint, 0xFFFF0000, current);
+                    }
+                }
+                else {
+                    if (y < quadPoint) {
+                        assertEquals("x=" + x + " y=" + y + " q=" + quadPoint, 0xFF00FF00, current);
+                    }
+                    else {
+                        assertEquals("x=" + x + " y=" + y + " q=" + quadPoint, 0xFF000000, current);
+                    }
+                }
+            }
+        }
     }
 
     @Test

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
@@ -74,7 +74,7 @@ public class SVGImageReaderTest extends ImageReaderAbstractTest<SVGImageReader> 
                 new TestData(getClassLoaderResource("/svg/batikLogo.svg"), new Dimension(450, 500)),
                 new TestData(getClassLoaderResource("/svg/red-square.svg"), new Dimension(100, 100)),
                 new TestData(getClassLoaderResource("/svg/blue-square.svg"), new Dimension(100, 100)),
-                new TestData(getClassLoaderResource("/svg/Android_robot.svg"), new Dimension(400, 400))
+                new TestData(getClassLoaderResource("/svg/Android_robot.svg"), new Dimension(294, 345))
         );
     }
 

--- a/imageio/imageio-batik/src/test/resources/svg/quadrants.svg
+++ b/imageio/imageio-batik/src/test/resources/svg/quadrants.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" id="blue-square" version="1.1">
+  <g id="layer1">
+    <rect id="rect2985" width="50" height="50" x="0" y="0"
+	   style="color:#000000;fill:#0000ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect id="rect2986" width="50" height="50" x="50" y="0"
+	   style="color:#000000;fill:#00ff00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect id="rect2987" width="50" height="50" x="0" y="50"
+	   style="color:#000000;fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect id="rect2988" width="50" height="50" x="50" y="50"
+	   style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+</svg>


### PR DESCRIPTION
When a SVG only contains a ViewBox like "0 0 100 100" instead of width/height definitions, a default size of 400 / 400 is used.
This results in wrong image scaling if  SVGReadParam.setSourceRenderSize is used.