### PR TITLE
Removed custom metadata entry (tag) restrictions

### DIFF
--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriter.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriter.java
@@ -771,40 +771,7 @@ public final class TIFFImageWriter extends ImageWriterBase {
         if (ifd != null) {
             for (Entry entry : ifd) {
                 int tagId = (Integer) entry.getIdentifier();
-
-                switch (tagId) {
-                    // Baseline
-                    case TIFF.TAG_SUBFILE_TYPE:
-                    case TIFF.TAG_OLD_SUBFILE_TYPE:
-                    case TIFF.TAG_IMAGE_DESCRIPTION:
-                    case TIFF.TAG_MAKE:
-                    case TIFF.TAG_MODEL:
-                    case TIFF.TAG_ORIENTATION:
-                    case TIFF.TAG_X_RESOLUTION:
-                    case TIFF.TAG_Y_RESOLUTION:
-                    case TIFF.TAG_RESOLUTION_UNIT:
-                    case TIFF.TAG_SOFTWARE:
-                    case TIFF.TAG_DATE_TIME:
-                    case TIFF.TAG_ARTIST:
-                    case TIFF.TAG_HOST_COMPUTER:
-                    case TIFF.TAG_COPYRIGHT:
-                    // Extension
-                    case TIFF.TAG_DOCUMENT_NAME:
-                    case TIFF.TAG_PAGE_NAME:
-                    case TIFF.TAG_X_POSITION:
-                    case TIFF.TAG_Y_POSITION:
-                    case TIFF.TAG_PAGE_NUMBER:
-                    case TIFF.TAG_XMP:
-                    // Private/Custom
-                    case TIFF.TAG_IPTC:
-                    case TIFF.TAG_PHOTOSHOP:
-                    case TIFF.TAG_PHOTOSHOP_IMAGE_SOURCE_DATA:
-                    case TIFF.TAG_PHOTOSHOP_ANNOTATIONS:
-                    case TIFF.TAG_EXIF_IFD:
-                    case TIFF.TAG_GPS_IFD:
-                    case TIFF.TAG_INTEROP_IFD:
-                        entries.put(tagId, entry);
-                }
+                entries.put(tagId, entry);
             }
         }
 


### PR DESCRIPTION
Custom tags are still being removed as part of the code for re-creating the metadata in the convertImageMetadata method. By removing the checks that "vet" the tags, custom tags maybe entered without issues. 