### PR TITLE
Upgraded the Apache Batik library from 1.12 to 1.14 due to fixed CVEs.

### DIFF
--- a/imageio/imageio-batik/pom.xml
+++ b/imageio/imageio-batik/pom.xml
@@ -104,6 +104,6 @@
     </dependencies>
 
     <properties>
-        <batik.version>1.12</batik.version>
+        <batik.version>1.14</batik.version>
     </properties>
 </project>


### PR DESCRIPTION
After seeing this in the mail: https://mail-archives.apache.org/mod_mbox/xmlgraphics-batik-dev/202102.mbox/%3C000b01d70aa5%24df1b5130%249d51f390%24%40gmail.com%3E

I went and checked the security page:

https://xmlgraphics.apache.org/security.html

Which shows vulnerabilities fixed in 1.13 and 1.14

The oldest of the 2 is public: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17566

The newest is not: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11987

I couldn't find where to update the twelvemonkeys version though. The 3.6.2 string.

Tests ran locally, BATIK succeeds.

Only JPEG had failures, though the readme states difference in JVMs might be to blame? I'm running Amazon Corretto.