### PR TITLE
#579 Deeper EOL search in the CCITT stream

### DIFF
--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxDecoderStream.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxDecoderStream.java
@@ -174,13 +174,11 @@ final class CCITTFaxDecoderStream extends FilterInputStream {
                 for (int i = 12; i < limitBits; i++) {
                     if (i % 8 == 0) {
                         read = in.read();
-                        if (read > -1) {
-                            streamByte = (byte) read;
-                        }
-                        else {
+                        if (read == -1) {
                             // no EOL before stream end
                             return TIFFBaseline.COMPRESSION_CCITT_MODIFIED_HUFFMAN_RLE;
                         }
+                        streamByte = (byte) read;
                     }
 
                     b = (short) ((b << 1) + ((streamByte >> (7 - (i % 8))) & 0x01));


### PR DESCRIPTION
I've got other TIFFs which have some junk at the beginning of the CCITT stream, which is even longer than before. In an extrem case almost 300 bytes.

So I propose to increase the read limit for the CCITT type detection even further, but only read on demand till a EOL is found or the limit is reached.

Also relates to #535 