### PR TITLE
Documentation cleanup

### DIFF
--- a/common/common-image/src/main/java/com/twelvemonkeys/image/IndexImage.java
+++ b/common/common-image/src/main/java/com/twelvemonkeys/image/IndexImage.java
@@ -587,6 +587,7 @@ class IndexImage {
      * @deprecated Use {@link #getIndexColorModel(Image,int,int)} instead!
      *             This version will be removed in a later version of the API.
      */
+    @Deprecated
     public static IndexColorModel getIndexColorModel(Image pImage, int pNumberOfColors, boolean pFast) {
         return getIndexColorModel(pImage, pNumberOfColors, pFast ? COLOR_SELECTION_FAST : COLOR_SELECTION_QUALITY);
     }

--- a/common/common-io/src/main/java/com/twelvemonkeys/io/FilenameMaskFilter.java
+++ b/common/common-io/src/main/java/com/twelvemonkeys/io/FilenameMaskFilter.java
@@ -65,6 +65,7 @@ import java.io.FilenameFilter;
  * @see WildcardStringParser
  * @deprecated
  */
+@Deprecated
 public class FilenameMaskFilter implements FilenameFilter {
 
      // TODO: Rewrite to use regexp, or create new class

--- a/common/common-io/src/main/java/com/twelvemonkeys/io/LittleEndianDataInputStream.java
+++ b/common/common-io/src/main/java/com/twelvemonkeys/io/LittleEndianDataInputStream.java
@@ -442,6 +442,7 @@ public class LittleEndianDataInputStream extends FilterInputStream implements Da
      * @see        java.io.BufferedReader#readLine()
      * @see        java.io.DataInputStream#readLine()
      */
+    @Deprecated
     public String readLine() throws IOException {
         DataInputStream ds = new DataInputStream(in);
         return ds.readLine();

--- a/common/common-lang/src/main/java/com/twelvemonkeys/lang/StringUtil.java
+++ b/common/common-lang/src/main/java/com/twelvemonkeys/lang/StringUtil.java
@@ -770,6 +770,7 @@ public final class StringUtil {
      */
 
     /*public*/
+    @Deprecated
     static String formatNumber(long pNum, int pLen) throws IllegalArgumentException {
         StringBuilder result = new StringBuilder();
 
@@ -1464,6 +1465,7 @@ public final class StringUtil {
      */
 
     /*public*/
+    @Deprecated
     static String removeSubstring(final String pSource, final char pBeginBoundaryChar, final char pEndBoundaryChar, final int pOffset) {
         StringBuilder filteredString = new StringBuilder();
         boolean insideDemarcatedArea = false;

--- a/common/common-lang/src/main/java/com/twelvemonkeys/util/Time.java
+++ b/common/common-lang/src/main/java/com/twelvemonkeys/util/Time.java
@@ -157,6 +157,7 @@ public class Time {
      * @see #parseTime(String)
      * @deprecated
      */
+    @Deprecated
     public String toString(String pFormatStr) {
         TimeFormat tf = new TimeFormat(pFormatStr);
 
@@ -174,6 +175,7 @@ public class Time {
      * @see #toString(String)
      * @deprecated
      */
+    @Deprecated
     public static Time parseTime(String pStr) {
         TimeFormat tf = TimeFormat.getInstance();
 

--- a/common/common-lang/src/main/java/com/twelvemonkeys/util/regex/WildcardStringParser.java
+++ b/common/common-lang/src/main/java/com/twelvemonkeys/util/regex/WildcardStringParser.java
@@ -111,6 +111,7 @@ import java.io.PrintStream;
  * @author <a href="mailto:eirik.torske@iconmedialab.no">Eirik Torske</a>
  * @deprecated Will probably be removed in the near future
  */
+@Deprecated
 public class WildcardStringParser {
     // TODO: Get rid of this class
 

--- a/imageio/imageio-clippath/src/main/java/com/twelvemonkeys/imageio/path/AdobePathBuilder.java
+++ b/imageio/imageio-clippath/src/main/java/com/twelvemonkeys/imageio/path/AdobePathBuilder.java
@@ -39,6 +39,7 @@ import java.io.IOException;
  *
  * @deprecated Use {@link AdobePathReader} instead. This class will be removed in a future release.
  */
+@Deprecated
 public final class AdobePathBuilder {
 
     private final AdobePathReader delegate;

--- a/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/exif/EXIFReader.java
+++ b/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/exif/EXIFReader.java
@@ -46,6 +46,7 @@ import java.io.IOException;
  *
  * @deprecated Use com.twelvemonkeys.imageio.metadata.tiff.TIFFReader instead.
  */
+@Deprecated
 public final class EXIFReader extends MetadataReader {
 
     private final TIFFReader delegate = new TIFFReader();

--- a/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/exif/EXIFWriter.java
+++ b/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/exif/EXIFWriter.java
@@ -48,6 +48,7 @@ import java.util.Collection;
  *
  * @deprecated Use com.twelvemonkeys.imageio.metadata.tiff.TIFFWriter instead.
  */
+@Deprecated
 public final class EXIFWriter extends MetadataWriter {
 
     private final TIFFWriter delegate = new TIFFWriter();

--- a/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/exif/Rational.java
+++ b/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/exif/Rational.java
@@ -41,6 +41,7 @@ package com.twelvemonkeys.imageio.metadata.exif;
  *
  * @deprecated Use com.twelvemonkeys.imageio.metadata.tiff.Rational instead.
  */
+@Deprecated
 public final class Rational extends Number implements Comparable<Rational> {
     private final com.twelvemonkeys.imageio.metadata.tiff.Rational delegate;
 

--- a/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/exif/TIFF.java
+++ b/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/exif/TIFF.java
@@ -39,5 +39,6 @@ package com.twelvemonkeys.imageio.metadata.exif;
  *
  * @deprecated Use com.twelvemonkeys.imageio.metadata.tiff.TIFF instead.
  */
+@Deprecated
 public interface TIFF extends com.twelvemonkeys.imageio.metadata.tiff.TIFF {
 }

--- a/servlet/src/main/java/com/twelvemonkeys/servlet/GenericFilter.java
+++ b/servlet/src/main/java/com/twelvemonkeys/servlet/GenericFilter.java
@@ -357,6 +357,7 @@ public abstract class GenericFilter implements Filter, FilterConfig, Serializabl
      *
      * @deprecated For compatibility only, use {@link #init init} instead.
      */
+    @Deprecated
     @SuppressWarnings("UnusedDeclaration")
     public void setFilterConfig(final FilterConfig pFilterConfig) {
         try {

--- a/servlet/src/main/java/com/twelvemonkeys/servlet/ServletUtil.java
+++ b/servlet/src/main/java/com/twelvemonkeys/servlet/ServletUtil.java
@@ -337,6 +337,7 @@ public final class ServletUtil {
      * @deprecated Use {@link javax.servlet.http.HttpServletRequest#getRequestURL()}
      *             instead.
      */
+    @Deprecated
     static StringBuffer buildHTTPURL(final HttpServletRequest pRequest) {
         StringBuffer resultURL = new StringBuffer();
 

--- a/servlet/src/main/java/com/twelvemonkeys/servlet/cache/HTTPCache.java
+++ b/servlet/src/main/java/com/twelvemonkeys/servlet/cache/HTTPCache.java
@@ -271,9 +271,10 @@ public class HTTPCache {
      *                                  cannot be created.
      * @deprecated Use {@link #HTTPCache(File, long, int, int, boolean)} instead.
      */
+    @Deprecated
     public HTTPCache(final String pName, final ServletContext pContext,
-            final int pDefaultCacheExpiryTime, final int pMaxMemCacheSize,
-            final int pMaxCachedEntites, final boolean pDeleteCacheOnExit) {
+                     final int pDefaultCacheExpiryTime, final int pMaxMemCacheSize,
+                     final int pMaxCachedEntites, final boolean pDeleteCacheOnExit) {
         this(
                 getTempFolder(pName, pContext),
                 pDefaultCacheExpiryTime, pMaxMemCacheSize, pMaxCachedEntites, pDeleteCacheOnExit,

--- a/servlet/src/main/java/com/twelvemonkeys/servlet/image/ImageFilter.java
+++ b/servlet/src/main/java/com/twelvemonkeys/servlet/image/ImageFilter.java
@@ -146,7 +146,7 @@ public abstract class ImageFilter extends GenericFilter {
      * @param pRequest the original request
      * @return the new response, or {@code pResponse} if the response is already wrapped
      *
-     * @see com.twelvemonkeys.servlet.image.ImageServletResponse
+     * @see com.twelvemonkeys.servlet.image.ImageServletResponseImpl
      */
     private ImageServletResponse createImageServletResponse(final ServletRequest pRequest, final ServletResponse pResponse) {
         if (pResponse instanceof ImageServletResponseImpl) {

--- a/servlet/src/main/java/com/twelvemonkeys/servlet/image/ImageFilter.java
+++ b/servlet/src/main/java/com/twelvemonkeys/servlet/image/ImageFilter.java
@@ -146,7 +146,7 @@ public abstract class ImageFilter extends GenericFilter {
      * @param pRequest the original request
      * @return the new response, or {@code pResponse} if the response is already wrapped
      *
-     * @see com.twelvemonkeys.servlet.image.ImageServletResponseWrapper
+     * @see com.twelvemonkeys.servlet.image.ImageServletResponse
      */
     private ImageServletResponse createImageServletResponse(final ServletRequest pRequest, final ServletResponse pResponse) {
         if (pResponse instanceof ImageServletResponseImpl) {


### PR DESCRIPTION
Greetings.

I was setting up a new IDE and was testing the static code analysis.

This popped up and I felt like making a PR for it:

Added the `@Deprecated` tag to instances where is was mentioned in documentation, but not for the actual code itself.

Changed one documentation link pointing at a non-existing item.