### PR TITLE
Create jakartified package on build

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,16 @@ To depend on the JPEG and TIFF plugin using Maven, add the following to your POM
         <artifactId>servlet</artifactId>
         <version>3.7.0</version>
     </dependency>
+
+    <!--
+    Or Jakarta version, for Servlet API 5.0
+    -->
+    <dependency>
+        <groupId>com.twelvemonkeys.servlet</groupId>
+        <artifactId>servlet</artifactId>
+        <version>3.7.0</version>
+        <classifier>jakarta</classifier>
+    </dependency>
 </dependencies>
 ```
 

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -107,6 +107,36 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.2</version>
+                <executions>
+                    <execution>
+                        <id>jakarta</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>twelvemonkeys-${project.artifactId}-${project.version}-jakarta</finalName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>${project.groupId}:${project.artifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>javax.servlet</pattern>
+                                    <shadedPattern>jakarta.servlet</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
closes #589

I have validated the resulting jar has no other differences except `javax.servlet -> jakarta.servlet`.
Would be nice if this can be published soon, for already released version.