### PR TITLE
Added changed from ab13084f448e01ea939847aade21c3c3e060ef98 as fallba…

### DIFF
--- a/imageio/imageio-bmp/src/main/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderSpi.java
+++ b/imageio/imageio-bmp/src/main/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderSpi.java
@@ -39,6 +39,7 @@ import javax.imageio.stream.ImageInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Iterator;
 import java.util.Locale;
 
 import static com.twelvemonkeys.imageio.util.IIOUtil.lookupProviderByName;
@@ -59,10 +60,28 @@ public final class BMPImageReaderSpi extends ImageReaderSpiBase {
     public void onRegistration(final ServiceRegistry registry, final Class<?> category) {
         ImageReaderSpi defaultProvider = lookupProviderByName(registry, "com.sun.imageio.plugins.bmp.BMPImageReaderSpi", ImageReaderSpi.class);
 
+        if (defaultProvider == null) {
+            defaultProvider = lookupDefaultProvider(registry);
+        }
+
         if (defaultProvider != null) {
             // Order before com.sun provider, to aid ImageIO in selecting our reader
             registry.setOrdering((Class<ImageReaderSpi>) category, this, defaultProvider);
         }
+    }
+
+    static ImageReaderSpi lookupDefaultProvider(final ServiceRegistry registry) {
+        Iterator<ImageReaderSpi> providers = registry.getServiceProviders(ImageReaderSpi.class, true);
+
+        while (providers.hasNext()) {
+            ImageReaderSpi provider = providers.next();
+
+            if (provider.getClass().getName().equals("com.sun.imageio.plugins.bmp.BMPImageReaderSpi")) {
+                return provider;
+            }
+        }
+
+        return null;
     }
 
     public boolean canDecodeInput(final Object pSource) throws IOException {

--- a/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderSpi.java
+++ b/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderSpi.java
@@ -87,7 +87,7 @@ public final class JPEGImageReaderSpi extends ImageReaderSpiBase {
         }
 
         if (delegateProvider == null) {
-            lookupDelegateProvider(registry);
+            delegateProvider = lookupDelegateProvider(registry);
         }
 
         if (delegateProvider != null) {

--- a/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderSpi.java
+++ b/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderSpi.java
@@ -40,6 +40,7 @@ import javax.imageio.metadata.IIOMetadataFormat;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.spi.ServiceRegistry;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Locale;
 
 import static com.twelvemonkeys.imageio.util.IIOUtil.lookupProviderByName;
@@ -85,6 +86,10 @@ public final class JPEGImageReaderSpi extends ImageReaderSpiBase {
             delegateProvider = lookupProviderByName(registry, "com.sun.imageio.plugins.jpeg.JPEGImageReaderSpi", ImageReaderSpi.class);
         }
 
+        if (delegateProvider == null) {
+            lookupDelegateProvider(registry);
+        }
+
         if (delegateProvider != null) {
             // Order before com.sun provider, to aid ImageIO in selecting our reader
             registry.setOrdering((Class<ImageReaderSpi>) category, this, delegateProvider);
@@ -93,6 +98,20 @@ public final class JPEGImageReaderSpi extends ImageReaderSpiBase {
             // Or, if no delegate is found, silently deregister from the registry
             IIOUtil.deregisterProvider(registry, this, category);
         }
+    }
+
+    static ImageReaderSpi lookupDelegateProvider(final ServiceRegistry registry) {
+        Iterator<ImageReaderSpi> providers = registry.getServiceProviders(ImageReaderSpi.class, true);
+
+        while (providers.hasNext()) {
+            ImageReaderSpi provider = providers.next();
+
+            if (provider.getClass().getName().equals("com.sun.imageio.plugins.jpeg.JPEGImageReaderSpi")) {
+                return provider;
+            }
+        }
+
+        return null;
     }
 
     @Override

--- a/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageWriterSpi.java
+++ b/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageWriterSpi.java
@@ -84,7 +84,7 @@ public class JPEGImageWriterSpi extends ImageWriterSpiBase {
         }
 
         if (delegateProvider == null) {
-            lookupDelegateProvider(registry);
+            delegateProvider = lookupDelegateProvider(registry);
         }
 
         if (delegateProvider != null) {

--- a/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageWriterSpi.java
+++ b/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageWriterSpi.java
@@ -40,6 +40,7 @@ import javax.imageio.spi.ImageWriterSpi;
 import javax.imageio.spi.ServiceRegistry;
 import java.awt.image.RenderedImage;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Locale;
 
 import static com.twelvemonkeys.imageio.util.IIOUtil.deregisterProvider;
@@ -82,6 +83,10 @@ public class JPEGImageWriterSpi extends ImageWriterSpiBase {
             delegateProvider = lookupProviderByName(registry, "com.sun.imageio.plugins.jpeg.JPEGImageWriterSpi", ImageWriterSpi.class);
         }
 
+        if (delegateProvider == null) {
+            lookupDelegateProvider(registry);
+        }
+
         if (delegateProvider != null) {
             // Order before com.sun provider, to aid ImageIO in selecting our writer
             registry.setOrdering((Class<ImageWriterSpi>) category, this, delegateProvider);
@@ -90,6 +95,20 @@ public class JPEGImageWriterSpi extends ImageWriterSpiBase {
             // Or, if no delegate is found, silently deregister from the registry
             deregisterProvider(registry, this, category);
         }
+    }
+
+    static ImageWriterSpi lookupDelegateProvider(final ServiceRegistry registry) {
+        Iterator<ImageWriterSpi> providers = registry.getServiceProviders(ImageWriterSpi.class, true);
+
+        while (providers.hasNext()) {
+            ImageWriterSpi provider = providers.next();
+
+            if (provider.getClass().getName().equals("com.sun.imageio.plugins.jpeg.JPEGImageWriterSpi")) {
+                return provider;
+            }
+        }
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Commit ab13084f448e01ea939847aade21c3c3e060ef98 breaks OSGi support due to classloader issues (what happens is Class.forName in com.twelvemonkeys.imageio.util.IIOUtil#lookupProviderByName throws a ClassNotFoundException, using the lookup as fallback works)