### PR TITLE
Support writing ASCII array in TIFF metadata

### DIFF
--- a/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFWriter.java
+++ b/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFWriter.java
@@ -292,15 +292,17 @@ public final class TIFFWriter extends MetadataWriter {
 
     private int getCount(final Entry entry) {
         Object value = entry.getValue();
-        if(value instanceof String){
+        if (value instanceof String) {
             return ((String) value).getBytes(StandardCharsets.UTF_8).length + 1;
-        } else if(value instanceof String[]){
+        }
+        else if (value instanceof String[]) {
             int sum = 0;
-            for (String string : (String[]) value){
+            for (String string : (String[]) value) {
                 sum += string.getBytes(StandardCharsets.UTF_8).length + 1;
             }
             return sum;
-        } else {
+        }
+        else {
             return entry.valueCount();
         }
     }
@@ -423,9 +425,7 @@ public final class TIFFWriter extends MetadataWriter {
                 case TIFF.TYPE_ASCII:
                     String[] strings = (String[]) value;
                     for (String string : strings) {
-                        byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
-                        stream.write(bytes);
-                        stream.write(0);
+                        writeString(stream, string);
                     }
                     break;
                 default:
@@ -440,9 +440,7 @@ public final class TIFFWriter extends MetadataWriter {
                     stream.writeByte(((Number) value).intValue());
                     break;
                 case TIFF.TYPE_ASCII:
-                    byte[] bytes = ((String) value).getBytes(StandardCharsets.UTF_8);
-                    stream.write(bytes);
-                    stream.write(0);
+                    writeString(stream, (String) value);
                     break;
                 case TIFF.TYPE_SHORT:
                 case TIFF.TYPE_SSHORT:
@@ -477,6 +475,11 @@ public final class TIFFWriter extends MetadataWriter {
                     throw new IllegalArgumentException("Unsupported TIFF type: " + type);
             }
         }
+    }
+
+    private void writeString(ImageOutputStream stream, String value) throws IOException {
+        stream.write(value.getBytes(StandardCharsets.UTF_8));
+        stream.write(0);
     }
 
     private void writeValueAt(final long dataOffset, final Object value, final short type, final ImageOutputStream stream) throws IOException {

--- a/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFWriter.java
+++ b/imageio/imageio-metadata/src/main/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFWriter.java
@@ -292,7 +292,17 @@ public final class TIFFWriter extends MetadataWriter {
 
     private int getCount(final Entry entry) {
         Object value = entry.getValue();
-        return value instanceof String ? ((String) value).getBytes(StandardCharsets.UTF_8).length + 1 : entry.valueCount();
+        if(value instanceof String){
+            return ((String) value).getBytes(StandardCharsets.UTF_8).length + 1;
+        } else if(value instanceof String[]){
+            int sum = 0;
+            for (String string : (String[]) value){
+                sum += string.getBytes(StandardCharsets.UTF_8).length + 1;
+            }
+            return sum;
+        } else {
+            return entry.valueCount();
+        }
     }
 
     private void writeValueInline(final Object value, final short type, final ImageOutputStream stream) throws IOException {
@@ -410,7 +420,14 @@ public final class TIFFWriter extends MetadataWriter {
 
                         break;
                     }
-
+                case TIFF.TYPE_ASCII:
+                    String[] strings = (String[]) value;
+                    for (String string : strings) {
+                        byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+                        stream.write(bytes);
+                        stream.write(0);
+                    }
+                    break;
                 default:
                     throw new IllegalArgumentException("Unsupported TIFF type: " + type);
             }

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFWriterTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFWriterTest.java
@@ -47,8 +47,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * TIFFWriterTest
@@ -252,6 +254,27 @@ public class TIFFWriterTest extends MetadataWriterAbstractTest {
 
         assertEquals(94, writer.computeIFDSize(entries));
         assertEquals(98, stream.getStreamPosition());
+    }
+
+    @Test
+    public void testWriteASCIIArray() throws IOException {
+        ArrayList<Entry> entries = new ArrayList<>();
+        String[] strings = new String []{"Twelve", "Monkeys", "ImageIO"};
+        entries.add(new AbstractEntry(TIFF.TAG_SOFTWARE, strings) {});
+        Directory directory = new AbstractDirectory(entries) {};
+
+        ByteArrayOutputStream output = new FastByteArrayOutputStream(1024);
+        ImageOutputStream imageStream = ImageIO.createImageOutputStream(output);
+        imageStream.setByteOrder(ByteOrder.LITTLE_ENDIAN); // LE = Intel
+        createWriter().write(directory, imageStream);
+        imageStream.flush();
+
+        byte[] data = output.toByteArray();
+        Directory read = new TIFFReader().read(new ByteArrayImageInputStream(data));
+
+        assertNotNull(read.getEntryById(TIFF.TAG_SOFTWARE));
+        assertTrue("value not an string array", read.getEntryById(TIFF.TAG_SOFTWARE).getValue() instanceof String[]);
+        assertArrayEquals("", strings, (String[]) read.getEntryById(TIFF.TAG_SOFTWARE).getValue());
     }
 
     @Test


### PR DESCRIPTION
Currently the TIFF reader supports reading fields which contain multiple ASCII strings. Writing those metadata again then fails, because writing ASCII string arrays is not supported.