### PR TITLE
findCompressionType always uses RLE if leading EOL is missing

### DIFF
--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxDecoderStream.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxDecoderStream.java
@@ -170,6 +170,7 @@ final class CCITTFaxDecoderStream extends FilterInputStream {
                             // no EOL before stream end
                             return TIFFBaseline.COMPRESSION_CCITT_MODIFIED_HUFFMAN_RLE;
                         }
+                        streamByte = (byte) read;
                     }
 
                     b = (short) ((b << 1) + ((streamByte >> (7 - (i % 8))) & 0x01));

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxDecoderStreamTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxDecoderStreamTest.java
@@ -363,6 +363,20 @@ public class CCITTFaxDecoderStreamTest {
         }
     }
 
+    @Test
+    public void testFindCompressionTypeForMissingStartEOL() throws IOException {
+        // Type 4, missing leading EOL code
+        // starts with 1728px long white lines
+        byte[] data = new byte[]{
+                0x4d, (byte) 0x9a, (byte) 0x80, 0x01, 0x4d, (byte) 0x9a, (byte) 0x80, 0x01, 0x4d, (byte) 0x9a, (byte) 0x80, 0x01, 0x4d, (byte) 0x9a, (byte) 0x80, 0x01,
+                (byte) 0x91, 0x3c, 0x17, 0x6d, 0x02, (byte) 0xf2, (byte) 0xb0, 0x20, (byte) 0x01, (byte) 0xda, (byte) 0xa8, (byte) 0xb3, 0x17, 0x4e, 0x62, (byte) 0xcd, (byte) 0xa7
+        };
+        try (ByteArrayInputStream is = new ByteArrayInputStream(data)) {
+            int detectedType = CCITTFaxDecoderStream.findCompressionType(TIFFExtension.COMPRESSION_CCITT_T4, is);
+            assertEquals(TIFFExtension.COMPRESSION_CCITT_T4, detectedType);
+        }
+    }
+
     private InputStream getResourceAsStream(String name) {
         return getClass().getResourceAsStream(name);
     }


### PR DESCRIPTION
Update of the last read byte is missing since the last update. So if only the first EOL is missing, further EOLs after the lines are not detected.

It seems I lost the line in the refactoring steps when working on #626 and we had no tests checking for missing leading EOL.