### PR TITLE
Support org.w3c.dom.Document input to SVGImageReader

### DIFF
--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReader.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReader.java
@@ -115,6 +115,10 @@ public class SVGImageReader extends ImageReaderBase {
             TranscoderInput input = new TranscoderInput(IIOUtil.createStreamAdapter(imageInput));
             rasterizer.setInput(input);
         }
+        else if (pInput instanceof Document) {
+            Document doc = (Document) pInput;
+            rasterizer.setInput(new TranscoderInput(doc));
+        }
     }
 
     public BufferedImage read(int pIndex, ImageReadParam pParam) throws IOException {

--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
@@ -35,6 +35,7 @@ import com.twelvemonkeys.lang.SystemUtil;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import javax.xml.namespace.QName;
 
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ServiceRegistry;
@@ -55,7 +56,7 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
 
     final static boolean SVG_READER_AVAILABLE = SystemUtil.isClassAvailable("com.twelvemonkeys.imageio.plugins.svg.SVGImageReader", SVGImageReaderSpi.class);
 
-    static final String SVG_NS_URI = "http://www.w3.org/2000/svg";
+    static final QName SVG_ROOT = new QName("http://www.w3.org/2000/svg", "svg");
 
     /**
      * Creates an {@code SVGImageReaderSpi}.
@@ -168,8 +169,8 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
     private static boolean canDecode(Document doc) {
         Element root = doc.getDocumentElement();
         return root != null
-                && "svg".equals(root.getLocalName())
-                && SVG_NS_URI.equals(root.getNamespaceURI());
+                && SVG_ROOT.getLocalPart().equals(root.getLocalName())
+                && SVG_ROOT.getNamespaceURI().equals(root.getNamespaceURI());
     }
 
     public ImageReader createReaderInstance(final Object extension) throws IOException {

--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
@@ -33,6 +33,9 @@ package com.twelvemonkeys.imageio.plugins.svg;
 import com.twelvemonkeys.imageio.spi.ImageReaderSpiBase;
 import com.twelvemonkeys.lang.SystemUtil;
 
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ServiceRegistry;
 import javax.imageio.stream.ImageInputStream;
@@ -52,16 +55,21 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
 
     final static boolean SVG_READER_AVAILABLE = SystemUtil.isClassAvailable("com.twelvemonkeys.imageio.plugins.svg.SVGImageReader", SVGImageReaderSpi.class);
 
+    static final String SVG_NS_URI = "http://www.w3.org/2000/svg";
+
     /**
      * Creates an {@code SVGImageReaderSpi}.
      */
     @SuppressWarnings("WeakerAccess")
     public SVGImageReaderSpi() {
         super(new SVGProviderInfo());
+
+        this.inputTypes = new Class<?>[] { ImageInputStream.class, Document.class };
     }
 
     public boolean canDecodeInput(final Object pSource) throws IOException {
-        return pSource instanceof ImageInputStream && canDecode((ImageInputStream) pSource);
+        return pSource instanceof ImageInputStream && canDecode((ImageInputStream) pSource)
+                || pSource instanceof Document && canDecode((Document) pSource);
     }
 
     @SuppressWarnings("StatementWithEmptyBody")
@@ -155,6 +163,13 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
             //noinspection ThrowFromFinallyBlock
             pInput.reset();
         }
+    }
+
+    private static boolean canDecode(Document doc) {
+        Element root = doc.getDocumentElement();
+        return root != null
+                && "svg".equals(root.getLocalName())
+                && SVG_NS_URI.equals(root.getNamespaceURI());
     }
 
     public ImageReader createReaderInstance(final Object extension) throws IOException {

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiDOMTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiDOMTest.java
@@ -51,7 +51,7 @@ public class SVGImageReaderSpiDOMTest {
 
     @Test
     public void canDecodeSVGDocument() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
 
         DocumentBuilder domBuilder = dbf.newDocumentBuilder();
@@ -63,7 +63,7 @@ public class SVGImageReaderSpiDOMTest {
 
     @Test
     public void cannotDecodeNamespaceUnawareDocument() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
         DocumentBuilder domBuilder = dbf.newDocumentBuilder();
         for (String validInput : VALID_INPUTS) {
@@ -75,7 +75,7 @@ public class SVGImageReaderSpiDOMTest {
 
     @Test
     public void cannotDecodeNonSVGNamespaceDocument() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
 
         Document document = dbf.newDocumentBuilder().newDocument();
@@ -90,7 +90,7 @@ public class SVGImageReaderSpiDOMTest {
 
     @Test
     public void cannotDecodeNonSVGRootElement() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
 
         Document document = dbf.newDocumentBuilder().newDocument();

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiDOMTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiDOMTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2023, Harald Kuhr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.twelvemonkeys.imageio.plugins.svg;
+
+import org.junit.Test;
+
+import org.w3c.dom.Document;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import javax.imageio.spi.ImageReaderSpi;
+
+import static com.twelvemonkeys.imageio.plugins.svg.SVGImageReaderSpiTest.VALID_INPUTS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * SVGImageReaderSpi canDecode DOM input tests.
+ */
+public class SVGImageReaderSpiDOMTest {
+
+    private final ImageReaderSpi provider = new SVGImageReaderSpi();
+
+    @Test
+    public void canDecodeSVGDocument() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+        dbf.setNamespaceAware(true);
+
+        DocumentBuilder domBuilder = dbf.newDocumentBuilder();
+        for (String validInput : VALID_INPUTS) {
+            Document input = domBuilder.parse(getClass().getResource(validInput).toString());
+            assertTrue("Can't read valid input: " + validInput, provider.canDecodeInput(input));
+        }
+    }
+
+    @Test
+    public void cannotDecodeNamespaceUnawareDocument() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+
+        DocumentBuilder domBuilder = dbf.newDocumentBuilder();
+        for (String validInput : VALID_INPUTS) {
+            Document input = domBuilder.parse(getClass().getResource(validInput).toString());
+            assertFalse("Claims to read namespace unaware document: " + validInput,
+                        provider.canDecodeInput(input));
+        }
+    }
+
+    @Test
+    public void cannotDecodeNonSVGNamespaceDocument() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+        dbf.setNamespaceAware(true);
+
+        Document document = dbf.newDocumentBuilder().newDocument();
+        document.appendChild(document
+                .createElementNS("http://www.w3.org/2000/doovde", "svg"));
+
+        assertFalse("Claims to read document with root element: {"
+                + document.getDocumentElement().getNamespaceURI() + "}"
+                + document.getDocumentElement().getLocalName(),
+                provider.canDecodeInput(document));
+    }
+
+    @Test
+    public void cannotDecodeNonSVGRootElement() throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
+        dbf.setNamespaceAware(true);
+
+        Document document = dbf.newDocumentBuilder().newDocument();
+        document.appendChild(document
+                .createElementNS("http://www.w3.org/2000/svg", "path"));
+
+        assertFalse("Claims to read document with root element: {"
+                + document.getDocumentElement().getNamespaceURI() + "}"
+                + document.getDocumentElement().getLocalName(),
+                provider.canDecodeInput(document));
+    }
+}

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
@@ -34,10 +34,6 @@ import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
 import org.junit.Test;
 
-import org.w3c.dom.Document;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
 import javax.imageio.spi.ImageReaderSpi;
@@ -56,7 +52,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class SVGImageReaderSpiTest {
 
-    private static final String[] VALID_INPUTS = {
+    static final String[] VALID_INPUTS = {
             "/svg/Android_robot.svg", // Minimal, no xml dec, no namespace
             "/svg/batikLogo.svg",     // xml dec, comments, namespace
             "/svg/blue-square.svg",   // xml dec, namespace
@@ -100,59 +96,5 @@ public class SVGImageReaderSpiTest {
                 assertFalse("Claims to read invalid input:" + invalidInput, provider.canDecodeInput(input));
             }
         }
-    }
-
-    @Test
-    public void canDecodeSVGDocument() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
-        dbf.setNamespaceAware(true);
-
-        DocumentBuilder domBuilder = dbf.newDocumentBuilder();
-        for (String validInput : VALID_INPUTS) {
-            Document input = domBuilder.parse(getClass().getResource(validInput).toString());
-            assertTrue("Can't read valid input: " + validInput, provider.canDecodeInput(input));
-        }
-    }
-
-    @Test
-    public void cannotDecodeNamespaceUnawareDocument() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
-
-        DocumentBuilder domBuilder = dbf.newDocumentBuilder();
-        for (String validInput : VALID_INPUTS) {
-            Document input = domBuilder.parse(getClass().getResource(validInput).toString());
-            assertFalse("Claims to read namespace unaware document: " + validInput,
-                        provider.canDecodeInput(input));
-        }
-    }
-
-    @Test
-    public void cannotDecodeNonSVGNamespaceDocument() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
-        dbf.setNamespaceAware(true);
-
-        Document document = dbf.newDocumentBuilder().newDocument();
-        document.appendChild(document
-                .createElementNS("http://www.w3.org/2000/doovde", "svg"));
-
-        assertFalse("Claims to read document with root element: {"
-                + document.getDocumentElement().getNamespaceURI() + "}"
-                + document.getDocumentElement().getLocalName(),
-                provider.canDecodeInput(document));
-    }
-
-    @Test
-    public void cannotDecodeNonSVGRootElement() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newDefaultInstance();
-        dbf.setNamespaceAware(true);
-
-        Document document = dbf.newDocumentBuilder().newDocument();
-        document.appendChild(document
-                .createElementNS("http://www.w3.org/2000/svg", "path"));
-
-        assertFalse("Claims to read document with root element: {"
-                + document.getDocumentElement().getNamespaceURI() + "}"
-                + document.getDocumentElement().getLocalName(),
-                provider.canDecodeInput(document));
     }
 }

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
@@ -493,8 +493,9 @@ public class SVGImageReaderTest extends ImageReaderAbstractTest<SVGImageReader> 
         Document svgDoc;
         try {
             svgDoc = dbf.newDocumentBuilder().newDocument();
-        } catch (ParserConfigurationException e) {
-            throw new IOException(e);
+        }
+        catch (ParserConfigurationException e) {
+            throw new IllegalStateException(e);
         }
 
         svgDoc.appendChild(svgDoc


### PR DESCRIPTION
_Use case:_ Allow reading an SVG source once, and tweaking its content in memory like changing viewBox, colors, and styles to produce multiple image variants in succession.

_Similar to:_ [DynamicSvgOffscreen](https://cwiki.apache.org/confluence/display/XMLGRAPHICSBATIK/DynamicSvgOffscreen) - Rendering a dynamic SVG document to an offscreen buffer (Batik HowTos)
