### PR TITLE
More universal SVG stream detection

### DIFF
--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/DoctypeHandler.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/DoctypeHandler.java
@@ -65,7 +65,9 @@ class DoctypeHandler extends DefaultHandler2 {
 
     private DoctypeHandler() {
         try {
-            xmlReader = saxParserFactory().newSAXParser().getXMLReader();
+            synchronized (DoctypeHandler.class) {
+                xmlReader = saxParserFactory().newSAXParser().getXMLReader();
+            }
         }
         catch (SAXException | ParserConfigurationException e) {
             throw new IllegalStateException(e);
@@ -119,7 +121,7 @@ class DoctypeHandler extends DefaultHandler2 {
                              String qName,
                              Attributes attributes)
             throws SAXException {
-        int colonIndex = qName.lastIndexOf(':');
+        int colonIndex = qName.indexOf(':');
         rootElement = colonIndex < 0 ? qName : qName.substring(colonIndex + 1);
 
         throw StopParseException.INSTANCE;
@@ -143,7 +145,8 @@ class DoctypeHandler extends DefaultHandler2 {
                 spf.setValidating(false);
                 spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
                 saxParserFactory = spf;
-            } catch (SAXException | ParserConfigurationException e) {
+            }
+            catch (SAXException | ParserConfigurationException e) {
                 throw new FactoryConfigurationError(e);
             }
         }

--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/DoctypeHandler.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/DoctypeHandler.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2023, Harald Kuhr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.twelvemonkeys.imageio.plugins.svg;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.ext.DefaultHandler2;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.FactoryConfigurationError;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+/**
+ * Parses XML up to the root element to identify the document type.
+ */
+class DoctypeHandler extends DefaultHandler2 {
+
+    private static ThreadLocal<XMLReader> localXMLReader = new ThreadLocal<XMLReader>() {
+        @Override protected XMLReader initialValue() {
+            synchronized (this) {
+                try {
+                    return saxParserFactory().newSAXParser().getXMLReader();
+                }
+                catch (SAXException | ParserConfigurationException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+    };
+
+    private static SAXParserFactory saxParserFactory;
+
+    String rootNamespaceURI;
+    String rootLocalName;
+
+    public static DoctypeHandler ofSource(InputSource source)
+            throws IOException, SAXException {
+        DoctypeHandler doctype = new DoctypeHandler();
+        XMLReader xmlReader = localXMLReader.get();
+        xmlReader.setContentHandler(doctype);
+        xmlReader.setErrorHandler(doctype);
+        xmlReader.setEntityResolver(doctype);
+        try {
+            xmlReader.setProperty("http://xml.org/sax/properties/lexical-handler", doctype);
+        }
+        catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+            // Optional
+        }
+
+        try {
+            xmlReader.parse(source);
+        }
+        catch (StopParseException e) {
+            // Found root element
+        }
+        return doctype;
+    }
+
+    @Override
+    public void startDTD(String name, String publicId, String systemId)
+            throws SAXException {
+        if (name.equals("svg") || name.endsWith(":svg")) {
+            // Speculate it is a legitimate SVG
+            rootLocalName = "svg";
+            rootNamespaceURI = SVGImageReaderSpi.SVG_NS_URI;
+        }
+        else {
+            rootLocalName = name;
+            rootNamespaceURI = publicId;
+        }
+
+        throw StopParseException.INSTANCE;
+    }
+
+    @Override
+    public void startElement(String uri,
+                             String localName,
+                             String qName,
+                             Attributes attributes)
+            throws SAXException {
+        rootNamespaceURI = uri;
+        rootLocalName = localName;
+
+        throw StopParseException.INSTANCE;
+    }
+
+    @Override
+    public InputSource resolveEntity(String name,
+                                     String publicId,
+                                     String baseURI,
+                                     String systemId) {
+        return new InputSource(new StringReader("")); // empty entity
+    }
+
+    private static SAXParserFactory saxParserFactory() {
+        if (saxParserFactory == null) {
+            try {
+                SAXParserFactory spf = SAXParserFactory.newInstance();
+                spf.setNamespaceAware(true);
+                spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                saxParserFactory = spf;
+            } catch (SAXException | ParserConfigurationException e) {
+                throw new FactoryConfigurationError(e);
+            }
+        }
+        return saxParserFactory;
+    }
+
+
+    private static class StopParseException extends SAXException {
+
+        private static final long serialVersionUID = 7645435205561343094L;
+
+        static final StopParseException INSTANCE = new StopParseException();
+
+        private StopParseException() {
+            super("Parsing stopped from content handler");
+        }
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this; // Don't fill in stack trace
+        }
+    }
+
+
+}

--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
@@ -84,7 +84,7 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
 
             if (Boolean.getBoolean(XML_READER_DETECT)) {
                 InputStream stream = IIOUtil.createStreamAdapter(pInput);
-                return SVG_ROOT.equals(DoctypeHandler
+                return SVG_ROOT.getLocalPart().equals(DoctypeHandler
                         .doctypeOf(new InputSource(stream)));
             }
 

--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
@@ -41,6 +41,7 @@ import javax.xml.namespace.QName;
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ServiceRegistry;
 import javax.imageio.stream.ImageInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
@@ -57,6 +58,9 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
 
     final static boolean SVG_READER_AVAILABLE = SystemUtil.isClassAvailable("com.twelvemonkeys.imageio.plugins.svg.SVGImageReader", SVGImageReaderSpi.class);
 
+    static final String XML_READER_DETECT =
+            "com.twelvemonkeys.imageio.plugins.svg.xmlReaderDetect";
+
     static final QName SVG_ROOT = new QName("http://www.w3.org/2000/svg", "svg");
 
     /**
@@ -71,15 +75,98 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
         return pSource instanceof ImageInputStream && canDecode((ImageInputStream) pSource);
     }
 
+    @SuppressWarnings("StatementWithEmptyBody")
     private static boolean canDecode(final ImageInputStream pInput) throws IOException {
-        QName doctype;
-        pInput.mark();
+        // NOTE: This test is quite quick as it does not involve any parsing,
+        // however it may not recognize all kinds of SVG documents.
         try {
-            @SuppressWarnings("resource")
-            InputStream stream = IIOUtil.createStreamAdapter(pInput);
-            // XMLReader.parse() generally closes the input streams but the
-            // stream adapter prevents closing the underlying stream (✔)
-            doctype = DoctypeHandler.doctypeOf(new InputSource(stream));
+            pInput.mark();
+
+            if (Boolean.getBoolean(XML_READER_DETECT)) {
+                InputStream stream = IIOUtil.createStreamAdapter(pInput);
+                return SVG_ROOT.equals(DoctypeHandler
+                        .doctypeOf(new InputSource(stream)));
+            }
+
+            // TODO: This is not ok for UTF-16 and other wide encodings
+            // TODO: Use an XML (encoding) aware Reader instance instead
+            // Need to figure out pretty fast if this is XML or not
+            int b;
+            while (Character.isWhitespace((char) (b = pInput.read()))) {
+                // Skip over leading WS
+            }
+
+            // If it's not a tag, this can't be valid XML
+            if (b != '<') {
+                return false;
+            }
+
+            // Algorithm for detecting SVG:
+            //  - Skip until begin tag '<' and read 4 bytes
+            //  - if next is "?" skip until "?>" and start over
+            //  - else if next is "!--" skip until  "-->" and start over
+            //  - else if next is  "!DOCTYPE " skip any whitespace
+            //      - compare next 3 bytes against "svg", return result
+            //  - else
+            //      - compare next 3 bytes against "svg", return result
+
+            byte[] buffer = new byte[4];
+            while (true) {
+                pInput.readFully(buffer);
+
+                if (buffer[0] == '?') {
+                    // This is the XML declaration or a processing instruction
+                    while (!((pInput.readByte() & 0xFF) == '?' && pInput.read() == '>')) {
+                        // Skip until end of XML declaration or processing instruction or EOF
+                    }
+                }
+                else if (buffer[0] == '!') {
+                    if (buffer[1] == '-' && buffer[2] == '-') {
+                        // This is a comment
+                        while (!((pInput.readByte() & 0xFF) == '-' && pInput.read() == '-' && pInput.read() == '>')) {
+                            // Skip until end of comment or EOF
+                        }
+                    }
+                    else if (buffer[1] == 'D' && buffer[2] == 'O' && buffer[3] == 'C'
+                            && pInput.read() == 'T' && pInput.read() == 'Y'
+                            && pInput.read() == 'P' && pInput.read() == 'E') {
+                        // This is the DOCTYPE declaration
+                        while (Character.isWhitespace((char) (b = pInput.read()))) {
+                            // Skip over WS
+                        }
+
+                        if (b == 's' && pInput.read() == 'v' && pInput.read() == 'g') {
+                            // It's SVG, identified by DOCTYPE
+                            return true;
+                        }
+
+                        // DOCTYPE found, but not SVG
+                        return false;
+                    }
+
+                    // Something else, we'll skip
+                }
+                else {
+                    // This is a normal tag
+                    if (buffer[0] == 's' && buffer[1] == 'v' && buffer[2] == 'g'
+                            && (Character.isWhitespace((char) buffer[3]) || buffer[3] == ':')) {
+                        // It's SVG, identified by root tag
+                        // TODO: Support svg with prefix + recognize namespace (http://www.w3.org/2000/svg)!
+                        return true;
+                    }
+
+                    // If the tag is not "svg", this isn't SVG
+                    return false;
+                }
+
+                while ((pInput.readByte() & 0xFF) != '<') {
+                    // Skip over, until next begin tag or EOF
+                }
+            }
+        }
+        catch (EOFException ignore) {
+            // Possible for small files...
+            return false;
         }
         catch (SAXException e) {
             // Malformed XML, or not an XML at all
@@ -89,7 +176,6 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
             //noinspection ThrowFromFinallyBlock
             pInput.reset();
         }
-        return SVG_ROOT.equals(doctype);
     }
 
     public ImageReader createReaderInstance(final Object extension) throws IOException {

--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
@@ -36,6 +36,8 @@ import com.twelvemonkeys.lang.SystemUtil;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import javax.xml.namespace.QName;
+
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ServiceRegistry;
 import javax.imageio.stream.ImageInputStream;
@@ -55,7 +57,7 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
 
     final static boolean SVG_READER_AVAILABLE = SystemUtil.isClassAvailable("com.twelvemonkeys.imageio.plugins.svg.SVGImageReader", SVGImageReaderSpi.class);
 
-    static final String SVG_NS_URI = "http://www.w3.org/2000/svg";
+    static final QName SVG_ROOT = new QName("http://www.w3.org/2000/svg", "svg");
 
     /**
      * Creates an {@code SVGImageReaderSpi}.
@@ -70,14 +72,14 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
     }
 
     private static boolean canDecode(final ImageInputStream pInput) throws IOException {
-        DoctypeHandler doctype;
+        QName doctype;
         pInput.mark();
         try {
             @SuppressWarnings("resource")
             InputStream stream = IIOUtil.createStreamAdapter(pInput);
             // XMLReader.parse() generally closes the input streams but the
             // stream adapter prevents closing the underlying stream (✔)
-            doctype = DoctypeHandler.ofSource(new InputSource(stream));
+            doctype = DoctypeHandler.doctypeOf(new InputSource(stream));
         }
         catch (SAXException e) {
             // Malformed XML, or not an XML at all
@@ -87,8 +89,7 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
             //noinspection ThrowFromFinallyBlock
             pInput.reset();
         }
-        return "svg".equals(doctype.rootLocalName)
-                && SVG_NS_URI.equals(doctype.rootNamespaceURI);
+        return SVG_ROOT.equals(doctype);
     }
 
     public ImageReader createReaderInstance(final Object extension) throws IOException {

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
@@ -103,6 +103,15 @@ public class SVGImageReaderSpiTest {
     }
 
     @Test
+    public void canDecodeSpeculativeDoctype() throws Exception {
+        String svg = "<!DOCTYPE svg><svg xmlns=\"http://www.w3.org/2023/fake\">";
+
+        try (ImageInputStream input = new ByteArrayImageInputStream(svg.getBytes(StandardCharsets.UTF_8))) {
+            assertTrue("Can't read speculative DOCTYPE: " + svg, provider.canDecodeInput(input));
+        }
+    }
+
+    @Test
     public void canDecodeUTFBOMInput() throws Exception {
         String svgRoot = "\uFEFF<svg xmlns='http://www.w3.org/2000/svg'>";
         Charset[] utfCharsets = { StandardCharsets.UTF_8,

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
@@ -38,10 +38,12 @@ import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * SVGImageReaderSpiTest.
@@ -70,6 +72,8 @@ public class SVGImageReaderSpiTest {
         "<!-- ", // #275 Infinite loop issue
         "<?123?>", // #275 Infinite loop issue
         "<svg",
+        "<svg xmlns=\"http://www.w3.org/2023/fake\"></svg>",
+        "<!-- Malformed -- XML --><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>",
     };
 
     static {
@@ -96,5 +100,51 @@ public class SVGImageReaderSpiTest {
                 assertFalse("Claims to read invalid input:" + invalidInput, provider.canDecodeInput(input));
             }
         }
+    }
+
+    @Test
+    public void canDecodeUTFBOMInput() throws Exception {
+        String svgRoot = "\uFEFF<svg xmlns='http://www.w3.org/2000/svg'>";
+        Charset[] utfCharsets = { StandardCharsets.UTF_8,
+                                  StandardCharsets.UTF_16LE,
+                                  StandardCharsets.UTF_16BE };
+
+        for (Charset charset : utfCharsets) {
+            try (ImageInputStream input = new ByteArrayImageInputStream(svgRoot.getBytes(charset))) {
+                assertTrue("Can't read valid " + charset + " input with BOM", provider.canDecodeInput(input));
+            }
+        }
+    }
+
+    @Test
+    public void canDecodeEBCDICInput() throws Exception {
+        // The SAX parser implementation may support EBCDIC regardless of
+        // the JVM Charset.availableCharsets();  The XML declaration is
+        // required for reliable detection:
+        //
+        // <?xml version='1.0' encoding='IBM01140'?>
+        // <svg xmlns='http://www.w3.org/2000/svg'>
+        //
+        byte[] validInput = bytes(0x4C, 0x6F, 0xA7, 0x94, 0x93, 0x40, 0xA5,
+                0x85, 0x99, 0xA2, 0x89, 0x96, 0x95, 0x7E, 0x7D, 0xF1, 0x4B,
+                0xF0, 0x7D, 0x40, 0x85, 0x95, 0x83, 0x96, 0x84, 0x89, 0x95,
+                0x87, 0x7E, 0x7D, 0xC9, 0xC2, 0xD4, 0xF0, 0xF1, 0xF1, 0xF4,
+                0xF0, 0x7D, 0x6F, 0x6E, 0x4C, 0xA2, 0xA5, 0x87, 0x40, 0xA7,
+                0x94, 0x93, 0x95, 0xA2, 0x7E, 0x7D, 0x88, 0xA3, 0xA3, 0x97,
+                0x7A, 0x61, 0x61, 0xA6, 0xA6, 0xA6, 0x4B, 0xA6, 0xF3, 0x4B,
+                0x96, 0x99, 0x87, 0x61, 0xF2, 0xF0, 0xF0, 0xF0, 0x61, 0xA2,
+                0xA5, 0x87, 0x7D, 0x6E);
+
+        try (ImageInputStream input = new ByteArrayImageInputStream(validInput)) {
+            assumeTrue("Can't read valid IBM01140 (EBCDIC) input", provider.canDecodeInput(input));
+        }
+    }
+
+    private static byte[] bytes(int... bytes) {
+        byte[] array = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            array[i] = (byte) bytes[i];
+        }
+        return array;
     }
 }

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
@@ -38,12 +38,10 @@ import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * SVGImageReaderSpiTest.
@@ -72,8 +70,6 @@ public class SVGImageReaderSpiTest {
         "<!-- ", // #275 Infinite loop issue
         "<?123?>", // #275 Infinite loop issue
         "<svg",
-        "<svg xmlns=\"http://www.w3.org/2023/fake\"></svg>",
-        "<!-- Malformed -- XML --><svg xmlns=\"http://www.w3.org/2000/svg\"></svg>",
     };
 
     static {
@@ -81,7 +77,7 @@ public class SVGImageReaderSpiTest {
         ImageIO.setUseCache(false);
     }
 
-    private final ImageReaderSpi provider = new SVGImageReaderSpi();
+    final ImageReaderSpi provider = new SVGImageReaderSpi();
 
     @Test
     public void canDecodeInput() throws Exception {
@@ -100,60 +96,5 @@ public class SVGImageReaderSpiTest {
                 assertFalse("Claims to read invalid input:" + invalidInput, provider.canDecodeInput(input));
             }
         }
-    }
-
-    @Test
-    public void canDecodeSpeculativeDoctype() throws Exception {
-        String svg = "<!DOCTYPE svg><svg xmlns=\"http://www.w3.org/2023/fake\">";
-
-        try (ImageInputStream input = new ByteArrayImageInputStream(svg.getBytes(StandardCharsets.UTF_8))) {
-            assertTrue("Can't read speculative DOCTYPE: " + svg, provider.canDecodeInput(input));
-        }
-    }
-
-    @Test
-    public void canDecodeUTFBOMInput() throws Exception {
-        String svgRoot = "\uFEFF<svg xmlns='http://www.w3.org/2000/svg'>";
-        Charset[] utfCharsets = { StandardCharsets.UTF_8,
-                                  StandardCharsets.UTF_16LE,
-                                  StandardCharsets.UTF_16BE };
-
-        for (Charset charset : utfCharsets) {
-            try (ImageInputStream input = new ByteArrayImageInputStream(svgRoot.getBytes(charset))) {
-                assertTrue("Can't read valid " + charset + " input with BOM", provider.canDecodeInput(input));
-            }
-        }
-    }
-
-    @Test
-    public void canDecodeEBCDICInput() throws Exception {
-        // The SAX parser implementation may support EBCDIC regardless of
-        // the JVM Charset.availableCharsets();  The XML declaration is
-        // required for reliable detection:
-        //
-        // <?xml version='1.0' encoding='IBM01140'?>
-        // <svg xmlns='http://www.w3.org/2000/svg'>
-        //
-        byte[] validInput = bytes(0x4C, 0x6F, 0xA7, 0x94, 0x93, 0x40, 0xA5,
-                0x85, 0x99, 0xA2, 0x89, 0x96, 0x95, 0x7E, 0x7D, 0xF1, 0x4B,
-                0xF0, 0x7D, 0x40, 0x85, 0x95, 0x83, 0x96, 0x84, 0x89, 0x95,
-                0x87, 0x7E, 0x7D, 0xC9, 0xC2, 0xD4, 0xF0, 0xF1, 0xF1, 0xF4,
-                0xF0, 0x7D, 0x6F, 0x6E, 0x4C, 0xA2, 0xA5, 0x87, 0x40, 0xA7,
-                0x94, 0x93, 0x95, 0xA2, 0x7E, 0x7D, 0x88, 0xA3, 0xA3, 0x97,
-                0x7A, 0x61, 0x61, 0xA6, 0xA6, 0xA6, 0x4B, 0xA6, 0xF3, 0x4B,
-                0x96, 0x99, 0x87, 0x61, 0xF2, 0xF0, 0xF0, 0xF0, 0x61, 0xA2,
-                0xA5, 0x87, 0x7D, 0x6E);
-
-        try (ImageInputStream input = new ByteArrayImageInputStream(validInput)) {
-            assumeTrue("Can't read valid IBM01140 (EBCDIC) input", provider.canDecodeInput(input));
-        }
-    }
-
-    private static byte[] bytes(int... bytes) {
-        byte[] array = new byte[bytes.length];
-        for (int i = 0; i < bytes.length; i++) {
-            array[i] = (byte) bytes[i];
-        }
-        return array;
     }
 }

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiXMLReaderTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiXMLReaderTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2023, Harald Kuhr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.twelvemonkeys.imageio.plugins.svg;
+
+import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
+import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.imageio.ImageIO;
+import javax.imageio.spi.IIORegistry;
+import javax.imageio.spi.ImageReaderSpi;
+import javax.imageio.stream.ImageInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * SVGImageReaderSpi.canDecodeInput() using XML reader.
+ */
+public class SVGImageReaderSpiXMLReaderTest extends SVGImageReaderSpiTest {
+
+    @BeforeClass
+    public static void setSuiteUp() {
+        System.setProperty(SVGImageReaderSpi.XML_READER_DETECT, "true");
+    }
+
+    @AfterClass
+    public static void tearSuiteDown() {
+        System.setProperty(SVGImageReaderSpi.XML_READER_DETECT, "false");
+    }
+
+    @Test
+    public void canDecodeSpeculativeDoctype() throws Exception {
+        String svg = "<!DOCTYPE svg><svg xmlns=\"http://www.w3.org/2023/fake\">";
+
+        try (ImageInputStream input = new ByteArrayImageInputStream(svg.getBytes(StandardCharsets.UTF_8))) {
+            assertTrue("Can't read speculative DOCTYPE: " + svg, provider.canDecodeInput(input));
+        }
+    }
+
+    @Test
+    public void canDecodeUTFBOMInput() throws Exception {
+        String svgRoot = "\uFEFF<svg xmlns='http://www.w3.org/2000/svg'>";
+        Charset[] utfCharsets = { StandardCharsets.UTF_8,
+                                  StandardCharsets.UTF_16LE,
+                                  StandardCharsets.UTF_16BE };
+
+        for (Charset charset : utfCharsets) {
+            try (ImageInputStream input = new ByteArrayImageInputStream(svgRoot.getBytes(charset))) {
+                assertTrue("Can't read " + charset + " input with BOM", provider.canDecodeInput(input));
+            }
+        }
+    }
+
+    @Test
+    public void canDecodeUTFWithoutBOM() throws Exception {
+        String svgRoot = "<?xml version='1.0' encoding='%s'?>"
+                + "<svg xmlns='http://www.w3.org/2000/svg'>";
+        Charset[] utfCharsets = { StandardCharsets.UTF_8,
+                                  StandardCharsets.UTF_16LE,
+                                  StandardCharsets.UTF_16BE };
+
+        for (Charset charset : utfCharsets) {
+            byte[] bytes = String.format(svgRoot, charset.name()).getBytes(charset);
+            try (ImageInputStream input = new ByteArrayImageInputStream(bytes)) {
+                assertTrue("Can't read " + charset + " input w/o BOM", provider.canDecodeInput(input));
+            }
+        }
+    }
+
+    @Test
+    public void canDecodeEBCDICInput() throws Exception {
+        // The SAX parser implementation may support EBCDIC regardless of
+        // the JVM Charset.availableCharsets();  The XML declaration is
+        // required for reliable detection:
+        //
+        // <?xml version='1.0' encoding='IBM01140'?>
+        // <svg xmlns='http://www.w3.org/2000/svg'>
+        //
+        byte[] validInput = bytes(0x4C, 0x6F, 0xA7, 0x94, 0x93, 0x40, 0xA5,
+                0x85, 0x99, 0xA2, 0x89, 0x96, 0x95, 0x7E, 0x7D, 0xF1, 0x4B,
+                0xF0, 0x7D, 0x40, 0x85, 0x95, 0x83, 0x96, 0x84, 0x89, 0x95,
+                0x87, 0x7E, 0x7D, 0xC9, 0xC2, 0xD4, 0xF0, 0xF1, 0xF1, 0xF4,
+                0xF0, 0x7D, 0x6F, 0x6E, 0x4C, 0xA2, 0xA5, 0x87, 0x40, 0xA7,
+                0x94, 0x93, 0x95, 0xA2, 0x7E, 0x7D, 0x88, 0xA3, 0xA3, 0x97,
+                0x7A, 0x61, 0x61, 0xA6, 0xA6, 0xA6, 0x4B, 0xA6, 0xF3, 0x4B,
+                0x96, 0x99, 0x87, 0x61, 0xF2, 0xF0, 0xF0, 0xF0, 0x61, 0xA2,
+                0xA5, 0x87, 0x7D, 0x6E);
+
+        try (ImageInputStream input = new ByteArrayImageInputStream(validInput)) {
+            assumeTrue("Can't read valid IBM01140 (EBCDIC) input", provider.canDecodeInput(input));
+        }
+    }
+
+    private static byte[] bytes(int... bytes) {
+        byte[] array = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            array[i] = (byte) bytes[i];
+        }
+        return array;
+    }
+}

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiXMLReaderTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiXMLReaderTest.java
@@ -31,15 +31,11 @@
 package com.twelvemonkeys.imageio.plugins.svg;
 
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
-import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javax.imageio.ImageIO;
-import javax.imageio.spi.IIORegistry;
-import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
This is a suggestion for implementing universal SVG stream detection using a SAX parser that (setup will most likely be used for the final parsing, and):

-   Would handle any supported text encoding including UTF-16 and possible BOM

    Parser following [_F.1 Detection Without External Encoding Information_](https://www.w3.org/TR/xml/#sec-guessing) would be able to handle EBCDIC code pages as well;

-   Handles possible namespace prefixes and matches the SVG namespace precisely.

I haven't verified explicitly but the parsing is stopped at most at the root document element, and the performance should not be noticeably slower.  As previously, uses possible `DOCTYPE` declaration as a speculative optimization:

```xml
<!DOCTYPE svg ...>
<!--
  - Lenghty comment block...
  -->
<svg ...>
```

---

Notable differences with the existing implementation include:

-   No longer accepted:

    ```xml
    <!--
      -- Malformed
      -->
    <svg xmlns="http://www.w3.org/2000/svg">
    ```

-   No longer accepted:

    ```xml
    <svg xmlns="http://www.w3.org/2023/fake">
    ```

-   Now is accepted:

    ```xml
    <!DOCTYPE ns:svg>
    <ns:svg xmlns:ns="http://www.w3.org/2000/svg">
    ```

The following is wrongfully accepted as before:

```xml
<!DOCTYPE svg>
<svg xmlns="http://www.w3.org/2023/fake">
```

I don't think it is necessary but the last one could be made more reliable by considering the `DOCTYPE` declaration only when the name doesn't match `svg` and doesn't end with `:svg` (definitely not an SVG), or when the name matches `svg` or ends with `:svg` and the public identifier matches `-//W3C//DTD SVG 1.0//EN` or `-//W3C//DTD SVG 1.1//EN`.  If the `DOCTYPE` name is `svg` or ends with `:svg`, but the public identifier is unknown it could always fall back to looking at the root document element.
