### PR TITLE
JPG File fails to process

### DIFF
--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
@@ -94,6 +94,7 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
     protected List<TestData> getTestData() {
         // While a lot of these files don't conform to any spec (Exif/JFIF), we will read these.
         return Arrays.asList(
+                new TestData(getClassLoaderResource("/test_jpeg/Portugal-Nazare.jpg"), new Dimension(13622, 5070)),
                 new TestData(getClassLoaderResource("/jpeg/cmm-exception-adobe-rgb.jpg"), new Dimension(626, 76)),
                 new TestData(getClassLoaderResource("/jpeg/cmm-exception-srgb.jpg"), new Dimension(1800, 1200)),
                 new TestData(getClassLoaderResource("/jpeg/corrupted-icc-srgb.jpg"), new Dimension(1024, 685)),


### PR DESCRIPTION
I ran into this image that couldn't get processed. I've added it to this branch and to the testsuite. In case someone is interested in analyzing it.

It simply fails with:
```
[INFO] Running com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageReaderTest
WARNING: Reader does not throw exception with non-declared destination: BufferedImage@3b366632: type = 8 DirectColorModel: rmask=f800 gmask=7e0 bmask=1f amask=0 ShortInterleavedRaster: width = 50 height = 50 #numDataElements 1
WARNING: Reader does not throw exception with non-declared destination: BufferedImage@70925b45: type = 9 DirectColorModel: rmask=7c00 gmask=3e0 bmask=1f amask=0 ShortInterleavedRaster: width = 50 height = 50 #numDataElements 1
[ERROR] Tests run: 141, Failures: 1, Errors: 0, Skipped: 3, Time elapsed: 20.693 s <<< FAILURE! - in com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageReaderTest
[ERROR] com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageReaderTest.testSetDestinationType  Time elapsed: 0.71 s  <<< FAILURE!
java.lang.AssertionError: Could not read file:...TwelveMonkeys/imageio/imageio-jpeg/target/test-classes/test_jpeg/Portugal-Nazare.jpg with explicit destination type javax.imageio.ImageTypeSpecifier@ab7ef9a8
Caused by: javax.imageio.IIOException: Destination type from ImageReadParam does not match!
```

It says "could not read file", though it's perfectly accessible. The "with explicit destination" is something I don't know about.

