### PR TITLE
wip: Support fake alpha for BMP files

### DIFF
--- a/imageio/imageio-bmp/src/main/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReader.java
+++ b/imageio/imageio-bmp/src/main/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReader.java
@@ -251,8 +251,14 @@ public final class BMPImageReader extends ImageReaderBase {
                         );
                     }
 
+                    // TODO: use some heuristic to determine if we should treat the extra byte as an alpha channel
+                    //
+                    // According to https://entropymine.com/jason/bmpsuite/bmpsuite/html/bmpsuite.html some BMP decoders
+                    // will treat the unused bits in a 32 bit representation as an alpha channel if any of the unused bits is non-zero
+                    // but that potentially requires doing a full pass over all the pizels (in that case that it doesn't use fake alpha).
+
                     // Default if no mask
-                    return ImageTypeSpecifiers.createFromBufferedImageType(BufferedImage.TYPE_INT_RGB);
+                    return ImageTypeSpecifiers.createFromBufferedImageType(BufferedImage.TYPE_INT_ARGB);
 
                 case 0:
                     if (header.getCompression() == DIB.COMPRESSION_JPEG || header.getCompression() == DIB.COMPRESSION_PNG) {

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderTest.java
@@ -394,6 +394,23 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
         }
     }
 
+    @Test
+    public void testFakeAlpha() throws IOException {
+      final ImageReader reader = createReader();
+      TestData data = new TestData(getClassLoaderResource("/bmpsuite/q/rgb32fakealpha.bmp"), new Dimension(127, 64));
+      reader.setInput(data.getInputStream());
+      try {
+        reader.read(0);
+      }
+      catch (IOException e) {
+        fail("Could not read image");
+      }
+
+      ImageTypeSpecifier rawType = reader.getRawImageType(0);
+      assertNotNull(rawType);
+      assertTrue("BMP with fake alpha should support the alpha channel", rawType.getColorModel().hasAlpha());
+    }
+
     private void assertNodeEquals(final String message, final Node expected, final Node actual) {
         assertEquals(message + " class differs", expected.getClass(), actual.getClass());
 


### PR DESCRIPTION
Fixes #727

This isn't currently in a mergeable state, because it just always assumes that the unused bits are an alpha channel if bpp is 32 and compression doesn't set BITFIELDS.