### PR TITLE
PSD: Add missing guide info in metadata

### DIFF
--- a/imageio/imageio-psd/src/main/java/com/twelvemonkeys/imageio/plugins/psd/PSDMetadata.java
+++ b/imageio/imageio-psd/src/main/java/com/twelvemonkeys/imageio/plugins/psd/PSDMetadata.java
@@ -203,6 +203,7 @@ public final class PSDMetadata extends AbstractMetadata {
                     IIOMetadataNode guideNode = new IIOMetadataNode("Guide");
                     guideNode.setAttribute("location", Integer.toString(guide.location));
                     guideNode.setAttribute("orientation", GUIDE_ORIENTATIONS[guide.direction]);
+                    node.appendChild(guideNode);
                 }
             }
             else if (imageResource instanceof PSDPixelAspectRatio) {


### PR DESCRIPTION
This adds the `<Guide>` node under the `<GridAndGuideInfo>` node.
This allows to access the guides info (location and orientation).