### PR TITLE
PSD: Adding parsing for 'lsdk' (undocumented) additional layer information

### DIFF
--- a/imageio/imageio-psd/src/main/java/com/twelvemonkeys/imageio/plugins/psd/PSD.java
+++ b/imageio/imageio-psd/src/main/java/com/twelvemonkeys/imageio/plugins/psd/PSD.java
@@ -709,4 +709,6 @@ interface PSD extends com.twelvemonkeys.imageio.metadata.psd.PSD {
     int luni = 'l' << 24 | 'u' << 16 | 'n' << 8 | 'i';
     int lyid = 'l' << 24 | 'y' << 16 | 'i' << 8 | 'd';
     int lsct = 'l' << 24 | 's' << 16 | 'c' << 8 | 't';
+    // Undocumented: Nested section divider setting
+    int lsdk = 'l' << 24 | 's' << 16 | 'd' << 8 | 'k';
 }

--- a/imageio/imageio-psd/src/main/java/com/twelvemonkeys/imageio/plugins/psd/PSDLayerInfo.java
+++ b/imageio/imageio-psd/src/main/java/com/twelvemonkeys/imageio/plugins/psd/PSDLayerInfo.java
@@ -155,6 +155,7 @@ final class PSDLayerInfo {
                     layerId = pInput.readInt();
                     break;
 
+                case PSD.lsdk:
                 case PSD.lsct:
                     if (resourceLength < 4) {
                         throw new IIOException(String.format("Expected sectionDividerSetting length >= 4: %d", resourceLength));


### PR DESCRIPTION
Photoshop currently has an additional not documented key for "additional layer information" that is `lsdk`.

This should be a `nested section divider setting` and should have the same behaviour of `lsct`, that is`section divider setting`.

Other PSD libraries parse it in an equivalent fashion:
- [webtoon/psd](https://github.com/webtoon/psd/blob/main/packages/psd/src/sections/LayerAndMaskInformation/AdditionalLayerInfo/index.ts#L76)
- [psd-tools/psd-tools](https://github.com/psd-tools/psd-tools/blob/main/src/psd_tools/api/psd_image.py#L589)

And here some some github discussions [link1](https://github.com/layervault/psd.rb/issues/38) and [link2](https://github.com/psd-tools/psd-tools/issues/16).

Unfortunately I cannot share the PSD I am working on since it's covered by an NDA and I was not able to reproduce it by myself.