### PR TITLE
Batik version bump

### DIFF
--- a/imageio/imageio-batik/pom.xml
+++ b/imageio/imageio-batik/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.jpms.module.name>com.twelvemonkeys.imageio.batik</project.jpms.module.name>
-        <batik.version>1.16</batik.version>
+        <batik.version>1.17</batik.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Compiled locally, so version 1.17 should be available.

3 security fixes:

https://issues.apache.org/jira/browse/BATIK-1349
https://issues.apache.org/jira/browse/BATIK-1347
https://issues.apache.org/jira/browse/BATIK-1346

Something about defining a list for running javascript and then disabling the previous default which allowed everything to run, without configuration.