### PR TITLE
Fix flaky test

### DIFF
--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/StandardImageMetadataSupportTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/StandardImageMetadataSupportTest.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import static com.twelvemonkeys.imageio.StandardImageMetadataSupport.builder;
 import static org.junit.Assert.*;
@@ -184,14 +183,13 @@ public class StandardImageMetadataSupportTest {
         NodeList textEntries = textNode.getElementsByTagName("TextEntry");
         assertEquals(entries.size(), textEntries.getLength());
 
-        int i = 0;
-        for (Entry<String, String> entry : entries.entrySet()) {
+        for(int i=0;i<entries.size();i++){
             IIOMetadataNode textEntry = (IIOMetadataNode) textEntries.item(i);
-            assertEquals(entry.getKey(), textEntry.getAttribute("keyword"));
-            assertEquals(entry.getValue(), textEntry.getAttribute("value"));
-
-            i++;
+            assertTrue(entries.containsKey(textEntry.getAttribute("keyword")));
+            String key = textEntry.getAttribute("keyword");
+            assertEquals(entries.get(key), textEntry.getAttribute("value"));
         }
+            
     }
 
     @Test


### PR DESCRIPTION
**Description**
Fixed the flaky test "withTextValuesMap" inside the "StandardImageMetadataSupportTest" class.

**Root Cause**
The test "withTextValuesMap" has been reported as flaky when run with the Nondex tool. The test failed because it is trying to compare the keys and values of a Map(entries) with that of the values in a NodeList. The values of the map are hardcoded in the code and compared with those of the values in NodeList. But the Map is initialized to be a HashMap and the HashMap in Java is implemented in such a way that it does not store the order in which the keys and values are inserted.

**Fix**
In order to fix this test, instead of just retrieving the keys and values from the Hashmap. I have first checked if the key is present in the hashmap using containsKey() function. If the key is present then the value corresponding to that key is compared to the value from the NodeList "textEntries". The code is updated in such a way that for each entry(irrespective of the order) in the hashmap, the attributes of "textEntries"(both "keyword" and "value") are tested to be present in the HashMap "entries". 

**Screenshot showing the test failure when run with the NonDex tool**

<img width="1081" alt="image" src="https://github.com/haraldk/TwelveMonkeys/assets/112648268/6d8e0b2f-027f-48f0-84a1-65b737a7a0ed">

**Screenshot showing the test Success with the proposed changes**

<img width="1282" alt="image" src="https://github.com/haraldk/TwelveMonkeys/assets/112648268/4b2a2291-3da7-4d90-94ba-8f2a5098ae78">
