### PR TITLE
Loop logic bug

### DIFF
--- a/common/common-image/src/main/java/com/twelvemonkeys/image/ImageUtil.java
+++ b/common/common-image/src/main/java/com/twelvemonkeys/image/ImageUtil.java
@@ -844,7 +844,7 @@ public final class ImageUtil {
                 return false;
             }
 
-            for (int i = 0; i > mapSize1; i++) {
+            for (int i = 0; i < mapSize1; i++) {
                 if (icm1.getRGB(i) != icm2.getRGB(i)) {
                     return false;
                 }


### PR DESCRIPTION
Seeing the new release come out, I let the old static code analyzer run over things and went over the results, looking for anything interesting. This showed up.

The loop as it was, was never going to run. The condition is "if i is greater than mapsize", which will never be the case, since i starts at 0.

For looping over the mapsize, the condition should be reversed.

I'm unaware if there are serious implications to this never having run, nor what the implications will be now that it will, in terms of process runtime and all that.