### PR TITLE
Change maven-bundle-plugin config to correctly export ImageWriterSpi services

### DIFF
--- a/imageio/imageio-bmp/pom.xml
+++ b/imageio/imageio-bmp/pom.xml
@@ -36,7 +36,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>

--- a/imageio/imageio-icns/pom.xml
+++ b/imageio/imageio-icns/pom.xml
@@ -36,7 +36,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>

--- a/imageio/imageio-iff/pom.xml
+++ b/imageio/imageio-iff/pom.xml
@@ -39,7 +39,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>

--- a/imageio/imageio-jpeg/pom.xml
+++ b/imageio/imageio-jpeg/pom.xml
@@ -42,7 +42,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>

--- a/imageio/imageio-pict/pom.xml
+++ b/imageio/imageio-pict/pom.xml
@@ -36,7 +36,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>

--- a/imageio/imageio-pnm/pom.xml
+++ b/imageio/imageio-pnm/pom.xml
@@ -38,7 +38,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>

--- a/imageio/imageio-psd/pom.xml
+++ b/imageio/imageio-psd/pom.xml
@@ -41,7 +41,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>

--- a/imageio/imageio-tga/pom.xml
+++ b/imageio/imageio-tga/pom.xml
@@ -38,7 +38,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>

--- a/imageio/imageio-tiff/pom.xml
+++ b/imageio/imageio-tiff/pom.xml
@@ -47,7 +47,8 @@
                     <instructions>
                         <Provide-Capability>
                             osgi.serviceloader;
-                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
+                            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
+                            osgi.serviceloader;
                             osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
                         </Provide-Capability>
                     </instructions>


### PR DESCRIPTION
This fixes https://github.com/haraldk/TwelveMonkeys/issues/855

The change is changing something like this
```
    <instructions>
        <Provide-Capability>
            osgi.serviceloader;
            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi;
            osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
        </Provide-Capability>
    </instructions>
```
to this
```
    <instructions>
        <Provide-Capability>
            osgi.serviceloader;
            osgi.serviceloader=javax.imageio.spi.ImageReaderSpi,
            osgi.serviceloader;
            osgi.serviceloader=javax.imageio.spi.ImageWriterSpi
        </Provide-Capability>
    </instructions>
```
for all bundles that export both a reader and a writer.

I.e. replace the semicolon after ImageReaderSpi with a comma, and add an extra osgi.serviceloader; before the second service.