### PR TITLE
SpotBugs bug on bitwise OR of signed byte computed

### DIFF
--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReader.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReader.java
@@ -1325,12 +1325,12 @@ public final class TIFFImageReader extends ImageReaderBase {
                     // but has the correct offset to the JPEG stream in the StripOffsets tag.
                     long realJPEGOffset = jpegOffset;
 
-                    short expectedSOI = (short) (imageInput.readByte() << 8 | imageInput.readByte());
+                    short expectedSOI = (short) (imageInput.readByte() << 8 | (imageInput.readByte() & 0xff));
                     if (expectedSOI != (short) JPEG.SOI) {
                         if (stripTileOffsets != null && stripTileOffsets.length == 1) {
                             imageInput.seek(stripTileOffsets[0]);
 
-                            expectedSOI = (short) (imageInput.readByte() << 8 | imageInput.readByte());
+                            expectedSOI = (short) (imageInput.readByte() << 8 | (imageInput.readByte() & 0xff));
                             if (expectedSOI == (short) JPEG.SOI) {
                                 realJPEGOffset = stripTileOffsets[0];
                             }
@@ -1356,7 +1356,7 @@ public final class TIFFImageReader extends ImageReaderBase {
                         // If the first tile stream starts with SOS, we'll correct offset/length
                         imageInput.seek(stripTileOffsets[0]);
 
-                        if ((short) (imageInput.readByte() << 8 | imageInput.readByte()) == (short) JPEG.SOS) {
+                        if ((short) (imageInput.readByte() << 8 | (imageInput.readByte() & 0xff)) == (short) JPEG.SOS) {
                             processWarningOccurred("Incorrect StripOffsets/TileOffsets, points to SOS marker, ignoring offsets/byte counts.");
                             int len = 2 + (imageInput.readUnsignedByte() << 8 | imageInput.readUnsignedByte());
                             stripTileOffsets[0] += len;
@@ -1530,7 +1530,7 @@ public final class TIFFImageReader extends ImageReaderBase {
 
                                 // If the tile stream starts with SOS...
                                 if (x == 0 && y == 0) {
-                                    if ((short) (imageInput.readByte() << 8 | imageInput.readByte()) == (short) JPEG.SOS) {
+                                    if ((short) (imageInput.readByte() << 8 | (imageInput.readByte() & 0xff)) == (short) JPEG.SOS) {
                                         imageInput.seek(stripTileOffsets[i] + 14); // TODO: Read from SOS length from stream, in case of gray/CMYK
                                         length -= 14;
                                     }


### PR DESCRIPTION
In trying out more static analysis, I ran into spotbugs, which produced this.

It seems to be a very niche, specific issue, only appearing for signed bytes, but also so extremely unlikely to be detected if you have to look for it. So I thought I'd add it, since the fix seems to be safe in all cases, from what I understand.

Though the test suites will have to indicate that in the end.

The detection is described here: https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#bit-bitwise-or-of-signed-byte-value-bit-ior-of-signed-byte

I'll copy the explanation here:

Loads a byte value (e.g., a value loaded from a byte array or returned by a method with return type byte) and performs a bitwise OR with that value. Byte values are sign extended to 32 bits before any bitwise operations are performed on the value. Thus, if `b[0]` contains the value `0xff`, and `x` is initially 0, then the code `((x << 8) | b[0])` will sign extend `0xff` to get `0xffffffff`, and thus give the value `0xffffffff` as the result.

In particular, the following code for packing a byte array into an int is badly wrong:
```
int result = 0;
for (int i = 0; i < 4; i++) {
    result = ((result << 8) | b[i]);
}
```
The following idiom will work instead:
```
int result = 0;
for (int i = 0; i < 4; i++) {
    result = ((result << 8) | (b[i] & 0xff));
}
```