### PR TITLE
TIFF: Add support for SAMPLEFORMAT_COMPLEXINT/SAMPLEFORMAT_COMPLEXIEEEFP

### DIFF
--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFExtension.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFExtension.java
@@ -71,6 +71,10 @@ interface TIFFExtension {
     int SAMPLEFORMAT_INT = 2;
     int SAMPLEFORMAT_FP = 3;
     int SAMPLEFORMAT_UNDEFINED = 4;
+    /** Complex signed integer */
+    int SAMPLEFORMAT_COMPLEXINT = 5;
+    /** Complex IEEE floating point */
+    int SAMPLEFORMAT_COMPLEXIEEEFP = 6;
 
     int YCBCR_POSITIONING_CENTERED = 1;
     int YCBCR_POSITIONING_COSITED = 2;

--- a/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReader.java
+++ b/imageio/imageio-tiff/src/main/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReader.java
@@ -809,6 +809,7 @@ public final class TIFFImageReader extends ImageReaderBase {
             case TIFFBaseline.SAMPLEFORMAT_UINT:
                 return bitsPerSample <= 8 ? DataBuffer.TYPE_BYTE : bitsPerSample <= 16 ? DataBuffer.TYPE_USHORT : DataBuffer.TYPE_INT;
             case TIFFExtension.SAMPLEFORMAT_INT:
+            case TIFFExtension.SAMPLEFORMAT_COMPLEXINT:
                 switch (bitsPerSample) {
                     case 8:
                         return DataBuffer.TYPE_BYTE;
@@ -818,9 +819,10 @@ public final class TIFFImageReader extends ImageReaderBase {
                         return DataBuffer.TYPE_INT;
                 }
 
-                throw new IIOException("Unsupported BitsPerSample for SampleFormat 2/Signed Integer (expected 8/16/32): " + bitsPerSample);
+                throw new IIOException("Unsupported BitsPerSample for SampleFormat 2/Signed Integer, 5/Complex Integer (expected 8/16/32): " + bitsPerSample);
 
             case TIFFExtension.SAMPLEFORMAT_FP:
+            case TIFFExtension.SAMPLEFORMAT_COMPLEXIEEEFP:
                 if (bitsPerSample == 16 || bitsPerSample == 32) {
                     return DataBuffer.TYPE_FLOAT;
                 }
@@ -828,9 +830,9 @@ public final class TIFFImageReader extends ImageReaderBase {
                     return DataBuffer.TYPE_DOUBLE;
                 }
 
-                throw new IIOException("Unsupported BitsPerSample for SampleFormat 3/Floating Point (expected 16/32/64): " + bitsPerSample);
+                throw new IIOException("Unsupported BitsPerSample for SampleFormat 3/Floating Point, 6/Complex Floating Point (expected 16/32/64): " + bitsPerSample);
             default:
-                throw new IIOException("Unknown TIFF SampleFormat (expected 1, 2, 3 or 4): " + sampleFormat);
+                throw new IIOException("Unknown TIFF SampleFormat (expected 1, 2, 3, 4, 5 or 6): " + sampleFormat);
         }
     }
 


### PR DESCRIPTION
Fixes #884

I didn't add tests in the commit (although I wrote one) because the [smallest sample file](https://capella-open-data.s3.amazonaws.com/data/2024/9/24/CAPELLA_C13_SM_SLC_VV_20240924045643_20240924045645/CAPELLA_C13_SM_SLC_VV_20240924045643_20240924045645.tif) I could find is 25 Mb... Let me know if I should add it anyway:

```diff
--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReaderTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReaderTest.java
@@ -194,7 +194,9 @@ public class TIFFImageReaderTest extends ImageReaderAbstractTest<TIFFImageReader
                 new TestData(getClassLoaderResource("/tiff/planar-yuv420-jpeg-uncompressed.tif"), new Dimension(256, 64)), // YCbCr, JPEG coefficients, uncompressed, striped
                 new TestData(getClassLoaderResource("/tiff/planar-yuv420-jpeg-lzw.tif"), new Dimension(256, 64)), // YCbCr, JPEG coefficients,LZW compressed, striped
                 new TestData(getClassLoaderResource("/tiff/planar-yuv410-jpeg-uncompressed.tif"), new Dimension(256, 64)), // YCbCr, JPEG coefficients, uncompressed, striped
-                new TestData(getClassLoaderResource("/tiff/planar-yuv410-jpeg-lzw.tif"), new Dimension(256, 64)) // YCbCr, JPEG coefficients,LZW compressed, striped
+                new TestData(getClassLoaderResource("/tiff/planar-yuv410-jpeg-lzw.tif"), new Dimension(256, 64)), // YCbCr, JPEG coefficients,LZW compressed, striped
+                // Complex sample formats
+                new TestData(getClassLoaderResource("/tiff/CAPELLA_C13_SM_SLC_VV_20240924045643_20240924045645.tif"), new Dimension(1871, 5026)) // Complex signed integer
         );
     }

```

