### PR TITLE
Upgrade to Junit5

### DIFF
--- a/common/common-image/src/test/java/com/twelvemonkeys/image/AffineTransformOpTest.java
+++ b/common/common-image/src/test/java/com/twelvemonkeys/image/AffineTransformOpTest.java
@@ -31,9 +31,7 @@
 package com.twelvemonkeys.image;
 
 import static java.lang.Math.min;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.awt.color.ColorSpace;
 import java.awt.geom.AffineTransform;
@@ -49,7 +47,7 @@ import java.util.List;
 
 import javax.imageio.ImageTypeSpecifier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * AffineTransformOpTest.
@@ -146,12 +144,12 @@ public class AffineTransformOpTest {
             BufferedImage jreResult = jreOp.filter(image, null);
             BufferedImage tmResult = tmOp.filter(image, null);
 
-            assertNotNull("No result!", tmResult);
-            assertEquals("Bad type", jreResult.getType(), tmResult.getType());
-            assertEquals("Incorrect color model", jreResult.getColorModel(), tmResult.getColorModel());
+            assertNotNull(tmResult, "No result!");
+            assertEquals(jreResult.getType(), tmResult.getType(), "Bad type");
+            assertEquals(jreResult.getColorModel(), tmResult.getColorModel(), "Incorrect color model");
 
-            assertEquals("Incorrect width", jreResult.getWidth(), tmResult.getWidth());
-            assertEquals("Incorrect height", jreResult.getHeight(), tmResult.getHeight());
+            assertEquals(jreResult.getWidth(), tmResult.getWidth(), "Incorrect width");
+            assertEquals(jreResult.getHeight(), tmResult.getHeight(), "Incorrect height");
         }
     }
 
@@ -164,7 +162,7 @@ public class AffineTransformOpTest {
             BufferedImage image = spec.createBufferedImage(width, height);
 
             BufferedImage tmResult = tmOp.filter(image, null);
-            assertNotNull("No result!", tmResult);
+            assertNotNull(tmResult, "No result!");
 
             BufferedImage jreResult = null;
 
@@ -176,18 +174,18 @@ public class AffineTransformOpTest {
             }
 
             if (jreResult != null) {
-                assertEquals("Bad type", jreResult.getType(), tmResult.getType());
-                assertEquals("Incorrect color model", jreResult.getColorModel(), tmResult.getColorModel());
+                assertEquals(jreResult.getType(), tmResult.getType(), "Bad type");
+                assertEquals(jreResult.getColorModel(), tmResult.getColorModel(), "Incorrect color model");
 
-                assertEquals("Incorrect width", jreResult.getWidth(), tmResult.getWidth());
-                assertEquals("Incorrect height", jreResult.getHeight(), tmResult.getHeight());
+                assertEquals(jreResult.getWidth(), tmResult.getWidth(), "Incorrect width");
+                assertEquals(jreResult.getHeight(), tmResult.getHeight(), "Incorrect height");
             }
             else {
-                assertEquals("Bad type", spec.getBufferedImageType(), tmResult.getType());
-                assertEquals("Incorrect color model", spec.getColorModel(), tmResult.getColorModel());
+                assertEquals(spec.getBufferedImageType(), tmResult.getType(), "Bad type");
+                assertEquals(spec.getColorModel(), tmResult.getColorModel(), "Incorrect color model");
 
-                assertEquals("Incorrect width", height, tmResult.getWidth());
-                assertEquals("Incorrect height", width, tmResult.getHeight());
+                assertEquals(height, tmResult.getWidth(), "Incorrect width");
+                assertEquals(width, tmResult.getHeight(), "Incorrect height");
             }
         }
     }
@@ -236,12 +234,12 @@ public class AffineTransformOpTest {
             }
 
             if (jreResult != null) {
-                assertEquals("Incorrect width", jreResult.getWidth(), tmResult.getWidth());
-                assertEquals("Incorrect height", jreResult.getHeight(), tmResult.getHeight());
+                assertEquals(jreResult.getWidth(), tmResult.getWidth(), "Incorrect width");
+                assertEquals(jreResult.getHeight(), tmResult.getHeight(), "Incorrect height");
             }
             else {
-                assertEquals("Incorrect width", height, tmResult.getWidth());
-                assertEquals("Incorrect height", width, tmResult.getHeight());
+                assertEquals(height, tmResult.getWidth(), "Incorrect width");
+                assertEquals(width, tmResult.getHeight(), "Incorrect height");
             }
         }
     }
@@ -277,12 +275,12 @@ public class AffineTransformOpTest {
             }
 
             if (jreResult != null) {
-                assertEquals("Incorrect width", jreResult.getWidth(), tmResult.getWidth());
-                assertEquals("Incorrect height", jreResult.getHeight(), tmResult.getHeight());
+                assertEquals(jreResult.getWidth(), tmResult.getWidth(), "Incorrect width");
+                assertEquals(jreResult.getHeight(), tmResult.getHeight(), "Incorrect height");
             }
             else {
-                assertEquals("Incorrect width", height, tmResult.getWidth());
-                assertEquals("Incorrect height", width, tmResult.getHeight());
+                assertEquals(height, tmResult.getWidth(), "Incorrect width");
+                assertEquals(width, tmResult.getHeight(), "Incorrect height");
             }
         }
     }

--- a/common/common-image/src/test/java/com/twelvemonkeys/image/BufferedImageFactoryTest.java
+++ b/common/common-image/src/test/java/com/twelvemonkeys/image/BufferedImageFactoryTest.java
@@ -85,7 +85,7 @@ public class BufferedImageFactoryTest {
     @Disabled("Bug in Toolkit")
     @Test
     public void testGetBufferedImageErrorSourceString() {
-        assertTimeout(Duration.ofMillis(1000), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(1000), () -> {
             Image source = Toolkit.getDefaultToolkit().createImage((String) null);
             BufferedImageFactory factory = new BufferedImageFactory(source);
             assertThrows(ImageConversionException.class, factory::getBufferedImage);
@@ -96,7 +96,7 @@ public class BufferedImageFactoryTest {
     // Unfortunately, the API doesn't allow this...
     @Test
     public void testGetBufferedImageErrorSourceURL() {
-        assertTimeout(Duration.ofMillis(1000), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(1000), () -> {
             Image source = Toolkit.getDefaultToolkit().createImage((String) null);
             BufferedImageFactory factory = new BufferedImageFactory(source);
             assertThrows(ImageConversionException.class, factory::getBufferedImage);

--- a/common/common-image/src/test/java/com/twelvemonkeys/image/BufferedImageFactoryTest.java
+++ b/common/common-image/src/test/java/com/twelvemonkeys/image/BufferedImageFactoryTest.java
@@ -30,17 +30,16 @@
 
 package com.twelvemonkeys.image;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.awt.*;
 import java.awt.color.*;
 import java.awt.image.*;
 import java.net.URL;
+import java.time.Duration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * BufferedImageFactoryTestCase
@@ -50,50 +49,58 @@ import static org.junit.Assert.assertTrue;
  * @version $Id: BufferedImageFactoryTestCase.java,v 1.0 May 7, 2010 12:40:08 PM haraldk Exp$
  */
 public class BufferedImageFactoryTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullImage() {
-        new BufferedImageFactory((Image) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new BufferedImageFactory((Image) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullProducer() {
-        new BufferedImageFactory((ImageProducer) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new BufferedImageFactory((ImageProducer) null);
+        });
     }
 
     // NPE in Toolkit, ok
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testGetBufferedImageErrorSourceByteArray() {
-        Image source = Toolkit.getDefaultToolkit().createImage((byte[]) null);
-
-        new BufferedImageFactory(source);
+        assertThrows(RuntimeException.class, () -> {
+            Image source = Toolkit.getDefaultToolkit().createImage((byte[]) null);
+            new BufferedImageFactory(source);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetBufferedImageErrorSourceImageProducer() {
         Image source = Toolkit.getDefaultToolkit().createImage((ImageProducer) null);
-
-        new BufferedImageFactory(source);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new BufferedImageFactory(source);
+        });
     }
 
     // TODO: This is a quite serious bug, however, the bug is in the Toolkit, allowing such images in the first place...
     // In any case, there's not much we can do, except until someone is bored and kills the app/thread... :-P
-    @Ignore("Bug in Toolkit")
-    @Test(timeout = 1000, expected = ImageConversionException.class)
+    @Disabled("Bug in Toolkit")
+    @Test
     public void testGetBufferedImageErrorSourceString() {
-        Image source = Toolkit.getDefaultToolkit().createImage((String) null);
-
-        BufferedImageFactory factory = new BufferedImageFactory(source);
-        factory.getBufferedImage();
+        assertTimeout(Duration.ofMillis(1000), () -> {
+            Image source = Toolkit.getDefaultToolkit().createImage((String) null);
+            BufferedImageFactory factory = new BufferedImageFactory(source);
+            assertThrows(ImageConversionException.class, factory::getBufferedImage);
+        });
     }
 
     // This is a little random, and it would be nicer if we could throw an IllegalArgumentException on create.
     // Unfortunately, the API doesn't allow this...
-    @Test(timeout = 1000, expected = ImageConversionException.class)
+    @Test
     public void testGetBufferedImageErrorSourceURL() {
-        Image source = Toolkit.getDefaultToolkit().createImage(getClass().getResource("/META-INF/MANIFEST.MF"));
-
-        BufferedImageFactory factory = new BufferedImageFactory(source);
-        factory.getBufferedImage();
+        assertTimeout(Duration.ofMillis(1000), () -> {
+            Image source = Toolkit.getDefaultToolkit().createImage((String) null);
+            BufferedImageFactory factory = new BufferedImageFactory(source);
+            assertThrows(ImageConversionException.class, factory::getBufferedImage);
+        });
     }
 
     @Test
@@ -165,7 +172,7 @@ public class BufferedImageFactoryTest {
 
         assertEquals(3, colorModel.getNumColorComponents());
         assertEquals(ColorSpace.getInstance(ColorSpace.CS_sRGB), colorModel.getColorSpace());
-        assertTrue(colorModel instanceof IndexColorModel);
+        assertInstanceOf(IndexColorModel.class, colorModel);
 
         assertTrue(colorModel.hasAlpha());
         assertEquals(4, colorModel.getNumComponents());
@@ -196,7 +203,7 @@ public class BufferedImageFactoryTest {
 
         for (int y = 0; y < image.getHeight(); y++) {
             for (int x = 0; x < image.getWidth(); x++) {
-                assertEquals("RGB[" + x + ", " + y + "]", original.getRGB(x * 2, y * 2), image.getRGB(x, y));
+                assertEquals(original.getRGB(x * 2, y * 2), image.getRGB(x, y), "RGB[" + x + ", " + y + "]");
             }
         }
     }
@@ -219,7 +226,7 @@ public class BufferedImageFactoryTest {
 
         for (int y = 0; y < image.getHeight(); y++) {
             for (int x = 0; x < image.getWidth(); x++) {
-                assertEquals("RGB[" + x + ", " + y + "]", original.getRGB(40 + x, 40 + y), image.getRGB(x, y));
+                assertEquals(original.getRGB(40 + x, 40 + y), image.getRGB(x, y), "RGB[" + x + ", " + y + "]");
             }
         }
     }
@@ -243,7 +250,7 @@ public class BufferedImageFactoryTest {
 
         for (int y = 0; y < image.getHeight(); y++) {
             for (int x = 0; x < image.getWidth(); x++) {
-                assertEquals("RGB[" + x + ", " + y + "]", original.getRGB(40 + x * 2, 40 + y * 2), image.getRGB(x, y));
+                assertEquals(original.getRGB(40 + x * 2, 40 + y * 2), image.getRGB(x, y), "RGB[" + x + ", " + y + "]");
             }
         }
     }

--- a/common/common-image/src/test/java/com/twelvemonkeys/image/ImageUtilTest.java
+++ b/common/common-image/src/test/java/com/twelvemonkeys/image/ImageUtilTest.java
@@ -304,6 +304,7 @@ public class ImageUtilTest {
                 int r = rgb >> 16 & 0xFF;
                 int g = rgb >> 8 & 0xFF;
                 int b = rgb & 0xFF;
+                assertTrue(r == 0 || r == 255, "Max contrast should only produce primary colors");
                 assertTrue(g == 0 || g == 255, "Max contrast should only produce primary colors");
                 assertTrue(b == 0 || b == 255, "Max contrast should only produce primary colors");
             }

--- a/common/common-image/src/test/java/com/twelvemonkeys/image/ImageUtilTest.java
+++ b/common/common-image/src/test/java/com/twelvemonkeys/image/ImageUtilTest.java
@@ -30,7 +30,7 @@
 
 package com.twelvemonkeys.image;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -39,7 +39,7 @@ import java.awt.image.IndexColorModel;
 import java.awt.image.RenderedImage;
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ImageUtilTest {
 
@@ -116,8 +116,8 @@ public class ImageUtilTest {
     public void testImageIsNotBufferedImage() {
         // Should not be a buffered image
         assertFalse(
-                "FOR SOME IMPLEMENTATIONS THIS MIGHT FAIL!\nIn that case, testToBufferedImage() will fail too.",
-                scaled instanceof BufferedImage
+                scaled instanceof BufferedImage,
+                "FOR SOME IMPLEMENTATIONS THIS MIGHT FAIL!\nIn that case, testToBufferedImage() will fail too."
         );
     }
 
@@ -247,7 +247,7 @@ public class ImageUtilTest {
         if (original != notContrasted) { // Don't care to test if images are same
             for (int y = 0; y < original.getHeight(); y++) {
                 for (int x = 0; x < original.getWidth(); x++) {
-                    assertEquals("0 constrast should not change image", original.getRGB(x, y), notContrasted.getRGB(x, y));
+                    assertEquals(original.getRGB(x, y), notContrasted.getRGB(x, y), "0 constrast should not change image");
                 }
             }
         }
@@ -275,24 +275,24 @@ public class ImageUtilTest {
 
                 // RED
                 if (oR < 127) {
-                    assertTrue("Contrast should be decreased or same", oR >= cR && cR >= dR);
+                    assertTrue(oR >= cR && cR >= dR, "Contrast should be decreased or same");
                 }
                 else {
-                    assertTrue("Contrast should be increased or same", oR <= cR && cR <= dR);
+                    assertTrue(oR <= cR && cR <= dR, "Contrast should be increased or same");
                 }
                 // GREEN
                 if (oG < 127) {
-                    assertTrue("Contrast should be decreased or same", oG >= cG && cG >= dG);
+                    assertTrue(oG >= cG && cG >= dG, "Contrast should be decreased or same");
                 }
                 else {
-                    assertTrue("Contrast should be increased or same", oG <= cG && cG <= dG);
+                    assertTrue(oG <= cG && cG <= dG, "Contrast should be increased or same");
                 }
                 // BLUE
                 if (oB < 127) {
-                    assertTrue("Contrast should be decreased or same", oB >= cB && cB >= dB);
+                    assertTrue(oB >= cB && cB >= dB, "Contrast should be decreased or same");
                 }
                 else {
-                    assertTrue("Contrast should be increased or same", oB <= cB && cB <= dB);
+                    assertTrue(oB <= cB && cB <= dB, "Contrast should be increased or same");
                 }
             }
         }
@@ -304,9 +304,8 @@ public class ImageUtilTest {
                 int r = rgb >> 16 & 0xFF;
                 int g = rgb >> 8 & 0xFF;
                 int b = rgb & 0xFF;
-                assertTrue("Max contrast should only produce primary colors", r == 0 || r == 255);
-                assertTrue("Max contrast should only produce primary colors", g == 0 || g == 255);
-                assertTrue("Max contrast should only produce primary colors", b == 0 || b == 255);
+                assertTrue(g == 0 || g == 255, "Max contrast should only produce primary colors");
+                assertTrue(b == 0 || b == 255, "Max contrast should only produce primary colors");
             }
         }
 
@@ -327,24 +326,24 @@ public class ImageUtilTest {
 
                 // RED
                 if (oR >= 127) {
-                    assertTrue("Contrast should be decreased or same", oR >= cR);
+                    assertTrue(oR >= cR, "Contrast should be decreased or same");
                 }
                 else {
-                    assertTrue("Contrast should be increased or same", oR <= cR);
+                    assertTrue(oR <= cR, "Contrast should be increased or same");
                 }
                 // GREEN
                 if (oG >= 127) {
-                    assertTrue("Contrast should be decreased or same", oG >= cG);
+                    assertTrue(oG >= cG, "Contrast should be decreased or same");
                 }
                 else {
-                    assertTrue("Contrast should be increased or same", oG <= cG);
+                    assertTrue(oG <= cG, "Contrast should be increased or same");
                 }
                 // BLUE
                 if (oB >= 127) {
-                    assertTrue("Contrast should be decreased or same", oB >= cB);
+                    assertTrue(oB >= cB, "Contrast should be decreased or same");
                 }
                 else {
-                    assertTrue("Contrast should be increased or same", oB <= cB);
+                    assertTrue(oB <= cB, "Contrast should be increased or same");
                 }
             }
         }
@@ -357,7 +356,7 @@ public class ImageUtilTest {
                 int r = rgb >> 16 & 0xFF;
                 int g = rgb >> 8 & 0xFF;
                 int b = rgb & 0xFF;
-                assertTrue("Minimum contrast should be all gray", r == 127 && g == 127 && b == 127);
+                assertTrue(r == 127 && g == 127 && b == 127, "Minimum contrast should be all gray");
             }
         }
 
@@ -400,7 +399,7 @@ public class ImageUtilTest {
         if (original != notSharpened) { // Don't care to test if images are same
             for (int y = 0; y < original.getHeight(); y++) {
                 for (int x = 0; x < original.getWidth(); x++) {
-                    assertEquals("0 sharpen should not change image", original.getRGB(x, y), notSharpened.getRGB(x, y));
+                    assertEquals(original.getRGB(x, y), notSharpened.getRGB(x, y), "0 sharpen should not change image");
                 }
             }
         }
@@ -446,13 +445,13 @@ public class ImageUtilTest {
         }
 
 //        assertEquals("Difference should not change", diffOriginal, diffSharpened);
-        assertTrue("Abs difference should increase", absDiffOriginal < absDiffSharpened);
+        assertTrue(absDiffOriginal < absDiffSharpened, "Abs difference should increase");
 //        assertEquals("Difference should not change", diffOriginal, diffDefault);
-        assertTrue("Abs difference should increase", absDiffOriginal < absDiffDefault);
+        assertTrue(absDiffOriginal < absDiffDefault, "Abs difference should increase");
 //        assertEquals("Difference should not change", diffOriginal, diffMore);
-        assertTrue("Abs difference should increase", absDiffOriginal < absDiffMore);
+        assertTrue(absDiffOriginal < absDiffMore, "Abs difference should increase");
 //        assertEquals("Difference should not change", diffSharpened, diffMore);
-        assertTrue("Abs difference should increase", absDiffSharpened < absDiffMore);
+        assertTrue(absDiffSharpened < absDiffMore, "Abs difference should increase");
     }
 
     @Test
@@ -466,7 +465,7 @@ public class ImageUtilTest {
         if (original != notBlurred) { // Don't care to test if images are same
             for (int y = 0; y < original.getHeight(); y++) {
                 for (int x = 0; x < original.getWidth(); x++) {
-                    assertEquals("0 blur should not change image", original.getRGB(x, y), notBlurred.getRGB(x, y));
+                    assertEquals(original.getRGB(x, y), notBlurred.getRGB(x, y), "0 blur should not change image");
                 }
             }
         }
@@ -512,13 +511,13 @@ public class ImageUtilTest {
         }
 
 //        assertEquals("Difference should not change", diffOriginal, diffBlurred);
-        assertTrue(String.format("Abs difference should decrease: %s <= %s", absDiffOriginal, absDiffBlurred), absDiffOriginal > absDiffBlurred);
+        assertTrue(absDiffOriginal > absDiffBlurred, String.format("Abs difference should decrease: %s <= %s", absDiffOriginal, absDiffBlurred));
 //        assertEquals("Difference should not change", diffOriginal, diffDefault);
-        assertTrue("Abs difference should decrease", absDiffOriginal > absDiffDefault);
+        assertTrue(absDiffOriginal > absDiffDefault, "Abs difference should decrease");
 //        assertEquals("Difference should not change", diffOriginal, diffMore);
-        assertTrue("Abs difference should decrease", absDiffOriginal > absDiffMore);
+        assertTrue(absDiffOriginal > absDiffMore, "Abs difference should decrease");
 //        assertEquals("Difference should not change", diffBlurred, diffMore);
-        assertTrue("Abs difference should decrease", absDiffBlurred > absDiffMore);
+        assertTrue(absDiffBlurred > absDiffMore, "Abs difference should decrease");
     }
 
     @Test
@@ -528,7 +527,7 @@ public class ImageUtilTest {
         assertNotNull(sunflower);
 
         BufferedImage image = ImageUtil.createIndexed(sunflower);
-        assertNotNull("Image was null", image);
-        assertTrue(image.getColorModel() instanceof IndexColorModel);
+        assertNotNull(image, "Image was null");
+        assertInstanceOf(IndexColorModel.class, image.getColorModel());
     }
 }

--- a/common/common-image/src/test/java/com/twelvemonkeys/image/ResampleOpTest.java
+++ b/common/common-image/src/test/java/com/twelvemonkeys/image/ResampleOpTest.java
@@ -30,8 +30,8 @@
 
 package com.twelvemonkeys.image;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * ResampleOpTestCase
@@ -124,7 +124,7 @@ public class ResampleOpTest {
             }
         }
 
-        assertEquals("Filter threw exceptions: ", Collections.EMPTY_LIST, exceptions);
+        assertEquals(Collections.EMPTY_LIST, exceptions, "Filter threw exceptions: ");
     }
 
     // 1x1
@@ -358,7 +358,7 @@ public class ResampleOpTest {
         }
     }
 
-    @Ignore("Not for general unit testing")
+    @Disabled("Not for general unit testing")
     @Test
     public void testTime() {
         int iterations = 1000;

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/CompoundReaderTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/CompoundReaderTest.java
@@ -32,7 +32,6 @@ package com.twelvemonkeys.io;
 
 import com.twelvemonkeys.lang.StringUtil;
 import com.twelvemonkeys.util.CollectionUtil;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -40,7 +39,8 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * CompoundReaderTestCase

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/FastByteArrayOutputStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/FastByteArrayOutputStreamTest.java
@@ -30,12 +30,11 @@
 
 package com.twelvemonkeys.io;
 
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * FastByteArrayOutputStreamTestCase

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/FileSeekableStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/FileSeekableStreamTest.java
@@ -30,11 +30,10 @@
 
 package com.twelvemonkeys.io;
 
-import org.junit.Test;
-
 import java.io.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * MemoryCacheSeekableStreamTestCase
@@ -92,13 +91,13 @@ public class FileSeekableStreamTest extends SeekableInputStreamAbstractTest {
         try {
             FileUtil.read(stream); // Read until EOF
 
-            assertEquals("EOF not reached (test case broken)", -1, stream.read());
-            assertFalse("Underlying stream closed before close", closed[0]);
+            assertEquals(-1, stream.read(), "EOF not reached (test case broken)");
+            assertFalse(closed[0], "Underlying stream closed before close");
         }
         finally {
             stream.close();
         }
 
-        assertTrue("Underlying stream not closed", closed[0]);
+        assertTrue(closed[0], "Underlying stream not closed");
     }
 }

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/InputStreamAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/InputStreamAbstractTest.java
@@ -172,7 +172,7 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
         int count5 = input.read(bytes, offset, lth);
         assertEquals(lth, count5, "Read 5");
         for (int i = offset; i < lth; i++) {
-            assertEquals( i - offset, bytes[i], "Check Bytes 2");
+            assertEquals(i - offset, bytes[i], "Check Bytes 2");
         }
     }
 

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/InputStreamAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/InputStreamAbstractTest.java
@@ -46,14 +46,14 @@
 package com.twelvemonkeys.io;
 
 import com.twelvemonkeys.lang.ObjectAbstractTest;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * InputStreamAbstractTestCase
@@ -104,15 +104,15 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
         int size = 5;
         InputStream input = makeInputStream(makeOrderedArray(size));
         for (int i = 0; i < size; i++) {
-            assertTrue("Check Size [" + i + "]", (size - i) >= input.available());
-            assertEquals("Check Value [" + i + "]", i, input.read());
+            assertTrue((size - i) >= input.available(), "Check Size [" + i + "]");
+            assertEquals(i, input.read(), "Check Value [" + i + "]");
         }
-        assertEquals("Available after contents all read", 0, input.available());
+        assertEquals(0, input.available(), "Available after contents all read");
 
         // Test reading after the end of file
         try {
             int result = input.read();
-            assertEquals("Wrong value read after end of file", -1, result);
+            assertEquals( -1, result, "Wrong value read after end of file");
         }
         catch (IOException e) {
             fail("Should not have thrown an IOException: " + e.getMessage());
@@ -122,12 +122,12 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
     @Test
     public void testAvailable() throws Exception {
         InputStream input = makeInputStream(1);
-        assertFalse("Unexpected EOF", input.read() < 0);
-        assertEquals("Available after contents all read", 0, input.available());
+        assertFalse(input.read() < 0, "Unexpected EOF");
+        assertEquals(0, input.available(), "Available after contents all read");
 
         // Check availbale is zero after End of file
-        assertEquals("End of File", -1, input.read());
-        assertEquals("Available after End of File", 0, input.available());
+        assertEquals(-1, input.read(), "End of File");
+        assertEquals( 0, input.available(), "Available after End of File");
     }
 
     @Test
@@ -138,26 +138,26 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
 
         // Read into array
         int count1 = input.read(bytes);
-        assertEquals("Read 1", bytes.length, count1);
+        assertEquals(bytes.length, count1, "Read 1");
         for (int i = 0; i < count1; i++) {
-            assertEquals("Check Bytes 1", i, bytes[i]);
+            assertEquals(i, bytes[i], "Check Bytes 1");
         }
 
         // Read into array
         int count2 = input.read(bytes);
-        assertEquals("Read 2", 5, count2);
+        assertEquals( 5, count2, "Read 2");
         for (int i = 0; i < count2; i++) {
-            assertEquals("Check Bytes 2", count1 + i, bytes[i]);
+            assertEquals(count1 + i, bytes[i], "Check Bytes 2");
         }
 
         // End of File
         int count3 = input.read(bytes);
-        assertEquals("Read 3 (EOF)", -1, count3);
+        assertEquals(-1, count3, "Read 3 (EOF)");
 
         // Test reading after the end of file
         try {
             int result = input.read(bytes);
-            assertEquals("Wrong value read after end of file", -1, result);
+            assertEquals(-1, result, "Wrong value read after end of file");
         }
         catch (IOException e) {
             fail("Should not have thrown an IOException: " + e.getMessage());
@@ -170,20 +170,20 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
         int offset = 2;
         int lth = 4;
         int count5 = input.read(bytes, offset, lth);
-        assertEquals("Read 5", lth, count5);
+        assertEquals(lth, count5, "Read 5");
         for (int i = offset; i < lth; i++) {
-            assertEquals("Check Bytes 2", i - offset, bytes[i]);
+            assertEquals( i - offset, bytes[i], "Check Bytes 2");
         }
     }
 
     @Test
     public void testEOF() throws Exception {
         InputStream input = makeInputStream(makeOrderedArray(2));
-        assertEquals("Read 1", 0, input.read());
-        assertEquals("Read 2", 1, input.read());
-        assertEquals("Read 3", -1, input.read());
-        assertEquals("Read 4", -1, input.read());
-        assertEquals("Read 5", -1, input.read());
+        assertEquals(0, input.read(), "Read 1");
+        assertEquals(1, input.read(), "Read 2");
+        assertEquals(-1, input.read(), "Read 3");
+        assertEquals(-1, input.read(), "Read 4");
+        assertEquals(-1, input.read(), "Read 5");
     }
 
     @Test
@@ -205,7 +205,7 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
             fail("Should throw IOException");
         }
         catch (IOException e) {
-            assertTrue("Wrong messge: " + e.getMessage(), e.getMessage().contains("reset"));
+            assertTrue(e.getMessage().contains("reset"), "Wrong messge: " + e.getMessage());
         }
     }
 
@@ -223,10 +223,10 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
         // No mark may either throw exception, or reset to beginning of stream.
         try {
             input.reset();
-            assertEquals("Re-read of reset data should be same", 0, input.read());
+            assertEquals(0, input.read(), "Re-read of reset data should be same");
         }
         catch (Exception e) {
-            assertTrue("Wrong no mark IOException message", e.getMessage().contains("mark"));
+            assertTrue(e.getMessage().contains("mark"), "Wrong no mark IOException message");
         }
     }
 
@@ -249,7 +249,7 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
 
         // Read further
         for (int i = 0; i < 3; i++) {
-            assertEquals("Read After Mark [" + i + "]", (position + i), input.read());
+            assertEquals((position + i), input.read(), "Read After Mark [" + i + "]");
         }
 
         // Reset
@@ -257,7 +257,7 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
 
         // Read from marked position
         for (int i = 0; i < readlimit + 1; i++) {
-            assertEquals("Read After Reset [" + i + "]", (position + i), input.read());
+            assertEquals((position + i), input.read(), "Read After Reset [" + i + "]");
         }
     }
 
@@ -280,16 +280,16 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
 
         // Read past marked position
         for (int i = 0; i < readlimit + 1; i++) {
-            assertEquals("Read After Reset [" + i + "]", (position + i), input.read());
+            assertEquals((position + i), input.read(), "Read After Reset [" + i + "]");
         }
 
         // Reset after read limit passed, may either throw exception, or reset to last mark
         try {
             input.reset();
-            assertEquals("Re-read of reset data should be same", 1, input.read());
+            assertEquals(1, input.read(), "Re-read of reset data should be same");
         }
         catch (Exception e) {
-            assertTrue("Wrong read-limit IOException message", e.getMessage().contains("mark"));
+            assertTrue(e.getMessage().contains("mark"), "Wrong read-limit IOException message");
         }
     }
 
@@ -302,29 +302,29 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
         }
 
         int first = input.read();
-        assertTrue("Expected to read positive value", first >= 0);
+        assertTrue(first >= 0, "Expected to read positive value");
 
         int readlimit = 5;
 
         // Mark
         input.mark(readlimit);
         int read = input.read();
-        assertTrue("Expected to read positive value", read >= 0);
+        assertTrue(read >= 0, "Expected to read positive value");
 
         assertTrue(input.read() >= 0);
         assertTrue(input.read() >= 0);
 
         input.reset();
-        assertEquals("Expected value read differs from actual", read, input.read());
+        assertEquals(read, input.read(), "Expected value read differs from actual");
 
         // Reset after read limit passed, may either throw exception, or reset to last good mark
         try {
             input.reset();
             int reRead = input.read();
-            assertTrue("Re-read of reset data should be same as initially marked or first", reRead == read || reRead == first);
+            assertTrue(reRead == read || reRead == first, "Re-read of reset data should be same as initially marked or first");
         }
         catch (Exception e) {
-            assertTrue("Wrong read-limit IOException message", e.getMessage().contains("mark"));
+            assertTrue(e.getMessage().contains("mark"), "Wrong read-limit IOException message");
         }
     }
 
@@ -332,17 +332,17 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
     public void testSkip() throws Exception {
         InputStream input = makeInputStream(makeOrderedArray(10));
 
-        assertEquals("Unexpected value read", 0, input.read());
-        assertEquals("Unexpected value read", 1, input.read());
-        assertEquals("Unexpected number of bytes skipped", 5, input.skip(5));
-        assertEquals("Unexpected value read", 7, input.read());
+        assertEquals(0, input.read(), "Unexpected value read");
+        assertEquals(1, input.read(), "Unexpected value read");
+        assertEquals(5, input.skip(5), "Unexpected number of bytes skipped");
+        assertEquals(7, input.read(), "Unexpected value read");
 
-        assertEquals("Unexpected number of bytes skipped", 2, input.skip(5)); // only 2 left to skip
-        assertEquals("Unexpected value read after EOF", -1, input.read());
+        assertEquals(2, input.skip(5), "Unexpected number of bytes skipped"); // only 2 left to skip
+        assertEquals(-1, input.read(), "Unexpected value read after EOF");
 
         // Spec says skip might return 0 or negative after EOF...
-        assertTrue("Positive value skipped after EOF", input.skip(5) <= 0); // End of file
-        assertEquals("Unexpected value read after EOF", -1, input.read());
+        assertTrue(input.skip(5) <= 0, "Positive value skipped after EOF"); // End of file
+        assertEquals(-1, input.read(), "Unexpected value read after EOF");
     }
 
     @Test

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/InputStreamAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/InputStreamAbstractTest.java
@@ -145,7 +145,7 @@ public abstract class InputStreamAbstractTest extends ObjectAbstractTest {
 
         // Read into array
         int count2 = input.read(bytes);
-        assertEquals( 5, count2, "Read 2");
+        assertEquals(5, count2, "Read 2");
         for (int i = 0; i < count2; i++) {
             assertEquals(count1 + i, bytes[i], "Check Bytes 2");
         }

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/LittleEndianDataInputStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/LittleEndianDataInputStreamTest.java
@@ -30,12 +30,11 @@
 
 package com.twelvemonkeys.io;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * LittleEndianDataInputStreamTest

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/OutputStreamAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/OutputStreamAbstractTest.java
@@ -31,13 +31,12 @@
 package com.twelvemonkeys.io;
 
 import com.twelvemonkeys.lang.ObjectAbstractTest;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * InputStreamAbstractTestCase

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/ReaderAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/ReaderAbstractTest.java
@@ -31,12 +31,12 @@
 package com.twelvemonkeys.io;
 
 import com.twelvemonkeys.lang.ObjectAbstractTest;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Reader;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * ReaderAbstractTestCase
@@ -112,7 +112,7 @@ public abstract class ReaderAbstractTest extends ObjectAbstractTest {
         int toSkip = mInput.length();
         while (toSkip > 0) {
             long skipped = reader.skip(toSkip);
-            assertFalse("Skipped < 0", skipped < 0);
+            assertFalse(skipped < 0, "Skipped < 0");
             toSkip -= skipped;
         }
 

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/SeekableAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/SeekableAbstractTest.java
@@ -30,10 +30,8 @@
 
 package com.twelvemonkeys.io;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * SeekableAbstractTestCase

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/SeekableInputStreamAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/SeekableInputStreamAbstractTest.java
@@ -30,14 +30,13 @@
 
 package com.twelvemonkeys.io;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * SeekableInputStreamAbstractTest
@@ -79,25 +78,25 @@ public abstract class SeekableInputStreamAbstractTest extends InputStreamAbstrac
             return; // Not supported, skip test
         }
 
-        assertTrue("Expected to read positive value", input.read() >= 0);
+        assertTrue(input.read() >= 0, "Expected to read positive value");
 
         int readlimit = 5;
 
         // Mark
         input.mark(readlimit);
         int read = input.read();
-        assertTrue("Expected to read positive value", read >= 0);
+        assertTrue(read >= 0, "Expected to read positive value");
 
         input.reset();
-        assertEquals("Expected value read differs from actual", read, input.read());
+        assertEquals(read, input.read(), "Expected value read differs from actual");
 
         // Reset after read limit passed, may either throw exception, or reset to last good mark
         try {
             input.reset();
-            assertEquals("Re-read of reset data should be first", 0, input.read());
+            assertEquals(0, input.read(), "Re-read of reset data should be first");
         }
         catch (Exception e) {
-            assertTrue("Wrong read-limit IOException message", e.getMessage().contains("mark"));
+            assertTrue(e.getMessage().contains("mark"), "Wrong read-limit IOException message");
         }
     }
 
@@ -127,7 +126,7 @@ public abstract class SeekableInputStreamAbstractTest extends InputStreamAbstrac
 
         seekable.seek(pos);
         long streamPos = seekable.getStreamPosition();
-        assertEquals("Stream positon should match seeked position", pos, streamPos);
+        assertEquals(pos, streamPos, "Stream positon should match seeked position");
     }
 
     @Test
@@ -137,7 +136,7 @@ public abstract class SeekableInputStreamAbstractTest extends InputStreamAbstrac
         seekable.seek(pos);
         seekable.flushBefore(pos);
         long flushedPos = seekable.getFlushedPosition();
-        assertEquals("Flushed positon should match position", pos, flushedPos);
+        assertEquals(pos, flushedPos, "Flushed positon should match position");
 
         try {
             seekable.seek(pos - 1);
@@ -382,13 +381,13 @@ public abstract class SeekableInputStreamAbstractTest extends InputStreamAbstrac
         int val;
 
         val = stream.read();
-        assertFalse("Unexepected EOF", val == -1);
+        assertFalse(val == -1, "Unexepected EOF");
         val = stream.read();
-        assertFalse("Unexepected EOF", val == -1);
+        assertFalse(val == -1, "Unexepected EOF");
         val = stream.read();
-        assertFalse("Unexepected EOF", val == -1);
+        assertFalse(val == -1, "Unexepected EOF");
         val = stream.read();
-        assertFalse("Unexepected EOF", val == -1);
+        assertFalse(val == -1, "Unexepected EOF");
 
         stream.seek(0);
 
@@ -422,19 +421,19 @@ public abstract class SeekableInputStreamAbstractTest extends InputStreamAbstrac
 
         stream.seek(0);
         for (int i = 0; i < bytes.length; i += 2) {
-            assertEquals("Wrong stream position", i, stream.getStreamPosition());
+            assertEquals(i, stream.getStreamPosition(), "Wrong stream position");
             int count = stream.read(buffer, 0, 2);
             assertEquals(2, count);
-            assertEquals(String.format("Wrong value read at pos %d", stream.getStreamPosition()), bytes[i], buffer[0]);
-            assertEquals(String.format("Wrong value read at pos %d", stream.getStreamPosition()), bytes[i + 1], buffer[1]);
+            assertEquals(bytes[i], buffer[0], String.format("Wrong value read at pos %d", stream.getStreamPosition()));
+            assertEquals(bytes[i + 1], buffer[1], String.format("Wrong value read at pos %d", stream.getStreamPosition()));
         }
 
         stream.seek(0);
         for (int i = 0; i < bytes.length; i++) {
-            assertEquals("Wrong stream position", i, stream.getStreamPosition());
+            assertEquals(i, stream.getStreamPosition(), "Wrong stream position");
             int actual = stream.read();
-            assertEquals(String.format("Wrong value read at pos %d", stream.getStreamPosition()), bytes[i] & 0xff, actual);
-            assertEquals(String.format("Wrong value read at pos %d", stream.getStreamPosition()), bytes[i], (byte) actual);
+            assertEquals(bytes[i] & 0xff, actual, String.format("Wrong value read at pos %d", stream.getStreamPosition()));
+            assertEquals(bytes[i], (byte) actual, String.format("Wrong value read at pos %d", stream.getStreamPosition()));
         }
 
     }
@@ -456,14 +455,14 @@ public abstract class SeekableInputStreamAbstractTest extends InputStreamAbstrac
         try {
             FileUtil.read(stream); // Read until EOF
 
-            assertEquals("EOF not reached (test case broken)", -1, stream.read());
-            assertFalse("Underlying stream closed before close", closed[0]);
+            assertEquals(-1, stream.read(), "EOF not reached (test case broken)");
+            assertFalse(closed[0], "Underlying stream closed before close");
         }
         finally {
             stream.close();
         }
 
-        assertTrue("Underlying stream not closed", closed[0]);
+        assertTrue(closed[0], "Underlying stream not closed");
 
     }
 

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/StringArrayReaderTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/StringArrayReaderTest.java
@@ -31,12 +31,12 @@
 package com.twelvemonkeys.io;
 
 import com.twelvemonkeys.lang.StringUtil;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Reader;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * StringArrayReaderTestCase

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/SubStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/SubStreamTest.java
@@ -106,14 +106,14 @@ public class SubStreamTest {
     @Test
     public void testCloseConsumesAllShortStream() throws IOException {
         assertTimeout(Duration.ofMillis(500), () -> {
-        ByteArrayInputStream stream = new ByteArrayInputStream(new byte[13]);
+            ByteArrayInputStream stream = new ByteArrayInputStream(new byte[13]);
 
-        try (InputStream ignore = new SubStream(stream, 42)) {
-            // Nothing here...
-        }
+            try (InputStream ignore = new SubStream(stream, 42)) {
+                // Nothing here...
+            }
 
-        assertEquals(0, stream.available());
-        assertEquals(-1, stream.read());
+            assertEquals(0, stream.available());
+            assertEquals(-1, stream.read());
         });
     }
 }

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/SubStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/SubStreamTest.java
@@ -105,7 +105,7 @@ public class SubStreamTest {
     @SuppressWarnings("EmptyTryBlock")
     @Test
     public void testCloseConsumesAllShortStream() throws IOException {
-        assertTimeout(Duration.ofMillis(500), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(500), () -> {
             ByteArrayInputStream stream = new ByteArrayInputStream(new byte[13]);
 
             try (InputStream ignore = new SubStream(stream, 42)) {

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/SubStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/SubStreamTest.java
@@ -1,15 +1,14 @@
 package com.twelvemonkeys.io;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Random;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * SubStreamTest.
@@ -23,14 +22,18 @@ public class SubStreamTest {
     private final Random rng = new Random(2918475687L);
 
     @SuppressWarnings("resource")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullStream() {
-        new SubStream(null, 42);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new SubStream(null, 42);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNegativeLength() {
-        new SubStream(new ByteArrayInputStream(new byte[1]), -1);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new SubStream(new ByteArrayInputStream(new byte[1]), -1);
+        });
     }
 
     @Test
@@ -100,8 +103,9 @@ public class SubStreamTest {
     }
 
     @SuppressWarnings("EmptyTryBlock")
-    @Test(timeout = 500L)
+    @Test
     public void testCloseConsumesAllShortStream() throws IOException {
+        assertTimeout(Duration.ofMillis(500), () -> {
         ByteArrayInputStream stream = new ByteArrayInputStream(new byte[13]);
 
         try (InputStream ignore = new SubStream(stream, 42)) {
@@ -110,5 +114,6 @@ public class SubStreamTest {
 
         assertEquals(0, stream.available());
         assertEquals(-1, stream.read());
+        });
     }
 }

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/enc/Base64DecoderTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/enc/Base64DecoderTest.java
@@ -31,15 +31,13 @@
 package com.twelvemonkeys.io.enc;
 
 import com.twelvemonkeys.io.FileUtil;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import static org.junit.Assert.assertEquals;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * Base64DecoderTest
  * <p/>
@@ -66,7 +64,7 @@ public class Base64DecoderTest extends DecoderAbstractTest {
 
         FileUtil.copy(in, bytes);
 
-        assertEquals("Strings does not match", "", new String(bytes.toByteArray()));
+        assertEquals("", new String(bytes.toByteArray()), "Strings does not match");
     }
 
     @Test
@@ -78,7 +76,7 @@ public class Base64DecoderTest extends DecoderAbstractTest {
 
         FileUtil.copy(in, bytes);
 
-        assertEquals("Strings does not match", "test", new String(bytes.toByteArray()));
+        assertEquals("test", new String(bytes.toByteArray()), "Strings does not match");
     }
 
     @Test
@@ -93,11 +91,12 @@ public class Base64DecoderTest extends DecoderAbstractTest {
 
         FileUtil.copy(in, bytes);
 
-        assertEquals("Strings does not match",
+        assertEquals(
                      "Lorem ipsum dolor sit amet, consectetuer adipiscing " +
                      "elit. Fusce est. Morbi luctus consectetuer justo. Vivamus " +
                      "dapibus laoreet purus. Nunc viverra dictum nisl. Integer " +
                      "ullamcorper, nisi in dictum amet.",
-                     new String(bytes.toByteArray()));
+                     new String(bytes.toByteArray()),
+                    "Strings does not match");
     }
 }

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/enc/Base64EncoderTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/enc/Base64EncoderTest.java
@@ -30,13 +30,12 @@
 
 package com.twelvemonkeys.io.enc;
 
-import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Base64EncoderTest
@@ -63,7 +62,7 @@ public class Base64EncoderTest extends EncoderAbstractTest {
         OutputStream out = new EncoderStream(bytes, createEncoder(), true);
         out.write(data.getBytes());
 
-        assertEquals("Strings does not match", "", new String(bytes.toByteArray()));
+        assertEquals("", new String(bytes.toByteArray()), "Strings does not match");
     }
 
     @Test
@@ -74,7 +73,7 @@ public class Base64EncoderTest extends EncoderAbstractTest {
         OutputStream out = new EncoderStream(bytes, createEncoder(), true);
         out.write(data.getBytes());
 
-        assertEquals("Strings does not match", "dGVzdA==", new String(bytes.toByteArray()));
+        assertEquals("dGVzdA==", new String(bytes.toByteArray()), "Strings does not match");
     }
 
     @Test
@@ -88,11 +87,12 @@ public class Base64EncoderTest extends EncoderAbstractTest {
         OutputStream out = new EncoderStream(bytes, createEncoder(), true);
         out.write(data.getBytes());
 
-        assertEquals("Strings does not match",
+        assertEquals(
                      "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVlciBhZGlwaXNjaW5nIGVsaXQuIEZ1" +
                     "c2NlIGVzdC4gTW9yYmkgbHVjdHVzIGNvbnNlY3RldHVlciBqdXN0by4gVml2YW11cyBkYXBpYnVzIGxh" +
                     "b3JlZXQgcHVydXMuIE51bmMgdml2ZXJyYSBkaWN0dW0gbmlzbC4gSW50ZWdlciB1bGxhbWNvcnBlciwg" +
                     "bmlzaSBpbiBkaWN0dW0gYW1ldC4=",
-                     new String(bytes.toByteArray()));
+                     new String(bytes.toByteArray()),
+                "Strings does not match");
     }
 }

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/enc/DecoderAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/enc/DecoderAbstractTest.java
@@ -32,12 +32,13 @@ package com.twelvemonkeys.io.enc;
 
 import com.twelvemonkeys.io.FileUtil;
 import com.twelvemonkeys.lang.ObjectAbstractTest;
-import org.junit.Test;
 
+import java.awt.image.ImageProducer;
 import java.io.*;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * AbstractDecoderTest
@@ -55,13 +56,13 @@ public abstract class DecoderAbstractTest extends ObjectAbstractTest {
         return createDecoder();
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public final void testNullDecode() throws IOException {
         Decoder decoder = createDecoder();
         ByteArrayInputStream bytes = new ByteArrayInputStream(new byte[20]);
-
-        decoder.decode(bytes, null);
-        fail("null should throw NullPointerException");
+        assertThrows(NullPointerException.class, () -> {
+            decoder.decode(bytes, null);
+        });
     }
 
     @Test
@@ -71,7 +72,7 @@ public abstract class DecoderAbstractTest extends ObjectAbstractTest {
 
         try {
             int count = decoder.decode(bytes, ByteBuffer.allocate(128));
-            assertEquals("Should not be able to read any bytes", 0, count);
+            assertEquals( 0, count, "Should not be able to read any bytes");
         }
         catch (EOFException allowed) {
             // Okay
@@ -94,7 +95,7 @@ public abstract class DecoderAbstractTest extends ObjectAbstractTest {
         byte[] encoded = outBytes.toByteArray();
 
         byte[] decoded = FileUtil.read(new DecoderStream(new ByteArrayInputStream(encoded), createDecoder()));
-        assertArrayEquals(String.format("Data %d", pLength), data, decoded);
+        assertArrayEquals(data, decoded, String.format("Data %d", pLength));
 
         InputStream in = new DecoderStream(new ByteArrayInputStream(encoded), createDecoder());
         outBytes = new ByteArrayOutputStream();
@@ -103,7 +104,7 @@ public abstract class DecoderAbstractTest extends ObjectAbstractTest {
         in.close();
 
         decoded = outBytes.toByteArray();
-        assertArrayEquals(String.format("Data %d", pLength), data, decoded);
+        assertArrayEquals(data, decoded, String.format("Data %d", pLength));
     }
 
     @Test

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/enc/DecoderStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/enc/DecoderStreamTest.java
@@ -30,7 +30,6 @@
 
 package com.twelvemonkeys.io.enc;
 
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -39,7 +38,8 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DecoderStreamTest {
 

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/enc/EncoderAbstractTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/enc/EncoderAbstractTest.java
@@ -33,13 +33,12 @@ package com.twelvemonkeys.io.enc;
 import com.twelvemonkeys.io.FileUtil;
 import com.twelvemonkeys.lang.ObjectAbstractTest;
 
-import org.junit.Test;
 
 import java.io.*;
 import java.util.Random;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * AbstractEncoderTest

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/enc/EncoderStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/enc/EncoderStreamTest.java
@@ -30,8 +30,6 @@
 
 package com.twelvemonkeys.io.enc;
 
-import org.junit.Test;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -39,7 +37,8 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
 
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class EncoderStreamTest {
 

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/ole2/CompoundDocumentTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/ole2/CompoundDocumentTest.java
@@ -31,9 +31,9 @@
 package com.twelvemonkeys.io.ole2;
 
 import com.twelvemonkeys.io.MemoryCacheSeekableStream;
-import org.junit.Test;
 
 import javax.imageio.stream.MemoryCacheImageInputStream;
+import java.awt.image.ImageProducer;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,8 +43,8 @@ import java.nio.ByteOrder;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * CompoundDocumentTestCase
  *
@@ -59,8 +59,8 @@ public class CompoundDocumentTest {
     protected final CompoundDocument createTestDocument() throws IOException {
         URL input = getClass().getResource(SAMPLE_DATA);
 
-        assertNotNull("Missing test resource!", input);
-        assertEquals("Test resource not a file:// resource", "file", input.getProtocol());
+        assertNotNull(input, "Missing test resource!");
+        assertEquals( "file", input.getProtocol(), "Test resource not a file:// resource");
 
         try {
             return new CompoundDocument(new File(input.toURI()));
@@ -103,7 +103,7 @@ public class CompoundDocumentTest {
         }
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testChildEntriesUnmodifiable() throws IOException {
         try (CompoundDocument document = createTestDocument()) {
             Entry root = document.getRootEntry();
@@ -111,9 +111,10 @@ public class CompoundDocumentTest {
             assertNotNull(root);
 
             SortedSet<Entry> children = root.getChildEntries();
-
-            // Should not be allowed, as it modifies the internal structure
-            children.remove(children.first());
+            assertThrows(UnsupportedOperationException.class, () -> {
+                // Should not be allowed, as it modifies the internal structure
+                children.remove(children.first());
+            });
         }
     }
 
@@ -128,7 +129,7 @@ public class CompoundDocumentTest {
             Entry catalog = root.getChildEntry("Catalog");
 
             assertNotNull(catalog);
-            assertNotNull("Input stream may not be null", catalog.getInputStream());
+            assertNotNull(catalog.getInputStream(), "Input stream may not be null");
         }
     }
 
@@ -136,7 +137,7 @@ public class CompoundDocumentTest {
     public void testReadCatalogInputStream() throws IOException {
         InputStream input = getClass().getResourceAsStream(SAMPLE_DATA);
 
-        assertNotNull("Missing test resource!", input);
+        assertNotNull(input, "Missing test resource!");
 
         CompoundDocument document = new CompoundDocument(input);
         Entry root = document.getRootEntry();
@@ -145,14 +146,14 @@ public class CompoundDocumentTest {
 
         Entry catalog = root.getChildEntry("Catalog");
         assertNotNull(catalog);
-        assertNotNull("Input stream may not be null", catalog.getInputStream());
+        assertNotNull(catalog.getInputStream(), "Input stream may not be null");
     }
 
     @Test
     public void testReadCatalogSeekableStream() throws IOException {
         InputStream input = getClass().getResourceAsStream(SAMPLE_DATA);
 
-        assertNotNull("Missing test resource!", input);
+        assertNotNull(input, "Missing test resource!");
 
         CompoundDocument document = new CompoundDocument(new MemoryCacheSeekableStream(input));
         Entry root = document.getRootEntry();
@@ -161,14 +162,14 @@ public class CompoundDocumentTest {
 
         Entry catalog = root.getChildEntry("Catalog");
         assertNotNull(catalog);
-        assertNotNull("Input stream may not be null", catalog.getInputStream());
+        assertNotNull(catalog.getInputStream(), "Input stream may not be null");
     }
 
     @Test
     public void testReadCatalogImageInputStream() throws IOException {
         InputStream input = getClass().getResourceAsStream(SAMPLE_DATA);
 
-        assertNotNull("Missing test resource!", input);
+        assertNotNull(input, "Missing test resource!");
 
         MemoryCacheImageInputStream stream = new MemoryCacheImageInputStream(input);
         stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -183,6 +184,6 @@ public class CompoundDocumentTest {
         Entry catalog = root.getChildEntry("Catalog");
 
         assertNotNull(catalog);
-        assertNotNull("Input stream may not be null", catalog.getInputStream());
+        assertNotNull(catalog.getInputStream(), "Input stream may not be null");
     }
 }

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/ole2/CompoundDocument_SeekableLittleEndianDataInputStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/ole2/CompoundDocument_SeekableLittleEndianDataInputStreamTest.java
@@ -31,7 +31,7 @@
 package com.twelvemonkeys.io.ole2;
 
 import com.twelvemonkeys.io.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/ole2/CompoundDocument_StreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/ole2/CompoundDocument_StreamTest.java
@@ -33,7 +33,6 @@ package com.twelvemonkeys.io.ole2;
 import com.twelvemonkeys.io.InputStreamAbstractTest;
 import com.twelvemonkeys.io.LittleEndianDataOutputStream;
 import com.twelvemonkeys.io.MemoryCacheSeekableStream;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -42,7 +41,8 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * CompoundDocument_StreamTestCase
@@ -165,8 +165,8 @@ public class CompoundDocument_StreamTest extends InputStreamAbstractTest {
             count++;
         }
 
-        assertFalse("Short stream", count < 32);
-        assertFalse("Stream overrun", count > 32);
+        assertFalse(count < 32, "Short stream");
+        assertFalse(count > 32, "Stream overrun");
     }
 
     @Test

--- a/common/common-io/src/test/java/com/twelvemonkeys/net/HTTPUtilTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/net/HTTPUtilTest.java
@@ -30,9 +30,8 @@
 
 package com.twelvemonkeys.net;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * HTTPUtilTest

--- a/common/common-lang/src/test/java/com/twelvemonkeys/lang/BeanUtilTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/lang/BeanUtilTest.java
@@ -30,14 +30,13 @@
 
 package com.twelvemonkeys.lang;
 
-import org.junit.Test;
-
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * BeanUtilTestCase
@@ -161,10 +160,8 @@ public class BeanUtilTest {
         }
 
         assertNotNull(bean.getAmbiguous());
-        assertEquals("String converted rather than invoking setAmbiguous(String), ordering not predictable",
-                     "one", bean.getAmbiguous());
-        assertSame("String converted rather than invoking setAmbiguous(String), ordering not predictable",
-                   value, bean.getAmbiguous());
+        assertEquals("one", bean.getAmbiguous(), "String converted rather than invoking setAmbiguous(String), ordering not predictable");
+        assertSame(value, bean.getAmbiguous(), "String converted rather than invoking setAmbiguous(String), ordering not predictable");
     }
 
     @Test
@@ -184,10 +181,10 @@ public class BeanUtilTest {
         }
 
         assertNotNull(bean.getAmbiguous());
-        assertEquals("Integer converted rather than invoking setAmbiguous(Integer), ordering not predictable",
-                2, bean.getAmbiguous());
-        assertSame("Integer converted rather than invoking setAmbiguous(Integer), ordering not predictable",
-                   value, bean.getAmbiguous());
+        assertEquals(2, bean.getAmbiguous(),
+                "Integer converted rather than invoking setAmbiguous(Integer), ordering not predictable");
+        assertSame(value, bean.getAmbiguous(),
+                "Integer converted rather than invoking setAmbiguous(Integer), ordering not predictable");
     }
 
     @Test
@@ -207,10 +204,8 @@ public class BeanUtilTest {
         }
 
         assertNotNull(bean.getAmbiguous());
-        assertEquals("Object converted rather than invoking setAmbiguous(Object), ordering not predictable",
-                     value.getClass(), bean.getAmbiguous().getClass());
-        assertSame("Object converted rather than invoking setAmbiguous(Object), ordering not predictable",
-                   value, bean.getAmbiguous());
+        assertEquals(value.getClass(), bean.getAmbiguous().getClass(), "Object converted rather than invoking setAmbiguous(Object), ordering not predictable");
+        assertSame(value, bean.getAmbiguous(), "Object converted rather than invoking setAmbiguous(Object), ordering not predictable");
     }
 
     static class TestBean {

--- a/common/common-lang/src/test/java/com/twelvemonkeys/lang/DateUtilTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/lang/DateUtilTest.java
@@ -30,16 +30,16 @@
 
 package com.twelvemonkeys.lang;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * DateUtilTest
@@ -48,22 +48,15 @@ import static org.junit.Assert.assertEquals;
  * @author last modified by $Author: haraldk$
  * @version $Id: DateUtilTest.java,v 1.0 11.04.12 16:21 haraldk Exp$
  */
-@RunWith(Parameterized.class)
+
 public class DateUtilTest {
 
-    private final TimeZone timeZone;
-
-    @Parameterized.Parameters
     public static List<Object[]> timeZones() {
         return Arrays.asList(new Object[][] {
                 {TimeZone.getTimeZone("UTC")},
                 {TimeZone.getTimeZone("CET")},
                 {TimeZone.getTimeZone("IST")}, // 30 min off
         });
-    }
-
-    public DateUtilTest(final TimeZone timeZone) {
-        this.timeZone = timeZone;
     }
 
     private Calendar getCalendar(long time) {
@@ -101,8 +94,9 @@ public class DateUtilTest {
         assertEquals(0, calendar.get(Calendar.MINUTE));
     }
 
-    @Test
-    public void testRoundToHourTZ() {
+    @ParameterizedTest
+    @MethodSource("timeZones")
+    public void testRoundToHourTZ(TimeZone timeZone) {
         Calendar calendar = getCalendar(DateUtil.roundToHour(System.currentTimeMillis(), timeZone), timeZone);
 
         assertEquals(0, calendar.get(Calendar.MILLISECOND));
@@ -120,8 +114,9 @@ public class DateUtilTest {
         assertEquals(0, calendar.get(Calendar.HOUR_OF_DAY));
     }
 
-    @Test
-    public void testRoundToDayTZ() {
+    @ParameterizedTest
+    @MethodSource("timeZones")
+    public void testRoundToDayTZ(TimeZone timeZone) {
         Calendar calendar = getCalendar(DateUtil.roundToDay(System.currentTimeMillis(), timeZone), timeZone);
 
         assertEquals(0, calendar.get(Calendar.MILLISECOND));

--- a/common/common-lang/src/test/java/com/twelvemonkeys/lang/ObjectAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/lang/ObjectAbstractTest.java
@@ -30,12 +30,11 @@
 
 package com.twelvemonkeys.lang;
 
-import org.junit.Test;
-
 import java.io.*;
 import java.lang.reflect.Method;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * AbstractObjectTestCase
@@ -79,10 +78,10 @@ public abstract class ObjectAbstractTest {
 
         Class cl = obj.getClass();
         if (isEqualsOverriden(cl)) {
-            assertTrue("Class " + cl.getName() + " implements equals but not hashCode", isHashCodeOverriden(cl));
+            assertTrue(isHashCodeOverriden(cl), "Class " + cl.getName() + " implements equals but not hashCode");
         }
         else if (isHashCodeOverriden(cl)) {
-            assertTrue("Class " + cl.getName() + " implements hashCode but not equals", isEqualsOverriden(cl));
+            assertTrue(isEqualsOverriden(cl), "Class " + cl.getName() + " implements hashCode but not equals");
         }
 
     }
@@ -107,7 +106,7 @@ public abstract class ObjectAbstractTest {
     @Test
     public void testObjectEqualsSelf() {
         Object obj = makeObject();
-        assertEquals("An Object should equal itself", obj, obj);
+        assertEquals(obj, obj, "An Object should equal itself");
     }
 
     @Test
@@ -115,32 +114,26 @@ public abstract class ObjectAbstractTest {
         Object obj = makeObject();
         // NOTE: Makes sure this doesn't throw NPE either
         //noinspection ObjectEqualsNull
-        assertFalse("An object should never equal null", obj.equals(null));
+        assertFalse(obj.equals(null), "An object should never equal null");
     }
 
     @Test
     public void testObjectHashCodeEqualsSelfHashCode() {
         Object obj = makeObject();
-        assertEquals("hashCode should be repeatable", obj.hashCode(), obj.hashCode());
+        assertEquals(obj.hashCode(), obj.hashCode(), "hashCode should be repeatable");
     }
 
     @Test
     public void testObjectHashCodeEqualsContract() {
         Object obj1 = makeObject();
         if (obj1.equals(obj1)) {
-            assertEquals(
-                "[1] When two objects are equal, their hashCodes should be also.",
-                obj1.hashCode(), obj1.hashCode());
+            assertEquals(obj1.hashCode(), obj1.hashCode(), "[1] When two objects are equal, their hashCodes should be also.");
         }
         // TODO: Make sure we create at least one equal object, and one different object
         Object obj2 = makeObject();
         if (obj1.equals(obj2)) {
-            assertEquals(
-                "[2] When two objects are equal, their hashCodes should be also.",
-                obj1.hashCode(), obj2.hashCode());
-            assertTrue(
-                "When obj1.equals(obj2) is true, then obj2.equals(obj1) should also be true",
-                obj2.equals(obj1));
+            assertEquals(obj1.hashCode(), obj2.hashCode(), "[2] When two objects are equal, their hashCodes should be also.");
+            assertTrue(obj2.equals(obj1), "When obj1.equals(obj2) is true, then obj2.equals(obj1) should also be true");
         }
     }
 
@@ -169,14 +162,14 @@ public abstract class ObjectAbstractTest {
 
             Object cloned = clone.invoke(obj);
 
-            assertNotNull("Cloned object should never be null", cloned);
+            assertNotNull(cloned, "Cloned object should never be null");
 
             // TODO: This can only be asserted if equals() test is based on
             // value equality, not reference (identity) equality
             // Maybe it's possible to do a reflective introspection of
             // the objects fields?
             if (isHashCodeOverriden(cl)) {
-                assertEquals("Cloned object not equal", obj, cloned);
+                assertEquals(obj, cloned, "Cloned object not equal");
             }
         }
     }
@@ -235,7 +228,7 @@ public abstract class ObjectAbstractTest {
             // Maybe it's possible to do a reflective introspection of
             // the objects fields?
             if (isEqualsOverriden(obj.getClass())) {
-                assertEquals("obj != deserialize(serialize(obj))", obj, dest);
+                assertEquals(obj, dest, "obj != deserialize(serialize(obj))");
             }
         }
     }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/lang/PlatformTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/lang/PlatformTest.java
@@ -30,13 +30,11 @@
 
 package com.twelvemonkeys.lang;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PlatformTest
@@ -121,7 +119,7 @@ public class PlatformTest {
         assertEquals(Platform.Architecture.X86, platform.getArchitecture());
     }
 
-    @Ignore("Known issue, needs resolve")
+    @Disabled("Known issue, needs resolve")
     @Test
     public void testCreateWindows686() {
         Platform platform = new Platform(createProperties("Windows", "5.1", "686"));
@@ -129,7 +127,7 @@ public class PlatformTest {
         assertEquals(Platform.Architecture.X86, platform.getArchitecture());
     }
 
-    @Ignore("Known issue, needs resolve")
+    @Disabled("Known issue, needs resolve")
     @Test
     public void testCreateLinuxX86() {
         Platform platform = new Platform(createProperties("Linux", "3.0.18", "x86"));

--- a/common/common-lang/src/test/java/com/twelvemonkeys/lang/StringUtilTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/lang/StringUtilTest.java
@@ -30,8 +30,6 @@
 
 package com.twelvemonkeys.lang;
 
-import static org.junit.Assert.*;
-
 import java.awt.*;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -41,8 +39,8 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * StringUtilTestCase
  *
@@ -165,10 +163,10 @@ public class StringUtilTest {
         // Test all alpha-chars
         for (int i = 'a'; i < 'z'; i++) {
             if (TEST_STRING.indexOf(i) < 0) {
-                assertFalse(TEST_STRING + " seems to contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i), StringUtil.contains(TEST_STRING, i));
+                assertFalse(StringUtil.contains(TEST_STRING, i), TEST_STRING + " seems to contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i));
             }
             else {
-                assertTrue(TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i), StringUtil.contains(TEST_STRING, i));
+                assertTrue(StringUtil.contains(TEST_STRING, i), TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i));
             }
         }
     }
@@ -199,10 +197,10 @@ public class StringUtilTest {
         // Test all alpha-chars
         for (int i = 'a'; i < 'z'; i++) {
             if ((TEST_STRING.indexOf(i) < 0) && (TEST_STRING.indexOf(Character.toUpperCase((char) i)) < 0)) {
-                assertFalse(TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))), StringUtil.containsIgnoreCase(TEST_STRING, i));
+                assertFalse(StringUtil.containsIgnoreCase(TEST_STRING, i), TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))));
             }
             else {
-                assertTrue(TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i), StringUtil.containsIgnoreCase(TEST_STRING, i));
+                assertTrue(StringUtil.containsIgnoreCase(TEST_STRING, i), TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i));
             }
         }
     }
@@ -350,10 +348,10 @@ public class StringUtilTest {
         // Test all alpha-chars
         for (int i = 'a'; i < 'z'; i++) {
             if ((TEST_STRING.indexOf(i) < 0) && (TEST_STRING.indexOf(Character.toUpperCase((char) i)) < 0)) {
-                assertEquals(TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))), -1, StringUtil.indexOfIgnoreCase(TEST_STRING, i));
+                assertEquals(-1, StringUtil.indexOfIgnoreCase(TEST_STRING, i), TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))));
             }
             else {
-                assertTrue(TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i), 0 <= StringUtil.indexOfIgnoreCase(TEST_STRING, i));
+                assertTrue(0 <= StringUtil.indexOfIgnoreCase(TEST_STRING, i), TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i));
             }
         }
     }
@@ -385,10 +383,10 @@ public class StringUtilTest {
         // Test all alpha-chars
         for (int i = 'a'; i < 'z'; i++) {
             if ((TEST_STRING.indexOf(i) < 0) && (TEST_STRING.indexOf(Character.toUpperCase((char) i)) < 0)) {
-                assertEquals(TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))), -1, StringUtil.indexOfIgnoreCase(TEST_STRING, i, 0));
+                assertEquals(-1, StringUtil.indexOfIgnoreCase(TEST_STRING, i, 0), TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))));
             }
             else {
-                assertTrue(TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i), 0 <= StringUtil.indexOfIgnoreCase(TEST_STRING, i, 0));
+                assertTrue(0 <= StringUtil.indexOfIgnoreCase(TEST_STRING, i, 0), TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i));
             }
         }
     }
@@ -420,10 +418,10 @@ public class StringUtilTest {
         // Test all alpha-chars
         for (int i = 'a'; i < 'z'; i++) {
             if ((TEST_STRING.indexOf(i) < 0) && (TEST_STRING.indexOf(Character.toUpperCase((char) i)) < 0)) {
-                assertEquals(TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))), -1, StringUtil.lastIndexOfIgnoreCase(TEST_STRING, i));
+                assertEquals(-1, StringUtil.lastIndexOfIgnoreCase(TEST_STRING, i), TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))));
             }
             else {
-                assertTrue(TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i), 0 <= StringUtil.lastIndexOfIgnoreCase(TEST_STRING, i));
+                assertTrue(0 <= StringUtil.lastIndexOfIgnoreCase(TEST_STRING, i), TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i));
             }
         }
     }
@@ -455,10 +453,10 @@ public class StringUtilTest {
         // Test all alpha-chars
         for (int i = 'a'; i < 'z'; i++) {
             if ((TEST_STRING.indexOf(i) < 0) && (TEST_STRING.indexOf(Character.toUpperCase((char) i)) < 0)) {
-                assertEquals(TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))), -1, StringUtil.lastIndexOfIgnoreCase(TEST_STRING, i, TEST_STRING.length()));
+                assertEquals(-1, StringUtil.lastIndexOfIgnoreCase(TEST_STRING, i, TEST_STRING.length()), TEST_STRING + " seems to contain '" + (char) i + "', at index " + Math.max(TEST_STRING.indexOf(i), TEST_STRING.indexOf(Character.toUpperCase((char) i))));
             }
             else {
-                assertTrue(TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i), 0 <= StringUtil.lastIndexOfIgnoreCase(TEST_STRING, i, TEST_STRING.length()));
+                assertTrue(0 <= StringUtil.lastIndexOfIgnoreCase(TEST_STRING, i, TEST_STRING.length()), TEST_STRING + " seems to not contain '" + (char) i + "', at index " + TEST_STRING.indexOf(i));
             }
         }
     }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/lang/SystemUtilTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/lang/SystemUtilTest.java
@@ -30,7 +30,7 @@
 
 package com.twelvemonkeys.lang;
 
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 
 /**
  * SystemUtilTest
@@ -39,6 +39,6 @@ import org.junit.Ignore;
  * @author last modified by $Author: haraldk$
  * @version $Id: SystemUtilTest.java,v 1.0 11.04.12 16:21 haraldk Exp$
  */
-@Ignore
+@Disabled
 public class SystemUtilTest {
 }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/lang/ValidateTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/lang/ValidateTest.java
@@ -64,15 +64,10 @@ public class ValidateTest {
 
     @Test
     public void testNotNullWithParameterNull() {
-        try {
-            assertThrows(IllegalArgumentException.class, () -> {
-                Validate.notNull(null, "xyzzy");
-            });
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notNull(null, "xyzzy");
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
     @Test

--- a/common/common-lang/src/test/java/com/twelvemonkeys/lang/ValidateTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/lang/ValidateTest.java
@@ -30,13 +30,11 @@
 
 package com.twelvemonkeys.lang;
 
-import org.junit.Test;
-
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * ValidateTest
  *
@@ -52,9 +50,11 @@ public class ValidateTest {
         assertEquals("foo", Validate.notNull("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotNullNull() {
-        Validate.notNull(null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notNull(null);
+        });
     }
 
     @Test
@@ -62,10 +62,12 @@ public class ValidateTest {
         assertEquals("foo", Validate.notNull("foo", "bar"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotNullWithParameterNull() {
         try {
-            Validate.notNull(null, "xyzzy");
+            assertThrows(IllegalArgumentException.class, () -> {
+                Validate.notNull(null, "xyzzy");
+            });
         }
         catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("xyzzy"));
@@ -78,9 +80,11 @@ public class ValidateTest {
         Validate.notNull("foo", null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotNullWithNullParameterNull() {
-        Validate.notNull(null, null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notNull(null, null);
+        });
     }
 
     // Not empty (CharSequence)
@@ -90,52 +94,49 @@ public class ValidateTest {
         assertEquals("foo", Validate.notEmpty("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceNull() {
-        Validate.notEmpty((CharSequence) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty((CharSequence) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceEmpty() {
-        Validate.notEmpty("");
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty("");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceOnlyWS() {
-        Validate.notEmpty(" \t\r");
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty(" \t\r");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceNullWithParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((CharSequence) null, "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceEmptyWithParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty("", "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceOnlyWSWithParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty(" \t", "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
     @Test
@@ -148,37 +149,28 @@ public class ValidateTest {
         assertEquals("foo", Validate.notEmpty("foo", null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceNullWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((CharSequence) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceEmptyWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty("", null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCharSequenceOnlyWSWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty(" \t\t  \n", null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
     // Not empty (array)
@@ -189,14 +181,18 @@ public class ValidateTest {
         assertSame(array, Validate.notEmpty(array));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyArrayNull() {
-        Validate.notEmpty((Object[]) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty((Object[]) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyArrayEmpty() {
-        Validate.notEmpty(new String[0]);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty(new String[0]);
+        });
     }
 
     @Test
@@ -205,26 +201,20 @@ public class ValidateTest {
         assertSame(array, Validate.notEmpty(array, "bar"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyArrayNullParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((Object[]) null, "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyArrayEmptyParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty(new Float[0], "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
     @Test
@@ -233,26 +223,20 @@ public class ValidateTest {
         assertSame(array, Validate.notEmpty(array, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyArrayNullWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((Object[]) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyArrayEmptyWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty(new Object[0], null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
     // Not empty (Collection)
@@ -263,14 +247,18 @@ public class ValidateTest {
         assertSame(collection, Validate.notEmpty(collection));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCollectionNull() {
-        Validate.notEmpty((Collection<?>) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty((Collection<?>) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCollectionEmpty() {
-        Validate.notEmpty(Collections.emptySet());
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty(Collections.emptySet());
+        });
     }
 
     @Test
@@ -279,26 +267,20 @@ public class ValidateTest {
         assertSame(collection, Validate.notEmpty(collection, "bar"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCollectionNullParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((Collection<?>) null, "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCollectionEmptyParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty(new ArrayList<Object>(), "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
     @Test
@@ -307,26 +289,20 @@ public class ValidateTest {
         assertSame(collection, Validate.notEmpty(collection, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCollectionNullWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((Collection<?>) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyCollectionEmptyWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((Collection<?>) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
     // Not empty (Map)
@@ -340,14 +316,18 @@ public class ValidateTest {
         assertSame(map, Validate.notEmpty(map));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyMapNull() {
-        Validate.notEmpty((Map<?, ?>) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty((Map<?, ?>) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyMapEmpty() {
-        Validate.notEmpty(Collections.emptyMap());
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.notEmpty(Collections.emptyMap());
+        });
     }
 
     @Test
@@ -356,26 +336,20 @@ public class ValidateTest {
         assertSame(map, Validate.notEmpty(map, "bar"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyMapNullParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((Map<?, ?>) null, "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyMapEmptyParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty(new HashMap<Object, Object>(), "xyzzy");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("xyzzy"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("xyzzy"));
     }
 
     @Test
@@ -384,26 +358,20 @@ public class ValidateTest {
         assertSame(map, Validate.notEmpty(map, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyMapNullWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((Map<?, ?>) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNotEmptyMapEmptyWithParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.notEmpty((Map<?, ?>) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("parameter"));
     }
 
     // No null elements (array)
@@ -420,20 +388,27 @@ public class ValidateTest {
         assertSame(array, Validate.noNullElements(array));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayNull() {
-        Validate.noNullElements((Object[]) null);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullElements((Object[]) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayNullElements() {
-        Validate.noNullElements(new Object[3]);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullElements(new Object[3]);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayMixed() {
         String[] array = new String[] {"foo", null, "bar"};
-        Validate.noNullElements(array);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullElements(array);
+        });
     }
 
     @Test
@@ -448,37 +423,28 @@ public class ValidateTest {
         assertSame(array, Validate.noNullElements(array, "foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayNullParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements((Object[]) null, "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayNullElementsParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements(new Object[3], "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayMixedParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements(new String[] {"foo", null, "bar"}, "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
     @Test
@@ -493,37 +459,28 @@ public class ValidateTest {
         assertSame(array, Validate.noNullElements(array, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayNullParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements((Object[]) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayNullElementsParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements(new Object[3], null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsArrayMixedParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements(new String[] {"foo", null, "bar"}, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
     // No null elements (Collection)
@@ -540,19 +497,25 @@ public class ValidateTest {
         assertSame(collection, Validate.noNullElements(collection));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionNull() {
-        Validate.noNullElements((Collection<?>) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullElements((Collection<?>) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionNullElements() {
-        Validate.noNullElements(Arrays.asList(null, null, null));
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullElements(Arrays.asList(null, null, null));
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionMixed() {
-        Validate.noNullElements(Arrays.asList("foo", null, "bar"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullElements(Arrays.asList("foo", null, "bar"));
+        });
     }
 
     @Test
@@ -567,37 +530,28 @@ public class ValidateTest {
         assertSame(collection, Validate.noNullElements(collection, "foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionNullParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements((Set<?>) null, "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionNullElementsParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements(Collections.singletonList(null), "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionMixedParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements(Arrays.asList("foo", null, "bar"), "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
     @Test
@@ -612,38 +566,29 @@ public class ValidateTest {
         assertSame(collection, Validate.noNullElements(collection, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionNullParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements((ArrayList<?>) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionNullElementsParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullElements(Collections.singleton(null), null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullElementsCollectionMixedParameterNull() {
-        Collection<?> collection = Arrays.asList("foo", null, "bar");
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            Collection<?> collection = Arrays.asList("foo", null, "bar");
             Validate.noNullElements(collection, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
     // No null values (Map)
@@ -664,23 +609,29 @@ public class ValidateTest {
         assertSame(map, Validate.noNullValues(map));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesNull() {
-        Validate.noNullValues((Map<?, ?>) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullValues((Map<?, ?>) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesNullElements() {
-        Validate.noNullValues(Collections.singletonMap("foo", null));
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullValues(Collections.singletonMap("foo", null));
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesMixed() {
-        Validate.noNullValues(new HashMap<String, Object>() {{
-            put("foo", 1);
-            put(null, null);
-            put("baz", null);
-        }});
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullValues(new HashMap<String, Object>() {{
+                put("foo", 1);
+                put(null, null);
+                put("baz", null);
+            }});
+        });
     }
 
     @Test
@@ -699,41 +650,32 @@ public class ValidateTest {
         assertSame(map, Validate.noNullValues(map, "foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesNullParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullValues((Map<?, ?>) null, "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesNullElementsParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullValues(Collections.singletonMap("bar", null), "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesMixedParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullValues(new HashMap<String, Object>() {{
                 put("foo", 1);
                 put(null, null);
                 put("bar", null);
             }}, "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
     @Test
@@ -752,42 +694,32 @@ public class ValidateTest {
         assertSame(map, Validate.noNullValues(map, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesNullParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullValues((Map<?, ?>) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesNullElementsParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullValues(Collections.singletonMap(null, null), null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullValuesMixedParameterNull() {
-
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullValues(new HashMap<String, Object>() {{
                 put("foo", 1);
                 put(null, null);
                 put("bar", null);
             }}, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
     // No null keys (Map)
@@ -808,23 +740,29 @@ public class ValidateTest {
         assertSame(map, Validate.noNullKeys(map));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysNull() {
-        Validate.noNullKeys((Map<?, ?>) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullKeys((Map<?, ?>) null);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysNullElements() {
-        Validate.noNullKeys(Collections.singletonMap(null, "foo"));
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullKeys(Collections.singletonMap(null, "foo"));
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysMixed() {
-        Validate.noNullKeys(new HashMap<String, Object>() {{
-            put("foo", 1);
-            put(null, null);
-            put("baz", null);
-        }});
+        assertThrows(IllegalArgumentException.class, () -> {
+            Validate.noNullKeys(new HashMap<String, Object>() {{
+                put("foo", 1);
+                put(null, null);
+                put("baz", null);
+            }});
+        });
     }
 
     @Test
@@ -843,41 +781,32 @@ public class ValidateTest {
         assertSame(map, Validate.noNullKeys(map, "foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysNullParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullKeys((Map<?, ?>) null, "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysNullElementsParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullKeys(Collections.singletonMap(null, "bar"), "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysMixedParameter() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullKeys(new HashMap<String, Object>() {{
                 put("foo", 1);
                 put(null, null);
                 put("bar", null);
             }}, "foo");
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
     @Test
@@ -896,42 +825,32 @@ public class ValidateTest {
         assertSame(map, Validate.noNullKeys(map, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysNullParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullKeys((Map<?, ?>) null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysNullElementsParameterNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullKeys(Collections.singletonMap(null, null), null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoNullKeysMixedParameterNull() {
-
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.noNullKeys(new HashMap<String, Object>() {{
                 put("foo", 1);
                 put(null, null);
                 put("bar", null);
             }}, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("method parameter"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("method parameter"));
     }
 
     // Is true
@@ -941,26 +860,20 @@ public class ValidateTest {
         assertTrue(Validate.isTrue(true, "%s"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsTrueFalse() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.isTrue(false, "is %s");
-        }
-        catch (IllegalArgumentException e) {
-            assertEquals("is false", e.getMessage());
-            throw e;
-        }
+        });
+        assertEquals("is false", exception.getMessage());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsTrueFalseNullParam() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.isTrue(false, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("false"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("false"));
     }
 
     @Test
@@ -969,15 +882,12 @@ public class ValidateTest {
         assertSame(object, Validate.isTrue(true, object, "%s"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsTrueFalseValue() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.isTrue(false, "baz", "foo is '%s'");
-        }
-        catch (IllegalArgumentException e) {
-            assertEquals("foo is 'baz'", e.getMessage());
-            throw e;
-        }
+        });
+        assertEquals("foo is 'baz'", exception.getMessage());
     }
 
     @Test
@@ -985,15 +895,12 @@ public class ValidateTest {
         assertEquals("foo", Validate.isTrue(true, "foo", null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsTrueFalseValueParamNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.isTrue(false, "foo", null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("foo"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("foo"));
     }
 
     @Test
@@ -1001,15 +908,11 @@ public class ValidateTest {
         assertNull(Validate.isTrue(true, null, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsTrueFalseValueNullParamNull() {
-        try {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
             Validate.isTrue(false, null, null);
-        }
-        catch (IllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("null"));
-            throw e;
-        }
+        });
+        assertTrue(exception.getMessage().contains("null"));
     }
-
 }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionAbstractTest.java
@@ -45,12 +45,11 @@
 
 package com.twelvemonkeys.util;
 
-import org.junit.Test;
-
 import java.lang.reflect.Array;
 import java.util.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Abstract test class for {@link java.util.Collection} methods and contracts.
@@ -251,11 +250,8 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
      */
     public void verifyAll() {
         int confirmedSize = confirmed.size();
-        assertEquals("Collection size should match confirmed collection's",
-                     confirmedSize, collection.size());
-        assertEquals("Collection isEmpty() result should match confirmed " +
-                     " collection's",
-                     confirmed.isEmpty(), collection.isEmpty());
+        assertEquals(confirmedSize, collection.size(), "Collection size should match confirmed collection's");
+        assertEquals(confirmed.isEmpty(), collection.isEmpty(), "Collection isEmpty() result should match confirmed  collection's");
 
         // verify the collections are the same by attempting to match each
         // object in the collection and confirmed collection.  To account for
@@ -521,8 +517,8 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
             boolean r = collection.add(elements[i]);
             confirmed.add(elements[i]);
             verifyAll();
-            assertTrue("Empty collection changed after add", r);
-            assertEquals("Collection size is 1 after first add", 1, collection.size());
+            assertTrue(r, "Empty collection changed after add");
+            assertEquals(1, collection.size(), "Collection size is 1 after first add");
         }
 
         resetEmpty();
@@ -532,10 +528,8 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
             confirmed.add(elements[i]);
             verifyAll();
             if (r) size++;
-            assertEquals("Collection size should grow after add",
-                         size, collection.size());
-            assertTrue("Collection should contain added element",
-                       collection.contains(elements[i]));
+            assertEquals(size, collection.size(), "Collection size should grow after add");
+            assertTrue(collection.contains(elements[i]), "Collection should contain added element");
         }
     }
 
@@ -552,10 +546,9 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         boolean r = collection.addAll(Arrays.asList(elements));
         confirmed.addAll(Arrays.asList(elements));
         verifyAll();
-        assertTrue("Empty collection should change after addAll", r);
+        assertTrue(r, "Empty collection should change after addAll");
         for (int i = 0; i < elements.length; i++) {
-            assertTrue("Collection should contain added element",
-                       collection.contains(elements[i]));
+            assertTrue(collection.contains(elements[i]), "Collection should contain added element");
         }
 
         resetFull();
@@ -564,13 +557,11 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         r = collection.addAll(Arrays.asList(elements));
         confirmed.addAll(Arrays.asList(elements));
         verifyAll();
-        assertTrue("Full collection should change after addAll", r);
+        assertTrue(r, "Full collection should change after addAll");
         for (int i = 0; i < elements.length; i++) {
-            assertTrue("Full collection should contain added element",
-                       collection.contains(elements[i]));
+            assertTrue(collection.contains(elements[i]), "Full collection should contain added element");
         }
-        assertEquals("Size should increase after addAll",
-                     size + elements.length, collection.size());
+        assertEquals(size + elements.length, collection.size(), "Size should increase after addAll");
 
         resetFull();
         size = collection.size();
@@ -578,11 +569,9 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         confirmed.addAll(Arrays.asList(getFullElements()));
         verifyAll();
         if (r) {
-            assertTrue("Size should increase if addAll returns true",
-                       size < collection.size());
+            assertTrue(size < collection.size(), "Size should increase if addAll returns true");
         } else {
-            assertEquals("Size should not change if addAll returns false",
-                         size, collection.size());
+            assertEquals(size, collection.size(), "Size should not change if addAll returns false");
         }
     }
 
@@ -666,16 +655,14 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         resetEmpty();
         elements = getFullElements();
         for(int i = 0; i < elements.length; i++) {
-            assertTrue("Empty collection shouldn't contain element[" + i + "]",
-                       !collection.contains(elements[i]));
+            assertTrue(!collection.contains(elements[i]), "Empty collection shouldn't contain element[" + i + "]");
         }
         // make sure calls to "contains" don't change anything
         verifyAll();
 
         elements = getOtherElements();
         for(int i = 0; i < elements.length; i++) {
-            assertTrue("Empty collection shouldn't contain element[" + i + "]",
-                       !collection.contains(elements[i]));
+            assertTrue(!collection.contains(elements[i]), "Empty collection shouldn't contain element[" + i + "]");
         }
         // make sure calls to "contains" don't change anything
         verifyAll();
@@ -683,8 +670,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         resetFull();
         elements = getFullElements();
         for(int i = 0; i < elements.length; i++) {
-            assertTrue("Full collection should contain element[" + i + "]",
-                       collection.contains(elements[i]));
+            assertTrue(collection.contains(elements[i]), "Full collection should contain element[" + i + "]");
         }
         // make sure calls to "contains" don't change anything
         verifyAll();
@@ -692,8 +678,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         resetFull();
         elements = getOtherElements();
         for(int i = 0; i < elements.length; i++) {
-            assertTrue("Full collection shouldn't contain element",
-                       !collection.contains(elements[i]));
+            assertTrue(!collection.contains(elements[i]), "Full collection shouldn't contain element");
         }
     }
 
@@ -705,22 +690,22 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
     public void testCollectionContainsAll() {
         resetEmpty();
         Collection col = new HashSet();
-        assertTrue("Every Collection should contain all elements of an " +
-                   "empty Collection.", collection.containsAll(col));
+        assertTrue(collection.containsAll(col),
+                "Every Collection should contain all elements of an " +
+                        "empty Collection.");
         col.addAll(Arrays.asList(getOtherElements()));
-        assertTrue("Empty Collection shouldn't contain all elements of " +
-                   "a non-empty Collection.", !collection.containsAll(col));
+        assertTrue(!collection.containsAll(col),
+                "Empty Collection shouldn't contain all elements of " +
+                        "a non-empty Collection.");
         // make sure calls to "containsAll" don't change anything
         verifyAll();
 
         resetFull();
-        assertTrue("Full collection shouldn't contain other elements",
-                   !collection.containsAll(col));
+        assertTrue(!collection.containsAll(col), "Full collection shouldn't contain other elements");
 
         col.clear();
         col.addAll(Arrays.asList(getFullElements()));
-        assertTrue("Full collection should containAll full elements",
-                   collection.containsAll(col));
+        assertTrue(collection.containsAll(col), "Full collection should containAll full elements");
         // make sure calls to "containsAll" don't change anything
         verifyAll();
 
@@ -728,18 +713,17 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         int max = (getFullElements().length == 1 ? 1 :
                     (getFullElements().length <= 5 ? getFullElements().length - 1 : 5));
         col = Arrays.asList(getFullElements()).subList(min, max);
-        assertTrue("Full collection should containAll partial full " +
-                   "elements", collection.containsAll(col));
-        assertTrue("Full collection should containAll itself",
-                   collection.containsAll(collection));
+        assertTrue(collection.containsAll(col), "Full collection should containAll partial full " +
+                "elements");
+        assertTrue(collection.containsAll(collection), "Full collection should containAll itself");
         // make sure calls to "containsAll" don't change anything
         verifyAll();
 
         col = new ArrayList();
         col.addAll(Arrays.asList(getFullElements()));
         col.addAll(Arrays.asList(getFullElements()));
-        assertTrue("Full collection should containAll duplicate full " +
-                   "elements", collection.containsAll(col));
+        assertTrue(collection.containsAll(col), "Full collection should containAll duplicate full " +
+                "elements");
 
         // make sure calls to "containsAll" don't change anything
         verifyAll();
@@ -751,14 +735,12 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
     @Test
     public void testCollectionIsEmpty() {
         resetEmpty();
-        assertEquals("New Collection should be empty.",
-                     true, collection.isEmpty());
+        assertEquals(true, collection.isEmpty(), "New Collection should be empty.");
         // make sure calls to "isEmpty() don't change anything
         verifyAll();
 
         resetFull();
-        assertEquals("Full collection shouldn't be empty",
-                     false, collection.isEmpty());
+        assertEquals(false, collection.isEmpty(), "Full collection shouldn't be empty");
         // make sure calls to "isEmpty() don't change anything
         verifyAll();
     }
@@ -771,8 +753,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
     public void testCollectionIterator() {
         resetEmpty();
         Iterator it1 = collection.iterator();
-        assertEquals("Iterator for empty Collection shouldn't have next.",
-                     false, it1.hasNext());
+        assertEquals(false, it1.hasNext(), "Iterator for empty Collection shouldn't have next.");
         try {
             it1.next();
             fail("Iterator at end of Collection should throw " +
@@ -786,18 +767,17 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         resetFull();
         it1 = collection.iterator();
         for (int i = 0; i < collection.size(); i++) {
-            assertTrue("Iterator for full collection should haveNext",
-                       it1.hasNext());
+            assertTrue(it1.hasNext(), "Iterator for full collection should haveNext");
             it1.next();
         }
-        assertTrue("Iterator should be finished", !it1.hasNext());
+        assertTrue(!it1.hasNext(), "Iterator should be finished");
 
         ArrayList list = new ArrayList();
         it1 = collection.iterator();
         for (int i = 0; i < collection.size(); i++) {
             Object next = it1.next();
-            assertTrue("Collection should contain element returned by " +
-                       "its iterator", collection.contains(next));
+            assertTrue(collection.contains(next), "Collection should contain element returned by " +
+                    "its iterator");
             list.add(next);
         }
         try {
@@ -865,11 +845,10 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
             }
 
             size--;
-            assertEquals("Collection should shrink by one after " +
-                         "iterator.remove", size, collection.size());
+            assertEquals(size, collection.size(), "Collection should shrink by one after " +
+                    "iterator.remove");
         }
-        assertTrue("Collection should be empty after iterator purge",
-                   collection.isEmpty());
+        assertTrue(collection.isEmpty(), "Collection should be empty after iterator purge");
 
         resetFull();
         iter = collection.iterator();
@@ -894,8 +873,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         resetEmpty();
         Object[] elements = getFullElements();
         for (int i = 0; i < elements.length; i++) {
-            assertTrue("Shouldn't remove nonexistent element",
-                       !collection.remove(elements[i]));
+            assertTrue(!collection.remove(elements[i]), "Shouldn't remove nonexistent element");
             verifyAll();
         }
 
@@ -903,16 +881,14 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
 
         resetFull();
         for (int i = 0; i < other.length; i++) {
-            assertTrue("Shouldn't remove nonexistent other element",
-                       !collection.remove(other[i]));
+            assertTrue(!collection.remove(other[i]), "Shouldn't remove nonexistent other element");
             verifyAll();
         }
 
         int size = collection.size();
         for (int i = 0; i < elements.length; i++) {
             resetFull();
-            assertTrue("Collection should remove extant element: " + elements[i],
-                       collection.remove(elements[i]));
+            assertTrue(collection.remove(elements[i]), "Collection should remove extant element: " + elements[i]);
 
             // if the elements aren't distinguishable, we can just remove a
             // matching element from the confirmed collection and verify
@@ -927,8 +903,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
                 verifyAll();
             }
 
-            assertEquals("Collection should shrink after remove",
-                         size - 1, collection.size());
+            assertEquals(size - 1, collection.size(), "Collection should shrink after remove");
         }
     }
 
@@ -941,28 +916,28 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         if (!isRemoveSupported()) return;
 
         resetEmpty();
-        assertTrue("Emtpy collection removeAll should return false for " +
-                   "empty input",
-                   !collection.removeAll(Collections.EMPTY_SET));
+        assertTrue(!collection.removeAll(Collections.EMPTY_SET),
+                "Emtpy collection removeAll should return false for " +
+                        "empty input");
         verifyAll();
 
-        assertTrue("Emtpy collection removeAll should return false for " +
-                   "nonempty input",
-                   !collection.removeAll(new ArrayList(collection)));
+        assertTrue(!collection.removeAll(new ArrayList(collection)),
+                "Emtpy collection removeAll should return false for " +
+                        "nonempty input");
         verifyAll();
 
         resetFull();
-        assertTrue("Full collection removeAll should return false for " +
-                   "empty input",
-                   !collection.removeAll(Collections.EMPTY_SET));
+        assertTrue(!collection.removeAll(Collections.EMPTY_SET),
+                "Full collection removeAll should return false for " +
+                        "empty input");
         verifyAll();
 
-        assertTrue("Full collection removeAll should return false for other elements",
-                   !collection.removeAll(Arrays.asList(getOtherElements())));
+        assertTrue(!collection.removeAll(Arrays.asList(getOtherElements())),
+                "Full collection removeAll should return false for other elements");
         verifyAll();
 
-        assertTrue("Full collection removeAll should return true for full elements",
-                    collection.removeAll(new HashSet(collection)));
+        assertTrue(collection.removeAll(new HashSet(collection)),
+                "Full collection removeAll should return true for full elements");
         confirmed.removeAll(new HashSet(confirmed));
         verifyAll();
 
@@ -972,17 +947,14 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         int max = (getFullElements().length == 1 ? 1 :
                     (getFullElements().length <= 5 ? getFullElements().length - 1 : 5));
         Collection all = Arrays.asList(getFullElements()).subList(min, max);
-        assertTrue("Full collection removeAll should work",
-                   collection.removeAll(all));
+        assertTrue(collection.removeAll(all), "Full collection removeAll should work");
         confirmed.removeAll(all);
         verifyAll();
 
-        assertTrue("Collection should shrink after removeAll",
-                   collection.size() < size);
+        assertTrue(collection.size() < size, "Collection should shrink after removeAll");
         Iterator iter = all.iterator();
         while (iter.hasNext()) {
-            assertTrue("Collection shouldn't contain removed element",
-                       !collection.contains(iter.next()));
+            assertTrue(!collection.contains(iter.next()), "Collection shouldn't contain removed element");
         }
     }
 
@@ -998,59 +970,51 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         List elements = Arrays.asList(getFullElements());
         List other = Arrays.asList(getOtherElements());
 
-        assertTrue("Empty retainAll() should return false",
-                   !collection.retainAll(Collections.EMPTY_SET));
+        assertTrue(!collection.retainAll(Collections.EMPTY_SET), "Empty retainAll() should return false");
         verifyAll();
 
-        assertTrue("Empty retainAll() should return false",
-                   !collection.retainAll(elements));
+        assertTrue(!collection.retainAll(elements), "Empty retainAll() should return false");
         verifyAll();
 
         resetFull();
-        assertTrue("Collection should change from retainAll empty",
-                   collection.retainAll(Collections.EMPTY_SET));
+        assertTrue(collection.retainAll(Collections.EMPTY_SET), "Collection should change from retainAll empty");
         confirmed.retainAll(Collections.EMPTY_SET);
         verifyAll();
 
         resetFull();
-        assertTrue("Collection changed from retainAll other",
-                   collection.retainAll(other));
+        assertTrue(collection.retainAll(other), "Collection changed from retainAll other");
         confirmed.retainAll(other);
         verifyAll();
 
         resetFull();
         int size = collection.size();
-        assertTrue("Collection shouldn't change from retainAll elements",
-                   !collection.retainAll(elements));
+        assertTrue(!collection.retainAll(elements), "Collection shouldn't change from retainAll elements");
         verifyAll();
-        assertEquals("Collection size shouldn't change", size,
-                     collection.size());
+        assertEquals(size, collection.size(), "Collection size shouldn't change");
 
         if (getFullElements().length > 1) {
             resetFull();
             size = collection.size();
             int min = (getFullElements().length < 2 ? 0 : 2);
             int max = (getFullElements().length <= 5 ? getFullElements().length - 1 : 5);
-            assertTrue("Collection should changed by partial retainAll",
-                       collection.retainAll(elements.subList(min, max)));
+            assertTrue(collection.retainAll(elements.subList(min, max)), "Collection should changed by partial retainAll");
             confirmed.retainAll(elements.subList(min, max));
             verifyAll();
 
             Iterator iter = collection.iterator();
             while (iter.hasNext()) {
-                assertTrue("Collection only contains retained element",
-                           elements.subList(min, max).contains(iter.next()));
+                assertTrue(elements.subList(min, max).contains(iter.next()), "Collection only contains retained element");
             }
         }
 
         resetFull();
         HashSet set = new HashSet(elements);
         size = collection.size();
-        assertTrue("Collection shouldn't change from retainAll without " +
-                   "duplicate elements", !collection.retainAll(set));
+        assertTrue(!collection.retainAll(set),
+                "Collection shouldn't change from retainAll without duplicate elements");
         verifyAll();
-        assertEquals("Collection size didn't change from nonduplicate " +
-                     "retainAll", size, collection.size());
+        assertEquals( size, collection.size(),
+                "Collection size didn't change from nonduplicate retainAll");
     }
 
 
@@ -1060,11 +1024,10 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
     @Test
     public void testCollectionSize() {
         resetEmpty();
-        assertEquals("Size of new Collection is 0.", 0, collection.size());
+        assertEquals(0, collection.size(), "Size of new Collection is 0.");
 
         resetFull();
-        assertTrue("Size of full collection should be greater than zero",
-                   collection.size() > 0);
+        assertTrue(collection.size() > 0, "Size of full collection should be greater than zero");
     }
 
 
@@ -1073,22 +1036,18 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
      */
     public void testCollectionToArray() {
         resetEmpty();
-        assertEquals("Empty Collection should return empty array for toArray",
-                     0, collection.toArray().length);
+        assertEquals(0, collection.toArray().length, "Empty Collection should return empty array for toArray");
 
         resetFull();
         Object[] array = collection.toArray();
-        assertEquals("Full collection toArray should be same size as " +
-                     "collection", array.length, collection.size());
+        assertEquals(array.length, collection.size(), "Full collection toArray should be same size as collection");
         Object[] confirmedArray = confirmed.toArray();
-        assertEquals("length of array from confirmed collection should " +
-                     "match the length of the collection's array",
-                     confirmedArray.length, array.length);
+        assertEquals(confirmedArray.length, array.length,
+                "length of array from confirmed collection should match the length of the collection's array");
         boolean[] matched = new boolean[array.length];
 
         for (int i = 0; i < array.length; i++) {
-            assertTrue("Collection should contain element in toArray",
-                       collection.contains(array[i]));
+            assertTrue(collection.contains(array[i]), "Collection should contain element in toArray");
 
             boolean match = false;
             // find a match in the confirmed array
@@ -1108,8 +1067,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
             }
         }
         for(int i = 0; i < matched.length; i++) {
-            assertEquals("Collection should return all its elements in " +
-                         "toArray", true, matched[i]);
+            assertEquals(true, matched[i], "Collection should return all its elements in toArray");
         }
     }
 
@@ -1123,8 +1081,8 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         resetEmpty();
         Object[] a = new Object[] { new Object(), null, null };
         Object[] array = collection.toArray(a);
-        assertArrayEquals("Given array shouldn't shrink", array, a);
-        assertNull("Last element should be set to null", a[0]);
+        assertArrayEquals(array, a, "Given array shouldn't shrink");
+        assertNull(a[0], "Last element should be set to null");
         verifyAll();
 
         resetFull();
@@ -1146,8 +1104,7 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
 
         array = collection.toArray(new Object[0]);
         a = collection.toArray();
-        assertEquals("toArrays should be equal",
-                     Arrays.asList(array), Arrays.asList(a));
+        assertEquals(Arrays.asList(array), Arrays.asList(a), "toArrays should be equal");
 
         // Figure out if they're all the same class
         // TODO: It'd be nicer to detect a common superclass
@@ -1163,11 +1120,10 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
         }
         a = (Object[])Array.newInstance(cl, 0);
         array = collection.toArray(a);
-        assertEquals("toArray(Object[]) should return correct array type",
-                     a.getClass(), array.getClass());
-        assertEquals("type-specific toArrays should be equal",
-                     Arrays.asList(array),
-                     Arrays.asList(collection.toArray()));
+        assertEquals(a.getClass(), array.getClass(), "toArray(Object[]) should return correct array type");
+        assertEquals(Arrays.asList(array),
+                     Arrays.asList(collection.toArray()),
+                "type-specific toArrays should be equal");
         verifyAll();
     }
 
@@ -1178,12 +1134,10 @@ public abstract class CollectionAbstractTest extends ObjectAbstractTest {
     @Test
     public void testCollectionToString() {
         resetEmpty();
-        assertTrue("toString shouldn't return null",
-                   collection.toString() != null);
+        assertTrue(collection.toString() != null, "toString shouldn't return null");
 
         resetFull();
-        assertTrue("toString shouldn't return null",
-                   collection.toString() != null);
+        assertTrue(collection.toString() != null, "toString shouldn't return null");
     }
 
 

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionUtilTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/CollectionUtilTest.java
@@ -30,13 +30,11 @@
 
 package com.twelvemonkeys.util;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.util.*;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * CollectionUtilTest
  *
@@ -61,44 +59,60 @@ public class CollectionUtilTest {
         assertArrayEquals(new Object[] {"bar", "baz", 3}, merged);
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMergeArraysObjectBadOffset() {
-        CollectionUtil.mergeArrays(stringObjects, 4, 2, integerObjects, 2, 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            CollectionUtil.mergeArrays(stringObjects, 4, 2, integerObjects, 2, 1);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMergeArraysObjectBadSecondOffset() {
-        CollectionUtil.mergeArrays(stringObjects, 1, 2, integerObjects, 4, 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            CollectionUtil.mergeArrays(stringObjects, 1, 2, integerObjects, 4, 1);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMergeArraysObjectBadLength() {
-        CollectionUtil.mergeArrays(stringObjects, 1, 4, integerObjects, 2, 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            CollectionUtil.mergeArrays(stringObjects, 1, 4, integerObjects, 2, 1);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMergeArraysObjectBadSecondLength() {
-        CollectionUtil.mergeArrays(stringObjects, 1, 2, integerObjects, 2, 2);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            CollectionUtil.mergeArrays(stringObjects, 1, 2, integerObjects, 2, 2);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMergeArraysObjectNegativeOffset() {
-        CollectionUtil.mergeArrays(stringObjects, -1, 2, integerObjects, 2, 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            CollectionUtil.mergeArrays(stringObjects, -1, 2, integerObjects, 2, 1);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMergeArraysObjectNegativeSecondOffset() {
-        CollectionUtil.mergeArrays(stringObjects, 1, 2, integerObjects, -1, 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            CollectionUtil.mergeArrays(stringObjects, 1, 2, integerObjects, -1, 1);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMergeArraysObjectNegativeLength() {
-        CollectionUtil.mergeArrays(stringObjects, 1, -1, integerObjects, 2, 1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            CollectionUtil.mergeArrays(stringObjects, 1, -1, integerObjects, 2, 1);
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testMergeArraysObjectNegativeSecondLength() {
-        CollectionUtil.mergeArrays(stringObjects, 1, 2, integerObjects, 2, -1);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            CollectionUtil.mergeArrays(stringObjects, 1, 2, integerObjects, 2, -1);
+        });
     }
 
     @Test
@@ -109,20 +123,24 @@ public class CollectionUtilTest {
         assertArrayEquals(new Object[] {"foo", "bar", "baz", 1, 2, 3}, merged);
     }
 
-    @Test(expected = ArrayStoreException.class)
+    @Test
     public void testMergeArraysObjectIllegalType() {
         String[] strings = {"foo", "bar", "baz"};
         Integer[] integers = {1, 2, 3}; // Integer not assignable to String
 
-        CollectionUtil.mergeArrays(strings, integers);
+        assertThrows(ArrayStoreException.class, () -> {
+            CollectionUtil.mergeArrays(strings, integers);
+        });
     }
 
-    @Test(expected = ArrayStoreException.class)
+    @Test
     public void testMergeArraysNativeIllegalType() {
         char[] chars = {'a', 'b', 'c'};
         int[] integers = {1, 2, 3}; // Integer not assignable to String
 
-        CollectionUtil.mergeArrays(chars, integers);
+        assertThrows(ArrayStoreException.class, () -> {
+            CollectionUtil.mergeArrays(chars, integers);
+        });
 
     }
 
@@ -147,9 +165,11 @@ public class CollectionUtilTest {
         assertArrayEquals(new int[] {2, 3, 4}, numbers);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testEnumIteratorNull() {
-        CollectionUtil.iterator((Enumeration<Object>) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            CollectionUtil.iterator((Enumeration<Object>) null);
+        });
     }
     
     @Test
@@ -183,9 +203,11 @@ public class CollectionUtilTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testArrayIteratorNull() {
-        CollectionUtil.iterator((Object[]) null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            CollectionUtil.iterator((Object[]) null);
+        });
     }
 
     @Test
@@ -262,7 +284,7 @@ public class CollectionUtilTest {
 
         int count = 0;
         for (Object element : elements) {
-            assertTrue("No next element for element '" + element + "' at index: " + count, iterator.hasNext());
+            assertTrue(iterator.hasNext(), "No next element for element '" + element + "' at index: " + count);
             assertEquals(count > 0, iterator.hasPrevious());
             assertEquals(count, iterator.nextIndex());
             assertEquals(count - 1, iterator.previousIndex());
@@ -318,7 +340,7 @@ public class CollectionUtilTest {
         assertEquals(elements.length, iterator.nextIndex());
 
         for (int i = count; i > 0; i--) {
-            assertTrue("No previous element for element '" + elements[i - 1] + "' at index: " + (i - 1), iterator.hasPrevious());
+            assertTrue(iterator.hasPrevious(), "No previous element for element '" + elements[i - 1] + "' at index: " + (i - 1));
             assertEquals(i < elements.length, iterator.hasNext());
             assertEquals(i - 1, iterator.previousIndex());
             assertEquals(i, iterator.nextIndex());
@@ -339,18 +361,24 @@ public class CollectionUtilTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testArrayIteratorRangeNull() {
-        CollectionUtil.iterator(null, 0, 0);
+        assertThrows(IllegalArgumentException.class, () -> {
+            CollectionUtil.iterator(null, 0, 0);
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testArrayIteratorRangeBadStart() {
-        CollectionUtil.iterator(stringObjects, stringObjects.length + 1, 2);
+        assertThrows(IllegalArgumentException.class, () -> {
+            CollectionUtil.iterator(stringObjects, stringObjects.length + 1, 2);
+        });
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testArrayIteratorRangeBadLength() {
-        CollectionUtil.iterator(stringObjects, 1, stringObjects.length);
+        assertThrows(IllegalArgumentException.class, () -> {
+            CollectionUtil.iterator(stringObjects, 1, stringObjects.length);
+        });
     }
 
     @Test
@@ -379,9 +407,11 @@ public class CollectionUtilTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReverseOrderNull() {
-        CollectionUtil.reverseOrder(null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            CollectionUtil.reverseOrder(null);
+        });
     }
 
     @Test
@@ -431,7 +461,7 @@ public class CollectionUtilTest {
         }
     }
 
-    @Ignore("For development only")
+    @Disabled("For development only")
     @Test
     @SuppressWarnings({"UnusedDeclaration"})
     public void testGenerify() {

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/LRUMapTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/LRUMapTest.java
@@ -45,11 +45,10 @@
 
 package com.twelvemonkeys.util;
 
-import org.junit.Test;
-
 import java.util.*;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests LRUMap.
@@ -81,8 +80,8 @@ public class LRUMapTest extends LinkedMapTest {
         map2.put(4,"foo"); // removes 1 since max size exceeded
         map2.removeLRU();  // should be Integer(2)
 
-        assertTrue("Second to last value should exist",map2.get(new Integer(3)).equals("foo"));
-        assertTrue("First value inserted should not exist", map2.get(new Integer(1)) == null);
+        assertTrue(map2.get(new Integer(3)).equals("foo"), "Second to last value should exist");
+        assertTrue(map2.get(new Integer(1)) == null, "First value inserted should not exist");
     }
 
     @Test
@@ -93,8 +92,8 @@ public class LRUMapTest extends LinkedMapTest {
         map2.put(3,"foo");
         map2.put(4,"bar");
 
-        assertTrue("last value should exist",map2.get(new Integer(4)).equals("bar"));
-        assertTrue("LRU should not exist", map2.get(new Integer(1)) == null);
+        assertTrue(map2.get(new Integer(4)).equals("bar"), "last value should exist");
+        assertTrue(map2.get(new Integer(1)) == null, "LRU should not exist");
     }
 
     /**
@@ -113,10 +112,8 @@ public class LRUMapTest extends LinkedMapTest {
 
         map2.putAll(hashMap);
 
-        assertTrue("max size is 3, but actual size is " + map2.size(),
-                   map2.size() == 3);
-        assertTrue("map should contain the Integer(4) object",
-                   map2.containsKey(new Integer(4)));
+        assertTrue(map2.size() == 3, "max size is 3, but actual size is " + map2.size());
+        assertTrue(map2.containsKey(new Integer(4)), "map should contain the Integer(4) object");
     }
 
     /**
@@ -134,8 +131,7 @@ public class LRUMapTest extends LinkedMapTest {
         map.put("6","6");
         map.setMaxSize(3);
 
-        assertTrue("map should have size = 3, but actually = " + map.size(),
-                   map.size() == 3);
+        assertTrue(map.size() == 3, "map should have size = 3, but actually = " + map.size());
     }
 
     @Test
@@ -160,9 +156,9 @@ public class LRUMapTest extends LinkedMapTest {
             keys[i] = keyIterator.next();
         }
 
-        assertTrue("first evicted should be 3, was " + keys[0], keys[0].equals("3"));
-        assertTrue("second evicted should be 1, was " + keys[1], keys[1].equals("1"));
-        assertTrue("third evicted should be 4, was " + keys[2], keys[2].equals("4"));
+        assertTrue(keys[0].equals("3"), "first evicted should be 3, was " + keys[0]);
+        assertTrue(keys[1].equals("1"), "second evicted should be 1, was " + keys[1]);
+        assertTrue(keys[2].equals("4"), "third evicted should be 4, was " + keys[2]);
 
     }
 
@@ -192,13 +188,12 @@ public class LRUMapTest extends LinkedMapTest {
         // 4 2
         counter.remove("5");
 
-        assertTrue("size should be 2, but was " + counter.size(), counter.size() == 2);
-        assertTrue("removedCount should be 3 but was " + counter.removedCount,
-                   counter.removedCount == 3);
+        assertTrue(counter.size() == 2, "size should be 2, but was " + counter.size());
+        assertTrue(counter.removedCount == 3, "removedCount should be 3 but was " + counter.removedCount);
 
-        assertTrue("first removed was '2'",counter.list.get(0).equals("2"));
-        assertTrue("second removed was '3'",counter.list.get(1).equals("3"));
-        assertTrue("third removed was '1'",counter.list.get(2).equals("1"));
+        assertTrue(counter.list.get(0).equals("2"), "first removed was '2'");
+        assertTrue(counter.list.get(1).equals("3"), "second removed was '3'");
+        assertTrue(counter.list.get(2).equals("1"), "third removed was '1'");
 
         //assertTrue("oldest key is '4'",counter.get(0).equals("4"));
         //assertTrue("newest key is '2'",counter.get(1).equals("2"));

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/LinkedMapTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/LinkedMapTest.java
@@ -45,15 +45,11 @@
 
 package com.twelvemonkeys.util;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests
@@ -74,7 +70,7 @@ public class LinkedMapTest extends MapAbstractTest {
      */
     protected LinkedMap labRat;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         // use makeMap and cast the result to a SeqHashMap
         // so that subclasses of SeqHashMap can share these tests
@@ -103,27 +99,21 @@ public class LinkedMapTest extends MapAbstractTest {
         }
 
         // Test size().
-        assertEquals("size() does not match expected size",
-                     expectedSize, labRat.size());
+        assertEquals(expectedSize, labRat.size(), "size() does not match expected size");
 
         // Test clone(), iterator(), and get(Object).
         LinkedMap clone = (LinkedMap) labRat.clone();
-        assertEquals("Size of clone does not match original",
-                     labRat.size(), clone.size());
+        assertEquals(labRat.size(), clone.size(), "Size of clone does not match original");
         Iterator origEntries = labRat.entrySet().iterator();
         Iterator copiedEntries = clone.entrySet().iterator();
         while (origEntries.hasNext()) {
             Map.Entry origEntry = (Map.Entry)origEntries.next();
             Map.Entry copiedEntry = (Map.Entry)copiedEntries.next();
-            assertEquals("Cloned key does not match original",
-                         origEntry.getKey(), copiedEntry.getKey());
-            assertEquals("Cloned value does not match original",
-                         origEntry.getValue(), copiedEntry.getValue());
-            assertEquals("Cloned entry does not match original",
-                         origEntry, copiedEntry);
+            assertEquals(origEntry.getKey(), copiedEntry.getKey(), "Cloned key does not match original");
+            assertEquals(origEntry.getValue(), copiedEntry.getValue(), "Cloned value does not match original");
+            assertEquals(origEntry, copiedEntry, "Cloned entry does not match original");
         }
-        assertTrue("iterator() returned different number of elements than keys()",
-               !copiedEntries.hasNext());
+        assertTrue(!copiedEntries.hasNext(), "iterator() returned different number of elements than keys()");
 
         // Test sequence()
         /*
@@ -207,7 +197,7 @@ public class LinkedMapTest extends MapAbstractTest {
     }
     */
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         labRat = null;
     }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/MapAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/MapAbstractTest.java
@@ -45,12 +45,10 @@
 
 package com.twelvemonkeys.util;
 
-import org.junit.After;
-import org.junit.Test;
-
 import java.util.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Abstract test class for {@link java.util.Map} methods and contracts.
@@ -390,19 +388,19 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
                 m.put(keys[i], values[i]);
             }
             catch (NullPointerException exception) {
-                assertTrue("NullPointerException only allowed to be thrown if either the key or value is null.",
-                        keys[i] == null || values[i] == null);
+                assertTrue(keys[i] == null || values[i] == null,
+                        "NullPointerException only allowed to be thrown if either the key or value is null.");
 
-                assertTrue("NullPointerException on null key, but isAllowNullKey is not overridden to return false.",
-                        keys[i] == null || !isAllowNullKey());
+                assertTrue(keys[i] == null || !isAllowNullKey(),
+                        "NullPointerException on null key, but isAllowNullKey is not overridden to return false.");
 
-                assertTrue("NullPointerException on null value, but isAllowNullValue is not overridden to return false.",
-                        values[i] == null || !isAllowNullValue());
+                assertTrue(values[i] == null || !isAllowNullValue(),
+                        "NullPointerException on null value, but isAllowNullValue is not overridden to return false.");
 
-                assertTrue("Unknown reason for NullPointer.", false);
+                fail("Unknown reason for NullPointer.");
             }
         }
-        assertEquals("size must reflect number of mappings added.", keys.length, m.size());
+        assertEquals(keys.length, m.size(), "size must reflect number of mappings added.");
     }
 
     //-----------------------------------------------------------------------
@@ -481,27 +479,26 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
         Object[] values = getSampleValues();
         Object[] newValues = getNewSampleValues();
 
-        assertTrue("failure in test: Must have keys returned from getSampleKeys.", keys != null);
-        assertTrue("failure in test: Must have values returned from getSampleValues.", values != null);
+        assertTrue(keys != null, "failure in test: Must have keys returned from getSampleKeys.");
+        assertTrue(values != null, "failure in test: Must have values returned from getSampleValues.");
 
         // verify keys and values have equivalent lengths (in case getSampleX are
         // overridden)
-        assertEquals("failure in test: not the same number of sample keys and values.", keys.length, values.length);
-        assertEquals("failure in test: not the same number of values and new values.", values.length, newValues.length);
+        assertEquals(keys.length, values.length, "failure in test: not the same number of sample keys and values.");
+        assertEquals(values.length, newValues.length, "failure in test: not the same number of values and new values.");
 
         // verify there aren't duplicate keys, and check values
         for (int i = 0; i < keys.length - 1; i++) {
             for (int j = i + 1; j < keys.length; j++) {
-                assertTrue("failure in test: duplicate null keys.", (keys[i] != null || keys[j] != null));
-                assertTrue("failure in test: duplicate non-null key.",
-                        (keys[i] == null || keys[j] == null || (!keys[i].equals(keys[j]) && !keys[j].equals(keys[i]))));
+                assertTrue((keys[i] != null || keys[j] != null), "failure in test: duplicate null keys.");
+                assertTrue((keys[i] == null || keys[j] == null || (!keys[i].equals(keys[j]) && !keys[j].equals(keys[i]))),
+                        "failure in test: duplicate non-null key.");
             }
 
-            assertTrue("failure in test: found null key, but isNullKeySupported is false.", keys[i] != null || isAllowNullKey());
-            assertTrue("failure in test: found null value, but isNullValueSupported is false.", values[i] != null || isAllowNullValue());
-            assertTrue("failure in test: found null new value, but isNullValueSupported is false.", newValues[i] != null || isAllowNullValue());
-            assertTrue("failure in test: values should not be the same as new value",
-                    values[i] != newValues[i] && (values[i] == null || !values[i].equals(newValues[i])));
+            assertTrue(keys[i] != null || isAllowNullKey(),"failure in test: found null key, but isNullKeySupported is false.");
+            assertTrue(values[i] != null || isAllowNullValue(),"failure in test: found null value, but isNullValueSupported is false.");
+            assertTrue(newValues[i] != null || isAllowNullValue(), "failure in test: found null new value, but isNullValueSupported is false.");
+            assertTrue(values[i] != newValues[i] && (values[i] == null || !values[i].equals(newValues[i])), "failure in test: values should not be the same as new value");
         }
     }
 
@@ -517,18 +514,18 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
     @Test
     public void testMakeMap() {
         Map em = makeEmptyMap();
-        assertTrue("failure in test: makeEmptyMap must return a non-null map.", em != null);
+        assertTrue(em != null, "failure in test: makeEmptyMap must return a non-null map.");
 
         Map em2 = makeEmptyMap();
-        assertTrue("failure in test: makeEmptyMap must return a non-null map.", em2 != null);
-        assertTrue("failure in test: makeEmptyMap must return a new map with each invocation.", em != em2);
+        assertTrue(em2 != null, "failure in test: makeEmptyMap must return a non-null map.");
+        assertTrue(em != em2, "failure in test: makeEmptyMap must return a new map with each invocation.");
 
         Map fm = makeFullMap();
-        assertTrue("failure in test: makeFullMap must return a non-null map.", fm != null);
+        assertTrue(fm != null, "failure in test: makeFullMap must return a non-null map.");
 
         Map fm2 = makeFullMap();
-        assertTrue("failure in test: makeFullMap must return a non-null map.", fm2 != null);
-        assertTrue("failure in test: makeFullMap must return a new map with each invocation.", fm != fm2);
+        assertTrue(fm2 != null, "failure in test: makeFullMap must return a non-null map.");
+        assertTrue(fm != fm2, "failure in test: makeFullMap must return a new map with each invocation.");
     }
 
     /**
@@ -537,11 +534,11 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
     @Test
     public void testMapIsEmpty() {
         resetEmpty();
-        assertEquals("Map.isEmpty() should return true with an empty map", true, map.isEmpty());
+        assertEquals(true, map.isEmpty(), "Map.isEmpty() should return true with an empty map");
         verifyAll();
 
         resetFull();
-        assertEquals("Map.isEmpty() should return false with a non-empty map", false, map.isEmpty());
+        assertEquals(false, map.isEmpty(), "Map.isEmpty() should return false with a non-empty map");
         verifyAll();
     }
 
@@ -551,11 +548,11 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
     @Test
     public void testMapSize() {
         resetEmpty();
-        assertEquals("Map.size() should be 0 with an empty map", 0, map.size());
+        assertEquals(0, map.size(), "Map.size() should be 0 with an empty map");
         verifyAll();
 
         resetFull();
-        assertEquals("Map.size() should equal the number of entries in the map", getSampleKeys().length, map.size());
+        assertEquals(getSampleKeys().length, map.size(), "Map.size() should equal the number of entries in the map");
         verifyAll();
     }
 
@@ -602,13 +599,13 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
 
         resetEmpty();
         for (Object key : keys) {
-            assertTrue("Map must not contain key when map is empty", !map.containsKey(key));
+            assertTrue(!map.containsKey(key), "Map must not contain key when map is empty");
         }
         verifyAll();
 
         resetFull();
         for (Object key : keys) {
-            assertTrue("Map must contain key for a mapping in the map. Missing: " + key, map.containsKey(key));
+            assertTrue(map.containsKey(key), "Map must contain key for a mapping in the map. Missing: " + key);
         }
         verifyAll();
     }
@@ -624,13 +621,13 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
 
         resetEmpty();
         for (Object value : values) {
-            assertTrue("Empty map must not contain value", !map.containsValue(value));
+            assertTrue(!map.containsValue(value), "Empty map must not contain value");
         }
         verifyAll();
 
         resetFull();
         for (Object value : values) {
-            assertTrue("Map must contain value for a mapping in the map.", map.containsValue(value));
+            assertTrue(map.containsValue(value), "Map must contain value for a mapping in the map.");
         }
         verifyAll();
     }
@@ -641,11 +638,11 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
     @Test
     public void testMapEquals() {
         resetEmpty();
-        assertTrue("Empty maps unequal.", map.equals(confirmed));
+        assertTrue(map.equals(confirmed), "Empty maps unequal.");
         verifyAll();
 
         resetFull();
-        assertTrue("Full maps unequal.", map.equals(confirmed));
+        assertTrue(map.equals(confirmed), "Full maps unequal.");
         verifyAll();
 
         resetFull();
@@ -654,11 +651,11 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
         Iterator iter = confirmed.keySet().iterator();
         iter.next();
         iter.remove();
-        assertTrue("Different maps equal.", !map.equals(confirmed));
+        assertTrue(!map.equals(confirmed), "Different maps equal.");
 
         resetFull();
-        assertTrue("equals(null) returned true.", !map.equals(null));
-        assertTrue("equals(new Object()) returned true.", !map.equals(new Object()));
+        assertTrue(!map.equals(null), "equals(null) returned true.");
+        assertTrue(!map.equals(new Object()), "equals(new Object()) returned true.");
         verifyAll();
     }
 
@@ -673,14 +670,14 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
         Object[] values = getSampleValues();
 
         for (Object key : keys) {
-            assertTrue("Empty map.get() should return null.", map.get(key) == null);
+            assertTrue(map.get(key) == null, "Empty map.get() should return null.");
         }
 
         verifyAll();
 
         resetFull();
         for (int i = 0; i < keys.length; i++) {
-            assertEquals("Full map.get() should return value from mapping.", values[i], map.get(keys[i]));
+            assertEquals(values[i], map.get(keys[i]), "Full map.get() should return value from mapping.");
         }
     }
 
@@ -690,10 +687,10 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
     @Test
     public void testMapHashCode() {
         resetEmpty();
-        assertTrue("Empty maps have different hashCodes.", map.hashCode() == confirmed.hashCode());
+        assertTrue(map.hashCode() == confirmed.hashCode(), "Empty maps have different hashCodes.");
 
         resetFull();
-        assertTrue("Equal maps have different hashCodes.", map.hashCode() == confirmed.hashCode());
+        assertTrue(map.hashCode() == confirmed.hashCode(), "Equal maps have different hashCodes.");
     }
 
     /**
@@ -708,11 +705,11 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
     @Test
     public void testMapToString() {
         resetEmpty();
-        assertTrue("Empty map toString() should not return null", map.toString() != null);
+        assertTrue(map.toString() != null, "Empty map toString() should not return null");
         verifyAll();
 
         resetFull();
-        assertTrue("Empty map toString() should not return null", map.toString() != null);
+        assertTrue(map.toString() != null, "Empty map toString() should not return null");
         verifyAll();
     }
 
@@ -776,29 +773,23 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
                 Object o = map.put(keys[i], values[i]);
                 confirmed.put(keys[i], values[i]);
                 verifyAll();
-                assertTrue("First map.put should return null", o == null);
-                assertTrue("Map should contain key after put",
-                        map.containsKey(keys[i]));
-                assertTrue("Map should contain value after put",
-                        map.containsValue(values[i]));
+                assertTrue(o == null, "First map.put should return null");
+                assertTrue(map.containsKey(keys[i]), "Map should contain key after put");
+                assertTrue(map.containsValue(values[i]), "Map should contain value after put");
             }
             if (isPutChangeSupported()) {
                 for (int i = 0; i < keys.length; i++) {
                     Object o = map.put(keys[i], newValues[i]);
                     confirmed.put(keys[i], newValues[i]);
                     verifyAll();
-                    assertEquals("Map.put should return previous value when changed",
-                            values[i], o);
-                    assertTrue("Map should still contain key after put when changed",
-                            map.containsKey(keys[i]));
-                    assertTrue("Map should contain new value after put when changed",
-                            map.containsValue(newValues[i]));
+                    assertEquals(values[i], o, "Map.put should return previous value when changed");
+                    assertTrue(map.containsKey(keys[i]), "Map should still contain key after put when changed");
+                    assertTrue(map.containsValue(newValues[i]), "Map should contain new value after put when changed");
 
                     // if duplicates are allowed, we're not guaranteed that the value
                     // no longer exists, so don't try checking that.
                     if (!isAllowDuplicateValues()) {
-                        assertTrue("Map should not contain old value after put when changed",
-                                !map.containsValue(values[i]));
+                        assertTrue(!map.containsValue(values[i]), "Map should not contain old value after put when changed");
                     }
                 }
             }
@@ -832,18 +823,14 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
                 Object o = map.put(key, newValues[i]);
                 Object value = confirmed.put(key, newValues[i]);
                 verifyAll();
-                assertEquals("Map.put should return previous value when changed",
-                        value, o);
-                assertTrue("Map should still contain key after put when changed",
-                        map.containsKey(key));
-                assertTrue("Map should contain new value after put when changed",
-                        map.containsValue(newValues[i]));
+                assertEquals(value, o, "Map.put should return previous value when changed");
+                assertTrue(map.containsKey(key), "Map should still contain key after put when changed");
+                assertTrue(map.containsValue(newValues[i]), "Map should contain new value after put when changed");
 
                 // if duplicates are allowed, we're not guaranteed that the value
                 // no longer exists, so don't try checking that.
                 if (!isAllowDuplicateValues()) {
-                    assertTrue("Map should not contain old value after put when changed",
-                            !map.containsValue(values[i]));
+                    assertTrue(!map.containsValue(values[i]), "Map should not contain old value after put when changed");
                 }
             }
         }
@@ -970,7 +957,7 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
         Object[] values = getSampleValues();
         for (int i = 0; i < keys.length; i++) {
             Object o = map.remove(keys[i]);
-            assertTrue("First map.remove should return null", o == null);
+            assertTrue(o == null, "First map.remove should return null");
         }
         verifyAll();
 
@@ -981,8 +968,7 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
             confirmed.remove(keys[i]);
             verifyAll();
 
-            assertEquals("map.remove with valid key should return value",
-                    values[i], o);
+            assertEquals(values[i], o, "map.remove with valid key should return value");
         }
 
         Object[] other = getOtherKeys();
@@ -991,10 +977,8 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
         int size = map.size();
         for (int i = 0; i < other.length; i++) {
             Object o = map.remove(other[i]);
-            assertEquals("map.remove for nonexistent key should return null",
-                    o, null);
-            assertEquals("map.remove for nonexistent key should not " +
-                    "shrink map", size, map.size());
+            assertEquals(o, null, "map.remove for nonexistent key should return null");
+            assertEquals(size, map.size(), "map.remove for nonexistent key should not shrink map");
         }
         verifyAll();
     }
@@ -1204,10 +1188,9 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
                     }
                     j++;
                 }
-                assertTrue("values().remove(obj) is broken", j < 10000);
-                assertTrue(
-                        "Value should have been removed from the underlying map.",
-                        !map.containsValue(sampleValues[i]));
+                assertTrue(j < 10000, "values().remove(obj) is broken");
+                assertTrue(!map.containsValue(sampleValues[i]),
+                        "Value should have been removed from the underlying map.");
             }
         }
     }
@@ -1230,9 +1213,8 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
                 // if key.remove is unsupported, just skip this test
                 return;
             }
-            assertTrue(
-                    "Key should have been removed from the underlying map.",
-                    !map.containsKey(sampleKeys[i]));
+            assertTrue(!map.containsKey(sampleKeys[i]),
+                    "Key should have been removed from the underlying map.");
         }
     }
 
@@ -1413,7 +1395,7 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
                     break;
                 }
             }
-            assertNotNull("No matching entry in map for key '" + key + "'", entry);
+            assertNotNull(entry, "No matching entry in map for key '" + key + "'");
             return entry;
         }
 
@@ -1638,14 +1620,14 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
     public void verifyMap() {
         int size = confirmed.size();
         boolean empty = confirmed.isEmpty();
-        assertEquals("Map should be same size as HashMap", size, map.size());
-        assertEquals("Map should be empty if HashMap is", empty, map.isEmpty());
-        assertEquals("hashCodes should be the same", confirmed.hashCode(), map.hashCode());
+        assertEquals(size, map.size(), "Map should be same size as HashMap");
+        assertEquals(empty, map.isEmpty(), "Map should be empty if HashMap is");
+        assertEquals(confirmed.hashCode(), map.hashCode(), "hashCodes should be the same");
         // this fails for LRUMap because confirmed.equals() somehow modifies
         // map, causing concurrent modification exceptions.
         //assertEquals("Map should still equal HashMap", confirmed, map);
         // this works though and performs the same verification:
-        assertTrue("Map should still equal HashMap", map.equals(confirmed));
+        assertTrue(map.equals(confirmed), "Map should still equal HashMap");
         // TODO: this should really be reexamined to figure out why LRU map
         // behaves like it does (the equals shouldn't modify since all accesses
         // by the confirmed collection should be through an iterator, thus not
@@ -1655,29 +1637,29 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
     public void verifyEntrySet() {
         int size = confirmed.size();
         boolean empty = confirmed.isEmpty();
-        assertEquals("entrySet should be same size as HashMap's\nTest: " + entrySet + "\nReal: " + confirmed.entrySet(),
-                size, entrySet.size());
-        assertEquals("entrySet should be empty if HashMap is\nTest: " + entrySet + "\nReal: " + confirmed.entrySet(),
-                empty, entrySet.isEmpty());
-        assertTrue("entrySet should contain all HashMap's elements\nTest: " + entrySet + "\nReal: " + confirmed.entrySet(),
-                entrySet.containsAll(confirmed.entrySet()));
-        assertEquals("entrySet hashCodes should be the same\nTest: " + entrySet + "\nReal: " + confirmed.entrySet(),
-                confirmed.entrySet().hashCode(), entrySet.hashCode());
-        assertEquals("Map's entry set should still equal HashMap's", confirmed.entrySet(), entrySet);
+        assertEquals(size, entrySet.size(),
+                "entrySet should be same size as HashMap's\nTest: " + entrySet + "\nReal: " + confirmed.entrySet());
+        assertEquals(empty, entrySet.isEmpty(),
+                "entrySet should be empty if HashMap is\nTest: " + entrySet + "\nReal: " + confirmed.entrySet());
+        assertTrue(entrySet.containsAll(confirmed.entrySet()),
+                "entrySet should contain all HashMap's elements\nTest: " + entrySet + "\nReal: " + confirmed.entrySet());
+        assertEquals(confirmed.entrySet().hashCode(), entrySet.hashCode(),
+                "entrySet hashCodes should be the same\nTest: " + entrySet + "\nReal: " + confirmed.entrySet());
+        assertEquals(confirmed.entrySet(), entrySet,"Map's entry set should still equal HashMap's");
     }
 
     public void verifyKeySet() {
         int size = confirmed.size();
         boolean empty = confirmed.isEmpty();
-        assertEquals("keySet should be same size as HashMap's\nTest: " + keySet + "\nReal: " + confirmed.keySet(),
-                size, keySet.size());
-        assertEquals("keySet should be empty if HashMap is\nTest: " + keySet + "\nReal: " + confirmed.keySet(),
-                empty, keySet.isEmpty());
-        assertTrue("keySet should contain all HashMap's elements\nTest: " + keySet + "\nReal: " + confirmed.keySet(),
-                keySet.containsAll(confirmed.keySet()));
-        assertEquals("keySet hashCodes should be the same\nTest: " + keySet + "\nReal: " + confirmed.keySet(),
-                confirmed.keySet().hashCode(), keySet.hashCode());
-        assertEquals("Map's key set should still equal HashMap's", confirmed.keySet(), keySet);
+        assertEquals(size, keySet.size(),
+                "keySet should be same size as HashMap's\nTest: " + keySet + "\nReal: " + confirmed.keySet());
+        assertEquals(empty, keySet.isEmpty(),
+                "keySet should be empty if HashMap is\nTest: " + keySet + "\nReal: " + confirmed.keySet());
+        assertTrue(keySet.containsAll(confirmed.keySet()),
+                "keySet should contain all HashMap's elements\nTest: " + keySet + "\nReal: " + confirmed.keySet());
+        assertEquals(confirmed.keySet().hashCode(), keySet.hashCode(),
+                "keySet hashCodes should be the same\nTest: " + keySet + "\nReal: " + confirmed.keySet());
+        assertEquals(confirmed.keySet(), keySet, "Map's key set should still equal HashMap's");
     }
 
     public void verifyValues() {
@@ -1687,23 +1669,23 @@ public abstract class MapAbstractTest extends ObjectAbstractTest {
         int size = confirmed.size();
         boolean empty = confirmed.isEmpty();
 
-        assertEquals("values should be same size as HashMap's\nTest: " + test + "\nReal: " + known, size, values.size());
-        assertEquals("values should be empty if HashMap is\nTest: " + test + "\nReal: " + known, empty, values.isEmpty());
-        assertTrue("values should contain all HashMap's elements\nTest: " + test + "\nReal: " + known, test.containsAll(known));
-        assertTrue("values should contain all HashMap's elements\nTest: " + test + "\nReal: " + known, known.containsAll(test));
+        assertEquals(size, values.size(), "values should be same size as HashMap's\nTest: " + test + "\nReal: " + known);
+        assertEquals(empty, values.isEmpty(), "values should be empty if HashMap is\nTest: " + test + "\nReal: " + known);
+        assertTrue(test.containsAll(known), "values should contain all HashMap's elements\nTest: " + test + "\nReal: " + known);
+        assertTrue(known.containsAll(test), "values should contain all HashMap's elements\nTest: " + test + "\nReal: " + known);
 
         for (Object aKnown : known) {
             boolean removed = test.remove(aKnown);
-            assertTrue("Map's values should still equal HashMap's", removed);
+            assertTrue(removed, "Map's values should still equal HashMap's");
         }
 
-        assertTrue("Map's values should still equal HashMap's", test.isEmpty());
+        assertTrue(test.isEmpty(), "Map's values should still equal HashMap's");
     }
 
     /**
      * Erases any leftover instance variables by setting them to null.
      */
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         map = null;
         keySet = null;

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/NullMapTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/NullMapTest.java
@@ -30,13 +30,11 @@
 
 package com.twelvemonkeys.util;
 
-import org.junit.Test;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * NOTE: This TestCase is written especially for NullMap, and is full of dirty
@@ -83,12 +81,12 @@ public class NullMapTest extends MapAbstractTest {
     @Override
     public void testMapIsEmpty() {
         resetEmpty();
-        assertEquals("Map.isEmpty() should return true with an empty map",
-                     true, map.isEmpty());
+        assertEquals(true, map.isEmpty(),
+                "Map.isEmpty() should return true with an empty map");
         verifyAll();
         resetFull();
-        assertEquals("Map.isEmpty() should return true with a full map",
-                     true, map.isEmpty());
+        assertEquals(true, map.isEmpty(),
+                "Map.isEmpty() should return true with a full map");
     }
 
     // Overriden, as this map is always empty
@@ -96,13 +94,13 @@ public class NullMapTest extends MapAbstractTest {
     @Override
     public void testMapSize() {
         resetEmpty();
-        assertEquals("Map.size() should be 0 with an empty map",
-                     0, map.size());
+        assertEquals(0, map.size(),
+                "Map.size() should be 0 with an empty map");
         verifyAll();
 
         resetFull();
-        assertEquals("Map.size() should equal the number of entries " +
-                     "in the map", 0, map.size());
+        assertEquals(0, map.size(),
+                "Map.size() should equal the number of entries in the map");
     }
 
     @Test
@@ -112,7 +110,7 @@ public class NullMapTest extends MapAbstractTest {
 
         resetEmpty();
         for (Object key : keys) {
-            assertTrue("Map must not contain key when map is empty", !map.containsKey(key));
+            assertTrue(!map.containsKey(key),"Map must not contain key when map is empty");
         }
         verifyAll();
     }
@@ -124,7 +122,7 @@ public class NullMapTest extends MapAbstractTest {
 
         resetEmpty();
         for (Object value : values) {
-            assertTrue("Empty map must not contain value", !map.containsValue(value));
+            assertTrue(!map.containsValue(value), "Empty map must not contain value");
         }
         verifyAll();
     }
@@ -133,7 +131,7 @@ public class NullMapTest extends MapAbstractTest {
     @Override
     public void testMapEquals() {
         resetEmpty();
-        assertTrue("Empty maps unequal.", map.equals(confirmed));
+        assertTrue(map.equals(confirmed), "Empty maps unequal.");
         verifyAll();
     }
 
@@ -141,8 +139,7 @@ public class NullMapTest extends MapAbstractTest {
     @Override
     public void testMapHashCode() {
         resetEmpty();
-        assertTrue("Empty maps have different hashCodes.",
-                   map.hashCode() == confirmed.hashCode());
+        assertTrue(map.hashCode() == confirmed.hashCode(), "Empty maps have different hashCodes.");
     }
 
     @Test
@@ -153,7 +150,7 @@ public class NullMapTest extends MapAbstractTest {
         Object[] keys = getSampleKeys();
 
         for (Object key : keys) {
-            assertTrue("Empty map.get() should return null.", map.get(key) == null);
+            assertTrue(map.get(key) == null, "Empty map.get() should return null.");
         }
         verifyAll();
     }
@@ -170,7 +167,7 @@ public class NullMapTest extends MapAbstractTest {
             Object o = map.put(keys[i], values[i]);
             //confirmed.put(keys[i], values[i]);
             verifyAll();
-            assertTrue("First map.put should return null", o == null);
+            assertTrue(o == null, "First map.put should return null");
         }
         for (int i = 0; i < keys.length; i++) {
             map.put(keys[i], newValues[i]);
@@ -183,8 +180,8 @@ public class NullMapTest extends MapAbstractTest {
     @Override
     public void testMapToString() {
         resetEmpty();
-        assertTrue("Empty map toString() should not return null",
-                   map.toString() != null);
+        assertTrue(map.toString() != null,
+                "Empty map toString() should not return null");
         verifyAll();
     }
 
@@ -202,7 +199,7 @@ public class NullMapTest extends MapAbstractTest {
         Object[] keys = getSampleKeys();
         for(int i = 0; i < keys.length; i++) {
             Object o = map.remove(keys[i]);
-            assertTrue("First map.remove should return null", o == null);
+            assertTrue(o == null, "First map.remove should return null");
         }
         verifyAll();
     }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/ObjectAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/ObjectAbstractTest.java
@@ -44,12 +44,10 @@
  */
 package com.twelvemonkeys.util;
 
-import org.junit.Test;
-
 import java.io.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Abstract test class for {@link Object} methods and contracts.
@@ -119,7 +117,7 @@ public abstract class ObjectAbstractTest {
     @Test
     public void testObjectEqualsSelf() {
         Object obj = makeObject();
-        assertEquals("A Object should equal itself", obj, obj);
+        assertEquals(obj, obj, "A Object should equal itself");
     }
 
     @Test
@@ -131,25 +129,24 @@ public abstract class ObjectAbstractTest {
     @Test
     public void testObjectHashCodeEqualsSelfHashCode() {
         Object obj = makeObject();
-        assertEquals("hashCode should be repeatable", obj.hashCode(), obj.hashCode());
+        assertEquals(obj.hashCode(), obj.hashCode(), "hashCode should be repeatable");
     }
 
     @Test
     public void testObjectHashCodeEqualsContract() {
         Object obj1 = makeObject();
         if (obj1.equals(obj1)) {
-            assertEquals(
-                "[1] When two objects are equal, their hashCodes should be also.",
-                obj1.hashCode(), obj1.hashCode());
+            assertEquals(obj1.hashCode(), obj1.hashCode(),
+                    "[1] When two objects are equal, their hashCodes should be also.");
         }
         Object obj2 = makeObject();
         if (obj1.equals(obj2)) {
             assertEquals(
-                "[2] When two objects are equal, their hashCodes should be also.",
-                obj1.hashCode(), obj2.hashCode());
+                obj1.hashCode(), obj2.hashCode(),
+                    "[2] When two objects are equal, their hashCodes should be also.");
             assertTrue(
-                "When obj1.equals(obj2) is true, then obj2.equals(obj1) should also be true",
-                obj2.equals(obj1));
+                obj2.equals(obj1),
+                    "When obj1.equals(obj2) is true, then obj2.equals(obj1) should also be true");
         }
     }
 
@@ -166,7 +163,7 @@ public abstract class ObjectAbstractTest {
             Object dest = in.readObject();
             in.close();
             if (isEqualsCheckable()) {
-                assertEquals("obj != deserialize(serialize(obj))", obj, dest);
+                assertEquals(obj, dest, "obj != deserialize(serialize(obj))");
             }
         }
     }
@@ -199,8 +196,8 @@ public abstract class ObjectAbstractTest {
             if (object instanceof Serializable) {
                 String name = getCanonicalEmptyCollectionName(object);
                 assertTrue(
-                    "Canonical empty collection (" + name + ") is not in CVS",
-                    new File(name).exists());
+                    new File(name).exists(),
+                        "Canonical empty collection (" + name + ") is not in CVS");
             }
         }
     }
@@ -216,8 +213,8 @@ public abstract class ObjectAbstractTest {
             if (object instanceof Serializable) {
                 String name = getCanonicalFullCollectionName(object);
                 assertTrue(
-                    "Canonical full collection (" + name + ") is not in CVS",
-                    new File(name).exists());
+                    new File(name).exists(),
+                        "Canonical full collection (" + name + ") is not in CVS");
             }
         }
     }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/SetAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/SetAbstractTest.java
@@ -44,12 +44,10 @@
  */
 package com.twelvemonkeys.util;
 
-import org.junit.Test;
-
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Abstract test class for {@link Set} methods and contracts.
@@ -79,14 +77,12 @@ public abstract class SetAbstractTest extends CollectionAbstractTest {
     public void verifyAll() {
         super.verifyAll();
 
-        assertEquals("Sets should be equal", confirmed, collection);
-        assertEquals("Sets should have equal hashCodes",
-                     confirmed.hashCode(), collection.hashCode());
+        assertEquals(confirmed, collection, "Sets should be equal");
+        assertEquals(confirmed.hashCode(), collection.hashCode(), "Sets should have equal hashCodes");
         Collection set = makeConfirmedCollection();
         Iterator iterator = collection.iterator();
         while (iterator.hasNext()) {
-            assertTrue("Set.iterator should only return unique elements",
-                       set.add(iterator.next()));
+            assertTrue(set.add(iterator.next()), "Set.iterator should only return unique elements");
         }
     }
 
@@ -180,23 +176,20 @@ public abstract class SetAbstractTest extends CollectionAbstractTest {
     @Test
     public void testSetEquals() {
         resetEmpty();
-        assertEquals("Empty sets should be equal",
-                     getSet(), getConfirmedSet());
+        assertEquals(getSet(), getConfirmedSet(), "Empty sets should be equal");
         verifyAll();
 
         Collection set2 = makeConfirmedCollection();
         set2.add("foo");
-        assertTrue("Empty set shouldn't equal nonempty set",
-                   !getSet().equals(set2));
+        assertTrue(!getSet().equals(set2), "Empty set shouldn't equal nonempty set");
 
         resetFull();
-        assertEquals("Full sets should be equal", getSet(), getConfirmedSet());
+        assertEquals(getSet(), getConfirmedSet(), "Full sets should be equal");
         verifyAll();
 
         set2.clear();
         set2.addAll(Arrays.asList(getOtherElements()));
-        assertTrue("Sets with different contents shouldn't be equal",
-                   !getSet().equals(set2));
+        assertTrue(!getSet().equals(set2), "Sets with different contents shouldn't be equal");
     }
 
     /**
@@ -205,11 +198,9 @@ public abstract class SetAbstractTest extends CollectionAbstractTest {
     @Test
     public void testSetHashCode() {
         resetEmpty();
-        assertEquals("Empty sets have equal hashCodes",
-                     getSet().hashCode(), getConfirmedSet().hashCode());
+        assertEquals(getSet().hashCode(), getConfirmedSet().hashCode(), "Empty sets have equal hashCodes");
 
         resetFull();
-        assertEquals("Equal sets have equal hashCodes",
-                     getSet().hashCode(), getConfirmedSet().hashCode());
+        assertEquals(getSet().hashCode(), getConfirmedSet().hashCode(), "Equal sets have equal hashCodes");
     }
 }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/StringTokenIteratorTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/StringTokenIteratorTest.java
@@ -30,12 +30,10 @@
 
 package com.twelvemonkeys.util;
 
-
-import org.junit.Test;
-
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * StringTokenIteratorTestCase
@@ -56,88 +54,88 @@ public class StringTokenIteratorTest extends TokenIteratorAbstractTest {
     @Test
     public void testEmptyDelimiter() {
         Iterator iterator = createTokenIterator("", "");
-        assertFalse("Empty string has elements", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "Empty string has elements");
     }
 
     @Test
     public void testSingleToken() {
         Iterator iterator = createTokenIterator("A");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testSingleTokenEmptyDelimiter() {
         Iterator iterator = createTokenIterator("A", "");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testSingleTokenSingleDelimiter() {
         Iterator iterator = createTokenIterator("A", ",");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testSingleSeparatorDefaultDelimiter() {
         Iterator iterator = createTokenIterator("A B C D");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("B", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("C", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("D", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testSingleSeparator() {
         Iterator iterator = createTokenIterator("A,B,C", ",");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("B", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("C", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testMultipleSeparatorDefaultDelimiter() {
         Iterator iterator = createTokenIterator("A B   C\nD\t\t \nE");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("B", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("C", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("D", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("E", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testMultipleSeparator() {
         Iterator iterator = createTokenIterator("A,B,;,C...D, ., ,E", " ,.;:");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("B", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("C", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("D", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("E", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/TimeoutMapTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/TimeoutMapTest.java
@@ -30,12 +30,10 @@
 
 package com.twelvemonkeys.util;
 
-import org.junit.Test;
-
 import java.util.*;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * TimeoutMapTest
  * <p/>
@@ -541,7 +539,7 @@ public class TimeoutMapTest extends MapAbstractTest {
             }
         }
 
-        assertTrue("Elements expired too early, test did not run as expected.", count > 0);
+        assertTrue(count > 0, "Elements expired too early, test did not run as expected.");
         //assertEquals("Elements did not expire as expected.", 1, count);
     }
 
@@ -573,7 +571,7 @@ public class TimeoutMapTest extends MapAbstractTest {
             }
         }
 
-        assertTrue("Elements expired too early, test did not run as expected.", count > 0);
+        assertTrue(count > 0, "Elements expired too early, test did not run as expected.");
         //assertEquals("Elements did not expire as expected.", 1, count);
     }
 
@@ -613,7 +611,7 @@ public class TimeoutMapTest extends MapAbstractTest {
             }
         }
 
-        assertTrue("Elements expired too early, test did not run as expected.", count > 0);
+        assertTrue(count > 0, "Elements expired too early, test did not run as expected.");
         //assertEquals("Elements did not expire as expected.", 1, count);
     }
 
@@ -630,7 +628,7 @@ public class TimeoutMapTest extends MapAbstractTest {
         Object removedKey = null;
         Object otherKey = null;
         Iterator iterator = map.entrySet().iterator();
-        assertTrue("Iterator was empty", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "Iterator was empty");
         try {
             Map.Entry entry = (Map.Entry) iterator.next();
             assertNotNull(entry);
@@ -648,8 +646,8 @@ public class TimeoutMapTest extends MapAbstractTest {
             fail("Elements expired between Interator.hasNext() and Iterator.remove()");
         }
 
-        assertTrue("Wrong entry removed, keySet().iterator() is broken.", !map.containsKey(removedKey));
-        assertTrue("Wrong entry removed, keySet().iterator() is broken.", map.containsKey(otherKey));
+        assertTrue(!map.containsKey(removedKey), "Wrong entry removed, keySet().iterator() is broken.");
+        assertTrue(map.containsKey(otherKey), "Wrong entry removed, keySet().iterator() is broken.");
     }
 
 

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/TokenIteratorAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/TokenIteratorAbstractTest.java
@@ -30,12 +30,10 @@
 
 package com.twelvemonkeys.util;
 
-import org.junit.Test;
-
 import java.util.Iterator;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * TokenIteratorAbstractTestCase
@@ -80,7 +78,7 @@ public abstract class TokenIteratorAbstractTest {
     @Test
     public void testEmptyString() {
         Iterator iterator = createTokenIterator("");
-        assertFalse("Empty string has elements", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "Empty string has elements");
     }
 
 }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/convert/ConverterTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/convert/ConverterTest.java
@@ -30,8 +30,8 @@
 
 package com.twelvemonkeys.util.convert;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * ConverterTest
@@ -43,7 +43,7 @@ import org.junit.Test;
  */
 public class ConverterTest {
 
-    @Ignore("Not implemented")
+    @Disabled("Not implemented")
     @Test
     public void testMe() {
         // TODO: Implement tests

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/convert/DateConverterTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/convert/DateConverterTest.java
@@ -31,7 +31,7 @@
 package com.twelvemonkeys.util.convert;
 
 import com.twelvemonkeys.lang.DateUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.text.DateFormat;
 import java.util.Date;

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/convert/DefaultConverterTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/convert/DefaultConverterTest.java
@@ -31,13 +31,13 @@
 package com.twelvemonkeys.util.convert;
 
 import com.twelvemonkeys.lang.Validate;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import java.io.File;
 import java.net.URI;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * DefaultConverterTest
@@ -138,7 +138,7 @@ public class DefaultConverterTest extends PropertyConverterAbstractTest {
         assertEquals(-2.3456, (Double) converter.toObject("-2.3456", Double.TYPE, null), 0);
     }
 
-    @Ignore("Known issue. Why would anyone do something like this?")
+    @Disabled("Known issue. Why would anyone do something like this?")
     @Test
     public void testConvertCharPrimitive() {
         PropertyConverter converter = makePropertyConverter();

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/convert/PropertyConverterAbstractTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/convert/PropertyConverterAbstractTest.java
@@ -32,11 +32,11 @@ package com.twelvemonkeys.util.convert;
 
 import com.twelvemonkeys.lang.ObjectAbstractTest;
 import com.twelvemonkeys.lang.Validate;
-import org.junit.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PropertyConverterAbstractTest
@@ -66,26 +66,26 @@ public abstract class PropertyConverterAbstractTest extends ObjectAbstractTest {
             try {
                 obj = converter.toObject(test.original(), test.type(), test.format());
 
-                assertEquals(String.format("'%s' converted to incorrect type", test.original()), test.type(), obj.getClass());
+                assertEquals(test.type(), obj.getClass(), String.format("'%s' converted to incorrect type", test.original()));
                 if (test.type().isArray()) {
                     assertArrayEquals0(String.format("'%s' not converted", test.original()), test.value(), obj);
                 }
                 else {
-                    assertEquals(String.format("'%s' not converted", test.original()), test.value(), obj);
+                    assertEquals(test.value(), obj, String.format("'%s' not converted", test.original()));
                 }
 
                 String result = converter.toString(test.value(), test.format());
 
-                assertEquals(String.format("'%s' does not match", test.converted()), test.converted(), result);
+                assertEquals(test.converted(), result, String.format("'%s' does not match", test.converted()));
 
                 obj = converter.toObject(result, test.type(), test.format());
-                assertEquals(String.format("'%s' converted to incorrect type", test.original()), test.type(), obj.getClass());
+                assertEquals(test.type(), obj.getClass(), String.format("'%s' converted to incorrect type", test.original()));
 
                 if (test.type().isArray()) {
                     assertArrayEquals0(String.format("'%s' did not survive round trip conversion", test.original()), test.value(), obj);
                 }
                 else {
-                    assertEquals(String.format("'%s' did not survive round trip conversion", test.original()), test.value(), obj);
+                    assertEquals(test.value(), obj, String.format("'%s' did not survive round trip conversion", test.original()));
                 }
             }
             catch (ConversionException e) {
@@ -98,35 +98,35 @@ public abstract class PropertyConverterAbstractTest extends ObjectAbstractTest {
         Class<?> componentType = left.getClass().getComponentType();
         if (componentType.isPrimitive()) {
             if (int.class == componentType) {
-                assertArrayEquals(message, (int[]) left, (int[]) right);
+                assertArrayEquals((int[]) left, (int[]) right, message);
             }
             else if (short.class == componentType) {
-                assertArrayEquals(message, (short[]) left, (short[]) right);
+                assertArrayEquals((short[]) left, (short[]) right, message);
             }
             else if (long.class == componentType) {
-                assertArrayEquals(message, (long[]) left, (long[]) right);
+                assertArrayEquals((long[]) left, (long[]) right, message);
             }
             else if (float.class == componentType) {
-                assertArrayEquals(message, (float[]) left, (float[]) right, 0f);
+                assertArrayEquals((float[]) left, (float[]) right, 0f, message);
             }
             else if (double.class == componentType) {
-                assertArrayEquals(message, (double[]) left, (double[]) right, 0d);
+                assertArrayEquals((double[]) left, (double[]) right, 0d, message);
             }
             else if (boolean.class == componentType) {
-                assertTrue(message, Arrays.equals((boolean[]) left, (boolean[]) right));
+                assertTrue(Arrays.equals((boolean[]) left, (boolean[]) right), message);
             }
             else if (byte.class == componentType) {
-                assertArrayEquals(message, (byte[]) left, (byte[]) right);
+                assertArrayEquals((byte[]) left, (byte[]) right, message);
             }
             else if (char.class == componentType) {
-                assertArrayEquals(message, (char[]) left, (char[]) right);
+                assertArrayEquals((char[]) left, (char[]) right, message);
             }
             else {
                 fail(String.format("Unknown primitive type: %s", componentType));
             }
         }
         else {
-            assertArrayEquals(message, (Object[]) left, (Object[]) right);
+            assertArrayEquals((Object[]) left, (Object[]) right, message);
         }
     }
 

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/regex/RegExTokenIteratorTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/regex/RegExTokenIteratorTest.java
@@ -32,12 +32,11 @@ package com.twelvemonkeys.util.regex;
 
 import com.twelvemonkeys.util.TokenIterator;
 import com.twelvemonkeys.util.TokenIteratorAbstractTest;
-import org.junit.Test;
 
 import java.util.Iterator;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * StringTokenIteratorTestCase
  * <p/>
@@ -68,9 +67,9 @@ public class RegExTokenIteratorTest extends TokenIteratorAbstractTest {
     @Test
     public void testSingleToken() {
         Iterator iterator = createTokenIterator("A");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
@@ -87,67 +86,67 @@ public class RegExTokenIteratorTest extends TokenIteratorAbstractTest {
     @Test
     public void testSingleTokenSingleDelimiter() {
         Iterator iterator = createTokenIterator("A", "[^,]+");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testSingleSeparatorDefaultDelimiter() {
         Iterator iterator = createTokenIterator("A B C D");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("B", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("C", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("D", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testSingleSeparator() {
         Iterator iterator = createTokenIterator("A,B,C", "[^,]+");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("B", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("C", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testMultipleSeparatorDefaultDelimiter() {
         Iterator iterator = createTokenIterator("A B   C\nD\t\t \nE");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("A", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("B", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("C", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("D", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("E", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 
     @Test
     public void testMultipleSeparator() {
         Iterator iterator = createTokenIterator("A,B,;,C...D, ., ,E", "[^ ,.;:]+");
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         Object o = iterator.next();
         assertEquals("A", o);
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("B", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("C", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("D", iterator.next());
-        assertTrue("String has no elements", iterator.hasNext());
+        assertTrue(iterator.hasNext(), "String has no elements");
         assertEquals("E", iterator.next());
-        assertFalse("String has more than one element", iterator.hasNext());
+        assertFalse(iterator.hasNext(), "String has more than one element");
     }
 }

--- a/common/common-lang/src/test/java/com/twelvemonkeys/util/service/ServiceRegistryTest.java
+++ b/common/common-lang/src/test/java/com/twelvemonkeys/util/service/ServiceRegistryTest.java
@@ -30,12 +30,13 @@
 
 package com.twelvemonkeys.util.service;
 
+import com.twelvemonkeys.lang.Validate;
 import com.twelvemonkeys.util.CollectionUtil;
-import org.junit.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * ServiceRegistryTest
@@ -48,9 +49,11 @@ public class ServiceRegistryTest {
 
     private final TestRegistry registry = new TestRegistry();
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new ServiceRegistry(null);
+        assertThrows(IllegalArgumentException.class, () -> {
+            new ServiceRegistry(null);
+        });
     }
 
     @Test
@@ -64,11 +67,12 @@ public class ServiceRegistryTest {
         }
     }
 
-    @Test(expected = ServiceConfigurationError.class)
+    @Test
     public void testCreateBadConfig() {
-        @SuppressWarnings("unchecked") 
-        ServiceRegistry registry = new ServiceRegistry(Arrays.asList(BadSPI.class).iterator());
-        registry.registerApplicationClasspathSPIs();
+        assertThrows(ServiceConfigurationError.class, () -> {
+            ServiceRegistry registry = new ServiceRegistry(Arrays.asList(BadSPI.class).iterator());
+            registry.registerApplicationClasspathSPIs();
+        });
 
         // DONE: Test non-class
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -45,9 +45,15 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -61,11 +61,16 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/contrib/src/test/java/com/twelvemonkeys/contrib/exif/OrientationTest.java
+++ b/contrib/src/test/java/com/twelvemonkeys/contrib/exif/OrientationTest.java
@@ -1,9 +1,9 @@
 package com.twelvemonkeys.contrib.exif;
 
-import org.junit.Test;
-
 import static com.twelvemonkeys.contrib.exif.Orientation.*;
-import static org.junit.Assert.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * OrientationTest.

--- a/contrib/src/test/java/com/twelvemonkeys/contrib/tiff/TIFFUtilitiesTest.java
+++ b/contrib/src/test/java/com/twelvemonkeys/contrib/tiff/TIFFUtilitiesTest.java
@@ -34,8 +34,6 @@ import com.twelvemonkeys.contrib.tiff.TIFFUtilities.TIFFExtension;
 import com.twelvemonkeys.imageio.plugins.tiff.TIFFImageMetadataFormat;
 import com.twelvemonkeys.io.FileUtil;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.w3c.dom.Node;
 
 import javax.imageio.ImageIO;
@@ -53,6 +51,9 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * TIFFUtilitiesTest
@@ -95,7 +96,7 @@ public class TIFFUtilitiesTest {
         ImageInputStream iis = ImageIO.createImageInputStream(output);
         ImageReader reader = ImageIO.getImageReaders(iis).next();
         reader.setInput(iis);
-        Assert.assertEquals(3, reader.getNumImages(true));
+        assertEquals(3, reader.getNumImages(true));
 
         iis.close();
         output.delete();
@@ -119,11 +120,11 @@ public class TIFFUtilitiesTest {
         ImageReader reader = ImageIO.getImageReadersByFormatName("TIF").next();
 
         File[] outputFiles = outputDirectory.listFiles();
-        Assert.assertEquals(3, outputFiles.length);
+        assertEquals(3, outputFiles.length);
         for (File outputFile : outputFiles) {
             ImageInputStream iis = ImageIO.createImageInputStream(outputFile);
             reader.setInput(iis);
-            Assert.assertEquals(1, reader.getNumImages(true));
+            assertEquals(1, reader.getNumImages(true));
             iis.close();
             outputFile.delete();
         }
@@ -157,7 +158,7 @@ public class TIFFUtilitiesTest {
             Node metaData = reader.getImageMetadata(i)
                     .getAsTree(TIFFImageMetadataFormat.SUN_NATIVE_IMAGE_METADATA_FORMAT_NAME);
             short orientation = ((Number) expression.evaluate(metaData, XPathConstants.NUMBER)).shortValue();
-            Assert.assertEquals(orientation, TIFFExtension.ORIENTATION_RIGHTTOP);
+            assertEquals(orientation, TIFFExtension.ORIENTATION_RIGHTTOP);
         }
         checkTest1.close();
 
@@ -174,7 +175,7 @@ public class TIFFUtilitiesTest {
             Node metaData = reader.getImageMetadata(i)
                     .getAsTree(TIFFImageMetadataFormat.SUN_NATIVE_IMAGE_METADATA_FORMAT_NAME);
             short orientation = ((Number) expression.evaluate(metaData, XPathConstants.NUMBER)).shortValue();
-            Assert.assertEquals(orientation, i == 1
+            assertEquals(orientation, i == 1
                                              ? TIFFExtension.ORIENTATION_BOTRIGHT
                                              : TIFFExtension.ORIENTATION_RIGHTTOP);
         }
@@ -199,7 +200,7 @@ public class TIFFUtilitiesTest {
         byte[] original = ((DataBufferByte) image.getData().getDataBuffer()).getData();
         byte[] rotated = ((DataBufferByte) image360.getData().getDataBuffer()).getData();
 
-        Assert.assertArrayEquals(original, rotated);
+        assertArrayEquals(original, rotated);
     }
 
     @Test

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
@@ -32,16 +32,16 @@ package com.twelvemonkeys.imageio.plugins.svg;
 
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
-import org.junit.Test;
 
 import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * SVGImageReaderSpiTest.
@@ -83,18 +83,20 @@ public class SVGImageReaderSpiTest {
     public void canDecodeInput() throws Exception {
         for (String validInput : VALID_INPUTS) {
             try (ImageInputStream input = ImageIO.createImageInputStream(getClass().getResource(validInput))) {
-                assertTrue("Can't read valid input: " + validInput, provider.canDecodeInput(input));
+                assertTrue(provider.canDecodeInput(input), "Can't read valid input: " + validInput);
             }
         }
     }
 
     // Test will time out, if EOFs are not properly detected, see #275
-    @Test(timeout = 5000)
+    @Test
     public void canDecodeInputInvalid() throws Exception {
-        for (String invalidInput : INVALID_INPUTS) {
-            try (ImageInputStream input = new ByteArrayImageInputStream(invalidInput.getBytes(StandardCharsets.UTF_8))) {
-                assertFalse("Claims to read invalid input:" + invalidInput, provider.canDecodeInput(input));
+        assertTimeout(Duration.ofMillis(5000), () -> {
+            for (String invalidInput : INVALID_INPUTS) {
+                try (ImageInputStream input = new ByteArrayImageInputStream(invalidInput.getBytes(StandardCharsets.UTF_8))) {
+                    assertFalse(provider.canDecodeInput(input), "Claims to read invalid input:" + invalidInput);
+                }
             }
-        }
+        });
     }
 }

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
@@ -91,7 +91,7 @@ public class SVGImageReaderSpiTest {
     // Test will time out, if EOFs are not properly detected, see #275
     @Test
     public void canDecodeInputInvalid() throws Exception {
-        assertTimeout(Duration.ofMillis(5000), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(5000), () -> {
             for (String invalidInput : INVALID_INPUTS) {
                 try (ImageInputStream input = new ByteArrayImageInputStream(invalidInput.getBytes(StandardCharsets.UTF_8))) {
                     assertFalse(provider.canDecodeInput(input), "Claims to read invalid input:" + invalidInput);

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
@@ -312,6 +312,7 @@ public class SVGImageReaderTest extends ImageReaderAbstractTest<SVGImageReader> 
         }
     }
 
+    @Test
     public void testDisallowedExternalResources() throws URISyntaxException, IOException {
         // system-property set to true in surefire-plugin-settings in the pom
         URL resource = getClassLoaderResource("/svg/barChart.svg");

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderTest.java
@@ -32,9 +32,6 @@ package com.twelvemonkeys.imageio.plugins.svg;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import javax.imageio.IIOException;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
@@ -52,10 +49,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -128,18 +124,18 @@ public class SVGImageReaderTest extends ImageReaderAbstractTest<SVGImageReader> 
                 int current = image.getRGB(x, y);
                 if (x < quadPoint) {
                     if (y < quadPoint) {
-                        assertEquals("x=" + x + " y=" + y + " q=" + quadPoint, 0xFF0000FF, current);
+                        assertEquals( 0xFF0000FF, current, "x=" + x + " y=" + y + " q=" + quadPoint);
                     }
                     else {
-                        assertEquals("x=" + x + " y=" + y + " q=" + quadPoint, 0xFFFF0000, current);
+                        assertEquals(0xFFFF0000, current, "x=" + x + " y=" + y + " q=" + quadPoint);
                     }
                 }
                 else {
                     if (y < quadPoint) {
-                        assertEquals("x=" + x + " y=" + y + " q=" + quadPoint, 0xFF00FF00, current);
+                        assertEquals(0xFF00FF00, current, "x=" + x + " y=" + y + " q=" + quadPoint);
                     }
                     else {
-                        assertEquals("x=" + x + " y=" + y + " q=" + quadPoint, 0xFF000000, current);
+                        assertEquals(0xFF000000, current, "x=" + x + " y=" + y + " q=" + quadPoint);
                     }
                 }
             }
@@ -171,14 +167,14 @@ public class SVGImageReaderTest extends ImageReaderAbstractTest<SVGImageReader> 
     }
 
     @Test
-    @Ignore("Known issue: Source region reading not supported")
+    @Disabled("Known issue: Source region reading not supported")
     @Override
     public void testReadWithSourceRegionParamEqualImage() throws IOException {
         super.testReadWithSourceRegionParamEqualImage();
     }
 
     @Test
-    @Ignore("Known issue: Subsampled reading not supported")
+    @Disabled("Known issue: Subsampled reading not supported")
     @Override
     public void testReadWithSubsampleParamPixels() throws IOException {
         super.testReadWithSubsampleParamPixels();
@@ -316,7 +312,6 @@ public class SVGImageReaderTest extends ImageReaderAbstractTest<SVGImageReader> 
         }
     }
 
-    @Test(expected = SecurityException.class)
     public void testDisallowedExternalResources() throws URISyntaxException, IOException {
         // system-property set to true in surefire-plugin-settings in the pom
         URL resource = getClassLoaderResource("/svg/barChart.svg");
@@ -333,7 +328,9 @@ public class SVGImageReaderTest extends ImageReaderAbstractTest<SVGImageReader> 
             // `reader.read` for `/svg/barChart.svg` should raise
             // a SecurityException when External Resources are blocked
             // because the API invocation gets preference
-            reader.read(0, param);
+            assertThrows(SecurityException.class, () -> {
+                reader.read(0, param);
+            });
         }
         finally {
             reader.dispose();

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/wmf/WMFImageReaderTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/wmf/WMFImageReaderTest.java
@@ -32,9 +32,6 @@ package com.twelvemonkeys.imageio.plugins.wmf;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import javax.imageio.spi.ImageReaderSpi;
 import java.awt.*;
 import java.io.IOException;
@@ -42,6 +39,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 /**
  * WMFImageReaderTest
  *
@@ -77,14 +76,14 @@ public class WMFImageReaderTest extends ImageReaderAbstractTest<WMFImageReader> 
     }
 
     @Test
-    @Ignore("Known issue: Source region reading not supported")
+    @Disabled("Known issue: Source region reading not supported")
     @Override
     public void testReadWithSourceRegionParamEqualImage() throws IOException {
         super.testReadWithSourceRegionParamEqualImage();
     }
 
     @Test
-    @Ignore("Known issue: Subsampled reading not supported")
+    @Disabled("Known issue: Subsampled reading not supported")
     @Override
     public void testReadWithSubsampleParamPixels() throws IOException {
         super.testReadWithSubsampleParamPixels();

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderTest.java
@@ -267,8 +267,8 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
         BMPImageReader reader = createReader();
 
         try {
+            reader.setInput(ImageIO.createImageInputStream(getClassLoaderResource("/broken-bmp/corrupted-bmp.bmp")));
             assertThrows(IIOException.class, () -> {
-                reader.setInput(ImageIO.createImageInputStream(getClassLoaderResource("/broken-bmp/corrupted-bmp.bmp")));
                 reader.read(0);
             });
         }

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderTest.java
@@ -34,7 +34,6 @@ import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 import com.twelvemonkeys.xml.XMLSerializer;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
 import org.mockito.InOrder;
 import org.w3c.dom.Node;
@@ -61,6 +60,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -333,7 +333,7 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
         catch (Exception e) {
             e.printStackTrace();
             // Ignore this test if not on an Oracle JRE (com.sun...BMPImageReader not available)
-            Assumptions.assumeTrue(false, "Skipping test: BMPImageReaderSpi not available on non-Oracle JREs");
+            assumeTrue(false, "Skipping test: BMPImageReaderSpi not available on non-Oracle JREs");
             return;
         }
 

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/BMPImageReaderTest.java
@@ -33,8 +33,9 @@ package com.twelvemonkeys.imageio.plugins.bmp;
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 import com.twelvemonkeys.xml.XMLSerializer;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.mockito.InOrder;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -59,8 +60,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeNoException;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyFloat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -204,11 +204,11 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
                 }
             }
 
-            assertTrue("ImageTypeSepcifier from getRawImageType should be in the iterator from getImageTypes", rawFound);
+            assertTrue(rawFound, "ImageTypeSepcifier from getRawImageType should be in the iterator from getImageTypes");
         }
     }
 
-    @Ignore("Known issue: Subsampled reading is currently broken")
+    @Disabled("Known issue: Subsampled reading is currently broken")
     @Test
     public void testReadWithSubsampleParamPixelsIndexed8() throws IOException {
         ImageReader reader = createReader();
@@ -235,7 +235,7 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
     // TODO: 1. Subsampling is currently broken, should fix it.
     //       2. BMPs are (normally) stored bottom/up, meaning y subsampling offsets will differ from normal
     //          subsampling of the same data with an offset... Should we deal with this in the reader? Yes?
-    @Ignore("Known issue: Subsampled reading is currently broken")
+    @Disabled("Known issue: Subsampled reading is currently broken")
     @Test
     @Override
     public void testReadWithSubsampleParamPixels() throws IOException {
@@ -260,15 +260,17 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
         assertSubsampledImageDataEquals("Subsampled image data does not match expected", image, subsampled, param);
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testReadCorruptCausesIIOException() throws IOException {
         // See https://bugs.openjdk.java.net/browse/JDK-8066904
         // NullPointerException when calling ImageIO.read(InputStream) with corrupt BMP
         BMPImageReader reader = createReader();
 
         try {
-            reader.setInput(ImageIO.createImageInputStream(getClassLoaderResource("/broken-bmp/corrupted-bmp.bmp")));
-            reader.read(0);
+            assertThrows(IIOException.class, () -> {
+                reader.setInput(ImageIO.createImageInputStream(getClassLoaderResource("/broken-bmp/corrupted-bmp.bmp")));
+                reader.read(0);
+            });
         }
         finally {
             reader.dispose();
@@ -331,7 +333,7 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
         catch (Exception e) {
             e.printStackTrace();
             // Ignore this test if not on an Oracle JRE (com.sun...BMPImageReader not available)
-            assumeNoException(e);
+            Assumptions.assumeTrue(false, "Skipping test: BMPImageReaderSpi not available on non-Oracle JREs");
             return;
         }
 
@@ -383,7 +385,7 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
                     new XMLSerializer(expected, "UTF-8").serialize(expectedTree, false);
                     new XMLSerializer(actual, "UTF-8").serialize(actualTree, false);
 
-                    assertEquals(e.getMessage(), new String(expected.toByteArray(), StandardCharsets.UTF_8), new String(actual.toByteArray(), StandardCharsets.UTF_8));
+                    assertEquals(new String(expected.toByteArray(), StandardCharsets.UTF_8), new String(actual.toByteArray(), StandardCharsets.UTF_8), e.getMessage());
 
                     throw e;
                 }
@@ -392,24 +394,24 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
     }
 
     private void assertNodeEquals(final String message, final Node expected, final Node actual) {
-        assertEquals(message + " class differs", expected.getClass(), actual.getClass());
+        assertEquals(expected.getClass(), actual.getClass(), message + " class differs");
 
         if (!excludeEqualValueTest(expected)) {
-            assertEquals(message, expected.getNodeValue(), actual.getNodeValue());
+            assertEquals(expected.getNodeValue(), actual.getNodeValue(), message);
 
             if (expected instanceof IIOMetadataNode) {
                 IIOMetadataNode expectedIIO = (IIOMetadataNode) expected;
                 IIOMetadataNode actualIIO = (IIOMetadataNode) actual;
 
-                assertEquals(message, expectedIIO.getUserObject(), actualIIO.getUserObject());
+                assertEquals(expectedIIO.getUserObject(), actualIIO.getUserObject(), message);
             }
         }
 
         NodeList expectedChildNodes = expected.getChildNodes();
         NodeList actualChildNodes = actual.getChildNodes();
 
-        assertTrue(message + " child length differs: " + toString(expectedChildNodes) + " != " + toString(actualChildNodes),
-                expectedChildNodes.getLength() <= actualChildNodes.getLength());
+        assertTrue(expectedChildNodes.getLength() <= actualChildNodes.getLength(),
+                message + " child length differs: " + toString(expectedChildNodes) + " != " + toString(actualChildNodes));
 
         for (int i = 0; i < expectedChildNodes.getLength(); i++) {
             Node expectedChild = expectedChildNodes.item(i);
@@ -423,7 +425,7 @@ public class BMPImageReaderTest extends ImageReaderAbstractTest<BMPImageReader> 
                 }
             }
 
-            assertEquals(message + " node name differs", expectedChild.getLocalName(), actualChild.getLocalName());
+            assertEquals(expectedChild.getLocalName(), actualChild.getLocalName(), message + " node name differs");
             assertNodeEquals(message + "/" + expectedChild.getLocalName(), expectedChild, actualChild);
         }
     }

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/CURImageReaderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/CURImageReaderTest.java
@@ -32,9 +32,6 @@ package com.twelvemonkeys.imageio.plugins.bmp;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import javax.imageio.ImageReadParam;
 import javax.imageio.spi.ImageReaderSpi;
 import java.awt.*;
@@ -44,7 +41,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * CURImageReaderTest
@@ -93,16 +92,16 @@ public class CURImageReaderTest extends ImageReaderAbstractTest<CURImageReader> 
         if (hotspot != Image.UndefinedProperty || pParam == null) {
 
             // Typically never happens, because of weirdness with UndefinedProperty
-            assertNotNull("Hotspot for cursor not present", hotspot);
+            assertNotNull(hotspot, "Hotspot for cursor not present");
 
             // Image weirdness
-            assertNotSame("Hotspot for cursor undefined (java.awt.Image.UndefinedProperty)", Image.UndefinedProperty, hotspot);
+            assertNotSame(Image.UndefinedProperty, hotspot, "Hotspot for cursor undefined (java.awt.Image.UndefinedProperty)");
 
-            assertTrue(String.format("Hotspot not a java.awt.Point: %s", hotspot.getClass()), hotspot instanceof Point);
+            assertTrue(hotspot instanceof Point, String.format("Hotspot not a java.awt.Point: %s", hotspot.getClass()));
             assertEquals(pExpected, hotspot);
         }
 
-        assertNotNull("Hotspot for cursor not present", reader.getHotSpot(0));
+        assertNotNull(reader.getHotSpot(0), "Hotspot for cursor not present");
         assertEquals(pExpected, reader.getHotSpot(0));
     }
 
@@ -141,14 +140,14 @@ public class CURImageReaderTest extends ImageReaderAbstractTest<CURImageReader> 
     // TODO: Test cursor is transparent
 
     @Test
-    @Ignore("Known issue")
+    @Disabled("Known issue")
     @Override
     public void testNotBadCaching() throws IOException {
         super.testNotBadCaching();
     }
 
     @Test
-    @Ignore("Known issue: Subsampled reading currently not supported")
+    @Disabled("Known issue: Subsampled reading currently not supported")
     @Override
     public void testReadWithSubsampleParamPixels() throws IOException {
         super.testReadWithSubsampleParamPixels();

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/ICOImageReaderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/ICOImageReaderTest.java
@@ -32,15 +32,15 @@ package com.twelvemonkeys.imageio.plugins.bmp;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import javax.imageio.spi.ImageReaderSpi;
 import java.awt.*;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * ICOImageReaderTest
@@ -98,14 +98,14 @@ public class ICOImageReaderTest extends ImageReaderAbstractTest<ICOImageReader> 
     }
 
     @Test
-    @Ignore("Known issue")
+    @Disabled("Known issue")
     @Override
     public void testNotBadCaching() throws IOException {
         super.testNotBadCaching();
     }
 
     @Test
-    @Ignore("Known issue: Subsampled reading currently not supported")
+    @Disabled("Known issue: Subsampled reading currently not supported")
     @Override
     public void testReadWithSubsampleParamPixels() throws IOException {
         super.testReadWithSubsampleParamPixels();

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/RLE4DecoderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/RLE4DecoderTest.java
@@ -32,7 +32,6 @@ package com.twelvemonkeys.imageio.plugins.bmp;
 
 import com.twelvemonkeys.io.enc.Decoder;
 import com.twelvemonkeys.io.enc.DecoderStream;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -42,8 +41,8 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RLE4DecoderTest {
 
@@ -82,8 +81,8 @@ public class RLE4DecoderTest {
             int r = channel.read(plain);
             plain.rewind();
 
-            assertEquals("Difference at line " + i, r, d);
-            assertArrayEquals("Difference at line " + i, plain.array(), decoded.array());
+            assertEquals(r, d, "Difference at line " + i);
+            assertArrayEquals(plain.array(), decoded.array(), "Difference at line " + i);
         }
     }
 
@@ -104,7 +103,7 @@ public class RLE4DecoderTest {
         int pos = 0;
         while (true) {
             int expected = plainSream.read();
-            assertEquals("Differs at " + pos, expected, decoded.read());
+            assertEquals(expected, decoded.read(), "Differs at " + pos);
 
             if (expected < 0) {
                 break;

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/RLE8DecoderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/RLE8DecoderTest.java
@@ -32,7 +32,6 @@ package com.twelvemonkeys.imageio.plugins.bmp;
 
 import com.twelvemonkeys.io.enc.Decoder;
 import com.twelvemonkeys.io.enc.DecoderStream;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -42,8 +41,8 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RLE8DecoderTest {
 
@@ -108,7 +107,7 @@ public class RLE8DecoderTest {
         while (true) {
             int expected = plainSream.read();
 
-            assertEquals("Differs at " + pos, expected, decoded.read());
+            assertEquals(expected, decoded.read(), "Differs at " + pos);
 
             if (expected < 0) {
                 break;

--- a/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathBuilderTest.java
+++ b/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathBuilderTest.java
@@ -30,8 +30,6 @@
 
 package com.twelvemonkeys.imageio.path;
 
-import org.junit.Test;
-
 import javax.imageio.IIOException;
 import javax.imageio.stream.ImageInputStream;
 import java.awt.geom.Path2D;
@@ -39,36 +37,39 @@ import java.io.DataInput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static com.twelvemonkeys.imageio.path.PathsTest.assertPathEquals;
 import static com.twelvemonkeys.imageio.path.PathsTest.readExpectedPath;
-import static org.junit.Assert.assertNotNull;
 
 @SuppressWarnings("deprecation")
 public class AdobePathBuilderTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullBytes() {
-        new AdobePathBuilder((byte[]) null);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathBuilder((byte[]) null));
+
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new AdobePathBuilder((DataInput) null);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathBuilder((DataInput) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateEmpty() {
-        new AdobePathBuilder(new byte[0]);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathBuilder(new byte[0]));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateShortPath() {
-        new AdobePathBuilder(new byte[3]);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathBuilder(new byte[3]));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateImpossiblePath() {
-        new AdobePathBuilder(new byte[7]);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathBuilder(new byte[7]));
     }
 
     @Test
@@ -82,18 +83,20 @@ public class AdobePathBuilderTest {
         assertNotNull(path);
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testShortPath() throws IOException {
         byte[] data = new byte[26];
         ByteBuffer buffer = ByteBuffer.wrap(data);
         buffer.putShort((short) AdobePathSegment.CLOSED_SUBPATH_LENGTH_RECORD);
         buffer.putShort((short) 1);
 
-        Path2D path = new AdobePathBuilder(data).path();
-        assertNotNull(path);
+        assertThrows(IIOException.class, () -> {
+            Path2D path = new AdobePathBuilder(data).path();
+            assertNotNull(path);
+        });
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testShortPathToo() throws IOException {
         byte[] data = new byte[52];
         ByteBuffer buffer = ByteBuffer.wrap(data);
@@ -102,11 +105,13 @@ public class AdobePathBuilderTest {
         buffer.position(buffer.position() + 22);
         buffer.putShort((short) AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED);
 
-        Path2D path = new AdobePathBuilder(data).path();
-        assertNotNull(path);
+        assertThrows(IIOException.class, () -> {
+            Path2D path = new AdobePathBuilder(data).path();
+            assertNotNull(path);
+        });
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testLongPath() throws IOException {
         byte[] data = new byte[78];
         ByteBuffer buffer = ByteBuffer.wrap(data);
@@ -117,18 +122,22 @@ public class AdobePathBuilderTest {
         buffer.position(buffer.position() + 24);
         buffer.putShort((short) AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED);
 
-        Path2D path = new AdobePathBuilder(data).path();
-        assertNotNull(path);
+        assertThrows(IIOException.class, () -> {
+            Path2D path = new AdobePathBuilder(data).path();
+            assertNotNull(path);
+        });
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testPathMissingLength() throws IOException {
         byte[] data = new byte[26];
         ByteBuffer buffer = ByteBuffer.wrap(data);
         buffer.putShort((short) AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED);
 
-        Path2D path = new AdobePathBuilder(data).path();
-        assertNotNull(path);
+        assertThrows(IIOException.class, () -> {
+            Path2D path = new AdobePathBuilder(data).path();
+            assertNotNull(path);
+        });
     }
 
     @Test

--- a/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathReaderTest.java
+++ b/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathReaderTest.java
@@ -31,7 +31,6 @@
 
 package com.twelvemonkeys.imageio.path;
 
-import org.junit.Test;
 
 import javax.imageio.IIOException;
 import javax.imageio.stream.ImageInputStream;
@@ -39,36 +38,37 @@ import java.awt.geom.Path2D;
 import java.io.DataInput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static com.twelvemonkeys.imageio.path.PathsTest.assertPathEquals;
 import static com.twelvemonkeys.imageio.path.PathsTest.readExpectedPath;
-import static org.junit.Assert.assertNotNull;
 
 public class AdobePathReaderTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullBytes() {
-        new AdobePathReader((byte[]) null);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathReader((byte[]) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new AdobePathReader((DataInput) null);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathReader((DataInput) null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateEmpty() {
-        new AdobePathReader(new byte[0]);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathReader(new byte[0]));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateShortPath() {
-        new AdobePathReader(new byte[3]);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathReader(new byte[3]));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateImpossiblePath() {
-        new AdobePathReader(new byte[7]);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathReader(new byte[7]));
     }
 
     @Test
@@ -82,18 +82,20 @@ public class AdobePathReaderTest {
         assertNotNull(path);
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testShortPath() throws IOException {
         byte[] data = new byte[26];
         ByteBuffer buffer = ByteBuffer.wrap(data);
         buffer.putShort((short) AdobePathSegment.CLOSED_SUBPATH_LENGTH_RECORD);
         buffer.putShort((short) 1);
 
-        Path2D path = new AdobePathReader(data).readPath();
-        assertNotNull(path);
+        assertThrows(IIOException.class, () -> {
+            Path2D path = new AdobePathReader(data).readPath();
+            assertNotNull(path);
+        });
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testShortPathToo() throws IOException {
         byte[] data = new byte[52];
         ByteBuffer buffer = ByteBuffer.wrap(data);
@@ -102,11 +104,13 @@ public class AdobePathReaderTest {
         buffer.position(buffer.position() + 22);
         buffer.putShort((short) AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED);
 
-        Path2D path = new AdobePathReader(data).readPath();
-        assertNotNull(path);
+        assertThrows(IIOException.class, () -> {
+            Path2D path = new AdobePathReader(data).readPath();
+            assertNotNull(path);
+        });
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testLongPath() throws IOException {
         byte[] data = new byte[78];
         ByteBuffer buffer = ByteBuffer.wrap(data);
@@ -117,18 +121,22 @@ public class AdobePathReaderTest {
         buffer.position(buffer.position() + 24);
         buffer.putShort((short) AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED);
 
-        Path2D path = new AdobePathReader(data).readPath();
-        assertNotNull(path);
+        assertThrows(IIOException.class, () -> {
+            Path2D path = new AdobePathReader(data).readPath();
+            assertNotNull(path);
+        });
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testPathMissingLength() throws IOException {
         byte[] data = new byte[26];
         ByteBuffer buffer = ByteBuffer.wrap(data);
         buffer.putShort((short) AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED);
 
-        Path2D path = new AdobePathReader(data).readPath();
-        assertNotNull(path);
+        assertThrows(IIOException.class, () -> {
+            Path2D path = new AdobePathReader(data).readPath();
+            assertNotNull(path);
+        });
     }
 
     @Test

--- a/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathSegmentTest.java
+++ b/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathSegmentTest.java
@@ -30,9 +30,9 @@
 
 package com.twelvemonkeys.imageio.path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * AdobePathSegmentTest.
@@ -42,19 +42,20 @@ import static org.junit.Assert.*;
  * @version $Id: AdobePathSegmentTest.java,v 1.0 13/12/14 harald.kuhr Exp$
  */
 public class AdobePathSegmentTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateBadSelectorNegative() {
-        new AdobePathSegment(-1, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(-1, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateBadSelector() {
-        new AdobePathSegment(9, 2);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(9, 2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateOpenLengthRecordNegative() {
-        new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_LENGTH_RECORD, -1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_LENGTH_RECORD, -1));
+
 
     }
 
@@ -72,9 +73,9 @@ public class AdobePathSegmentTest {
         assertEquals(-1, segment.cply, 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateClosedLengthRecordNegative() {
-        new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_LENGTH_RECORD, -42);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_LENGTH_RECORD, -42));
     }
 
     @Test
@@ -107,19 +108,19 @@ public class AdobePathSegmentTest {
         assertEquals(1, segment.cply, 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateOpenLinkedRecordBad() {
-        new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_LINKED, 44);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_LINKED, 44));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateOpenLinkedRecordOutOfRangeNegative() {
-        new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_LINKED, -16.1, -16.1, 0, 0, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_LINKED, -16.1, -16.1, 0, 0, 1, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateOpenLinkedRecordOutOfRangePositive() {
-        new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_LINKED, 16.1, 16.1, 0, 0, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_LINKED, 16.1, 16.1, 0, 0, 1, 1));
     }
 
     @Test
@@ -136,20 +137,20 @@ public class AdobePathSegmentTest {
         assertEquals(1, segment.cply, 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateOpenUnlinkedRecordBad() {
-        new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_UNLINKED, 44);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_UNLINKED, 44));
     }
 
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateOpenUnlinkedRecordOutOfRangeNegative() {
-        new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_UNLINKED, -16.5, 0, 0, 0, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_UNLINKED, -16.5, 0, 0, 0, 1, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateOpenUnlinkedRecorOutOfRangePositive() {
-        new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_UNLINKED, 0, -17, 0, 0, 16.5, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_UNLINKED, 0, -17, 0, 0, 16.5, 1));
     }
 
     /// Closed subpath
@@ -168,19 +169,19 @@ public class AdobePathSegmentTest {
         assertEquals(1, segment.cply, 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateClosedLinkedRecordBad() {
-        new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED, 44);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED, 44));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateClosedLinkedRecordOutOfRangeNegative() {
-        new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED, -16.5, -.5, 0, 0, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED, -16.5, -.5, 0, 0, 1, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateClosedLinkedRecordOutOfRangePositive() {
-        new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED, .5, 16.5, 0, 0, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED, .5, 16.5, 0, 0, 1, 1));
     }
 
     @Test
@@ -197,59 +198,59 @@ public class AdobePathSegmentTest {
         assertEquals(1, segment.cply, 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateClosedUnlinkedRecordBad() {
-        new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_UNLINKED, 44);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_UNLINKED, 44));
     }
 
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateClosedUnlinkedRecordOutOfRangeNegative() {
-        new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_UNLINKED, -.5, -16.5, 0, 0, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_UNLINKED, -.5, -16.5, 0, 0, 1, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateClosedUnlinkedRecordOutOfRangePositive() {
-        new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_UNLINKED, 16.5, .5, 0, 0, 1, 1);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_UNLINKED, 16.5, .5, 0, 0, 1, 1));
     }
 
     @Test
     public void testToStringRule() {
         String string = new AdobePathSegment(AdobePathSegment.INITIAL_FILL_RULE_RECORD, 0).toString();
-        assertTrue(string, string.startsWith("Rule"));
-        assertTrue(string, string.contains("Initial"));
-        assertTrue(string, string.contains("fill"));
-        assertTrue(string, string.contains("rule=0"));
+        assertTrue(string.startsWith("Rule"), string);
+        assertTrue(string.contains("Initial"), string);
+        assertTrue(string.contains("fill"), string);
+        assertTrue(string.contains("rule=0"), string);
     }
 
     @Test
     public void testToStringLength() {
         String string = new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_LENGTH_RECORD, 2).toString();
-        assertTrue(string, string.startsWith("Len"));
-        assertTrue(string, string.contains("Closed"));
-        assertTrue(string, string.contains("subpath"));
-        assertTrue(string, string.contains("length=2"));
+        assertTrue(string.startsWith("Len"), string);
+        assertTrue(string.contains("Closed"), string);
+        assertTrue(string.contains("subpath"), string);
+        assertTrue(string.contains("length=2"), string);
 
         string = new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_LENGTH_RECORD, 42).toString();
-        assertTrue(string, string.startsWith("Len"));
-        assertTrue(string, string.contains("Open"));
-        assertTrue(string, string.contains("subpath"));
-        assertTrue(string, string.contains("length=42"));
+        assertTrue(string.startsWith("Len"), string);
+        assertTrue(string.contains("Open"), string);
+        assertTrue(string.contains("subpath"), string);
+        assertTrue(string.contains("length=42"), string);
     }
 
     @Test
     public void testToStringOther() {
         String string = new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_BEZIER_LINKED, 0, 0, 1, 1, 0, 0).toString();
-        assertTrue(string, string.startsWith("Pt"));
-        assertTrue(string, string.contains("Open"));
-        assertTrue(string, string.contains("Bezier"));
-        assertTrue(string, string.contains("linked"));
+        assertTrue(string.startsWith("Pt"), string);
+        assertTrue(string.contains("Open"), string);
+        assertTrue(string.contains("Bezier"), string);
+        assertTrue(string.contains("linked"), string);
 
         string = new AdobePathSegment(AdobePathSegment.CLOSED_SUBPATH_BEZIER_LINKED, 0, 0, 1, 1, 0, 0).toString();
-        assertTrue(string, string.startsWith("Pt"));
-        assertTrue(string, string.contains("Closed"));
-        assertTrue(string, string.contains("Bezier"));
-        assertTrue(string, string.contains("linked"));
+        assertTrue(string.startsWith("Pt"), string);
+        assertTrue(string.contains("Closed"), string);
+        assertTrue(string.contains("Bezier"), string);
+        assertTrue(string.contains("linked"), string);
     }
 
     @Test

--- a/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathSegmentTest.java
+++ b/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathSegmentTest.java
@@ -55,8 +55,6 @@ public class AdobePathSegmentTest {
     @Test
     public void testCreateOpenLengthRecordNegative() {
         assertThrows(IllegalArgumentException.class, () -> new AdobePathSegment(AdobePathSegment.OPEN_SUBPATH_LENGTH_RECORD, -1));
-
-
     }
 
     @Test

--- a/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathWriterTest.java
+++ b/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/AdobePathWriterTest.java
@@ -31,7 +31,6 @@
 package com.twelvemonkeys.imageio.path;
 
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
-import org.junit.Test;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
@@ -41,11 +40,11 @@ import java.awt.geom.*;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import org.junit.jupiter.api.Test;
 
 import static com.twelvemonkeys.imageio.path.AdobePathSegment.*;
 import static com.twelvemonkeys.imageio.path.PathsTest.assertPathEquals;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * AdobePathWriterTest.
@@ -56,22 +55,22 @@ import static org.junit.Assert.assertEquals;
  */
 public class AdobePathWriterTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateWriterNull() {
-        new AdobePathWriter(null);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathWriter(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateWriterInvalid() {
-        new AdobePathWriter(new Path2D.Double(Path2D.WIND_NON_ZERO));
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathWriter(new Path2D.Double(Path2D.WIND_NON_ZERO)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateWriterOutOfBounds() {
         Path2D path = new Path2D.Float(Path2D.WIND_EVEN_ODD);
         path.append(new Ellipse2D.Double(.5, 0.5, 2, 2), false);
 
-        new AdobePathWriter(path);
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathWriter(path));
     }
 
     @Test
@@ -93,14 +92,14 @@ public class AdobePathWriterTest {
         new AdobePathWriter(path);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNotClosed() {
         GeneralPath path = new GeneralPath(Path2D.WIND_EVEN_ODD);
         path.moveTo(.5, .5);
         path.lineTo(1, .5);
         path.curveTo(1, 1, 1, 1, .5, 1);
 
-        new AdobePathWriter(path).writePath();
+        assertThrows(IllegalArgumentException.class, () -> new AdobePathWriter(path).writePath());
     }
 
     @Test

--- a/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/PathsTest.java
+++ b/imageio/imageio-clippath/src/test/java/com/twelvemonkeys/imageio/path/PathsTest.java
@@ -33,7 +33,6 @@ package com.twelvemonkeys.imageio.path;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.imageio.stream.SubImageInputStream;
 import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
-import org.junit.Test;
 
 import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
@@ -48,8 +47,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assumptions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PathsTest.
@@ -63,9 +63,9 @@ public class PathsTest {
         IIORegistry.getDefaultInstance().registerServiceProvider(new URLImageInputStreamSpi());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadPathNull() throws IOException {
-        Paths.readPath(null);
+        assertThrows(IllegalArgumentException.class, () -> Paths.readPath(null));
     }
 
     @Test
@@ -127,14 +127,14 @@ public class PathsTest {
         assertPathEquals(readExpectedPath("/ser/grape-path.ser"), path);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testApplyClippingPathNullPath() {
-        Paths.applyClippingPath(null, new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_GRAY));
+        assertThrows(IllegalArgumentException.class, () -> Paths.applyClippingPath(null, new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_GRAY)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testApplyClippingPathNullSource() {
-        Paths.applyClippingPath(new GeneralPath(), null);
+        assertThrows(IllegalArgumentException.class, () -> Paths.applyClippingPath(new GeneralPath(), null));
     }
 
     @Test
@@ -165,9 +165,9 @@ public class PathsTest {
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testApplyClippingPathNullDestination() {
-        Paths.applyClippingPath(new GeneralPath(), new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_GRAY), null);
+        assertThrows(IllegalArgumentException.class, () -> Paths.applyClippingPath(new GeneralPath(), new BufferedImage(1, 1, BufferedImage.TYPE_BYTE_GRAY), null));
     }
 
     @Test
@@ -199,9 +199,9 @@ public class PathsTest {
         // TODO: Mor sophisticated test that tests all pixels outside path...
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadClippedNull() throws IOException {
-        Paths.readClipped(null);
+        assertThrows(IllegalArgumentException.class, () -> Paths.readClipped(null));
     }
 
     @Test
@@ -243,7 +243,7 @@ public class PathsTest {
     }
 
     static void assertPathEquals(final Path2D expectedPath, final Path2D actualPath) {
-        assertNotNull("Expected path is null, check your tests...", expectedPath);
+        assertNotNull(expectedPath, "Expected path is null, check your tests...");
         assertNotNull(actualPath);
 
         PathIterator expectedIterator = expectedPath.getPathIterator(null);
@@ -253,19 +253,19 @@ public class PathsTest {
         float[] actualCoords = new float[6];
 
         while(!expectedIterator.isDone()) {
-            assertFalse("Less points than expected", actualIterator.isDone());
+            assertFalse(actualIterator.isDone(), "Less points than expected");
 
             int expectedType = expectedIterator.currentSegment(expectedCoords);
             int actualType = actualIterator.currentSegment(actualCoords);
 
-            assertEquals("Unexpected segment type", expectedType, actualType);
-            assertArrayEquals("Unexpected coordinates", expectedCoords, actualCoords, 0);
+            assertEquals( expectedType, actualType, "Unexpected segment type");
+            assertArrayEquals(expectedCoords, actualCoords, 0, "Unexpected coordinates");
 
             actualIterator.next();
             expectedIterator.next();
         }
 
-        assertTrue("More points than expected", actualIterator.isDone());
+        assertTrue( actualIterator.isDone(), "More points than expected");
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/ImageReaderBaseTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/ImageReaderBaseTest.java
@@ -30,11 +30,9 @@
 
 package com.twelvemonkeys.imageio;
 
-import static java.util.Collections.singleton;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
+import static java.util.Collections.singleton;
+import static org.junit.jupiter.api.Assertions.*;
 import java.awt.*;
 import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
@@ -48,7 +46,7 @@ import javax.imageio.IIOException;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageTypeSpecifier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * ImageReaderBaseTest
@@ -64,36 +62,36 @@ public class ImageReaderBaseTest {
             ImageTypeSpecifier.createFromBufferedImageType(BufferedImage.TYPE_INT_ARGB)
     );
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDestinationZeroWidth() throws IIOException {
-        ImageReaderBase.getDestination(null, TYPES.iterator(), 0, 42);
+        assertThrows(IllegalArgumentException.class, () -> ImageReaderBase.getDestination(null, TYPES.iterator(), 0, 42));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDestinationNegativeWidth() throws IIOException {
-        ImageReaderBase.getDestination(null, TYPES.iterator(), -1, 42);
+        assertThrows(IllegalArgumentException.class, () -> ImageReaderBase.getDestination(null, TYPES.iterator(), -1, 42));
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDestinationZeroHeight() throws IIOException {
-        ImageReaderBase.getDestination(null, TYPES.iterator(), 42, 0);
+        assertThrows(IllegalArgumentException.class, () -> ImageReaderBase.getDestination(null, TYPES.iterator(), 42, 0));
 
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDestinationNegativeHeight() throws IIOException {
-        ImageReaderBase.getDestination(null, TYPES.iterator(), 42, -1);
+        assertThrows(IllegalArgumentException.class, () -> ImageReaderBase.getDestination(null, TYPES.iterator(), 42, -1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDestinationNullTypes() throws IIOException {
-        ImageReaderBase.getDestination(null, null, 42, 42);
+        assertThrows(IllegalArgumentException.class, () -> ImageReaderBase.getDestination(null, null, 42, 42));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetDestinationNoTypes() throws IIOException {
-        ImageReaderBase.getDestination(null, Collections.<ImageTypeSpecifier>emptyList().iterator(), 42, 42);
+        assertThrows(IllegalArgumentException.class, () -> ImageReaderBase.getDestination(null, Collections.<ImageTypeSpecifier>emptyList().iterator(), 42, 42));
     }
 
     @Test
@@ -162,11 +160,11 @@ public class ImageReaderBaseTest {
         assertEquals(1, destination.getHeight());
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testGetDestinationParamIllegalDestination() throws IIOException {
         ImageReadParam param = new ImageReadParam();
         param.setDestination(new BufferedImage(21, 1, BufferedImage.TYPE_USHORT_565_RGB));
-        ImageReaderBase.getDestination(param, TYPES.iterator(), 42, 1);
+        assertThrows(IIOException.class, () -> ImageReaderBase.getDestination(param, TYPES.iterator(), 42, 1));
     }
 
     @Test
@@ -191,18 +189,18 @@ public class ImageReaderBaseTest {
         assertEquals(7, destination.getHeight());
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testGetDestinationParamIllegalDestinationType() throws IIOException {
         ImageReadParam param = new ImageReadParam();
         param.setDestinationType(ImageTypeSpecifier.createFromBufferedImageType(BufferedImage.TYPE_BYTE_GRAY));
-        ImageReaderBase.getDestination(param, TYPES.iterator(), 6, 7);
+        assertThrows(IIOException.class, () -> ImageReaderBase.getDestination(param, TYPES.iterator(), 6, 7));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testGetDestinationParamIllegalDestinationTypeAlt() throws IIOException {
         ImageReadParam param = new ImageReadParam();
         param.setDestinationType(ImageTypeSpecifier.createFromBufferedImageType(BufferedImage.TYPE_INT_BGR));
-        ImageReaderBase.getDestination(param, TYPES.iterator(), 6, 7);
+        assertThrows(IIOException.class, () -> ImageReaderBase.getDestination(param, TYPES.iterator(), 6, 7));
     }
 
     @Test
@@ -215,22 +213,22 @@ public class ImageReaderBaseTest {
         assertEquals(TYPES.get(0).getBufferedImageType(), destination.getType());
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testGetDestinationParamDestinationExceedsIntegerMax() throws IIOException {
         ImageReadParam param = new ImageReadParam();
         param.setSourceRegion(new Rectangle(3 * Short.MAX_VALUE, 2 * Short.MAX_VALUE)); // 6 442 057 734 pixels
-        ImageReaderBase.getDestination(param, TYPES.iterator(), 6 * Short.MAX_VALUE, 4 * Short.MAX_VALUE); // 25 768 230 936 pixels
+        assertThrows(IIOException.class, () -> ImageReaderBase.getDestination(param, TYPES.iterator(), 6 * Short.MAX_VALUE, 4 * Short.MAX_VALUE)); // 25 768 230 936 pixels
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testGetDestinationDimensionExceedsIntegerMax() throws IIOException {
-        ImageReaderBase.getDestination(null, TYPES.iterator(), 3 * Short.MAX_VALUE, 2 * Short.MAX_VALUE); // 6 442 057 734 pixels
+        assertThrows(IIOException.class, () -> ImageReaderBase.getDestination(null, TYPES.iterator(), 3 * Short.MAX_VALUE, 2 * Short.MAX_VALUE)); // 6 442 057 734 pixels
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testGetDestinationStorageExceedsIntegerMax() throws IIOException {
         Set<ImageTypeSpecifier> byteTypes = singleton(ImageTypeSpecifier.createFromBufferedImageType(BufferedImage.TYPE_3BYTE_BGR));
-        ImageReaderBase.getDestination(null, byteTypes.iterator(), Short.MAX_VALUE,  Short.MAX_VALUE); // 1 073 676 289 pixels
+        assertThrows(IIOException.class, () -> ImageReaderBase.getDestination(null, byteTypes.iterator(), Short.MAX_VALUE,  Short.MAX_VALUE)); // 1 073 676 289 pixels
         // => 3 221 028 867 bytes needed in continuous array, not possible
     }
 

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/StandardImageMetadataSupportTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/StandardImageMetadataSupportTest.java
@@ -7,9 +7,9 @@ import com.twelvemonkeys.imageio.StandardImageMetadataSupport.SubimageInterpreta
 import com.twelvemonkeys.imageio.StandardImageMetadataSupport.TextEntry;
 import com.twelvemonkeys.imageio.util.ImageTypeSpecifiers;
 
-import org.junit.Test;
 import org.w3c.dom.NodeList;
 
+import javax.imageio.IIOException;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataNode;
 import java.awt.image.*;
@@ -23,22 +23,23 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static com.twelvemonkeys.imageio.StandardImageMetadataSupport.builder;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StandardImageMetadataSupportTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createNullBuilder() {
-        new StandardImageMetadataSupport(null);
+        assertThrows(IllegalArgumentException.class, () -> new StandardImageMetadataSupport(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createNullType() {
-        new StandardImageMetadataSupport(builder(null));
+        assertThrows(IllegalArgumentException.class, () -> new StandardImageMetadataSupport(builder(null)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void builderNullType() {
-        builder(null).build();
+        assertThrows(IllegalArgumentException.class, () -> builder(null).build());
     }
 
     @Test
@@ -89,10 +90,10 @@ public class StandardImageMetadataSupportTest {
         assertEquals("TRUE", compressionLossless.getAttribute("value"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void withCompressionLossyIllegal() {
-        builder(ImageTypeSpecifiers.createFromBufferedImageType(BufferedImage.TYPE_BYTE_GRAY))
-                .withCompressionLossless(false);
+        assertThrows(IllegalArgumentException.class, () -> builder(ImageTypeSpecifiers.createFromBufferedImageType(BufferedImage.TYPE_BYTE_GRAY))
+                .withCompressionLossless(false));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/CIELabColorConverterTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/CIELabColorConverterTest.java
@@ -31,9 +31,9 @@
 package com.twelvemonkeys.imageio.color;
 
 import com.twelvemonkeys.imageio.color.CIELabColorConverter.Illuminant;
-import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * CIELabColorConverterTest.
@@ -43,9 +43,9 @@ import static org.junit.Assert.assertArrayEquals;
  * @version $Id: CIELabColorConverterTest.java,v 1.0 22/10/15 harald.kuhr Exp$
  */
 public class CIELabColorConverterTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testNoIllumninant() {
-        new CIELabColorConverter(null);
+        assertThrows(IllegalArgumentException.class, () -> new CIELabColorConverter(null));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/ColorProfilesTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/ColorProfilesTest.java
@@ -1,7 +1,5 @@
 package com.twelvemonkeys.imageio.color;
 
-import org.junit.Test;
-
 import java.awt.color.ColorSpace;
 import java.awt.color.ICC_ColorSpace;
 import java.awt.color.ICC_Profile;
@@ -9,7 +7,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ColorProfilesTest {
     @Test
@@ -53,9 +52,9 @@ public class ColorProfilesTest {
         assertFalse(ColorProfiles.isCS_sRGB(ICC_Profile.getInstance(ColorSpace.CS_PYCC)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsCS_sRGBNull() {
-        ColorProfiles.isCS_sRGB(null);
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.isCS_sRGB(null));
     }
 
     @Test
@@ -71,29 +70,29 @@ public class ColorProfilesTest {
         assertFalse(ColorProfiles.isCS_GRAY(ICC_Profile.getInstance(ColorSpace.CS_PYCC)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsCS_GRAYNull() {
-        ColorProfiles.isCS_GRAY(null);
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.isCS_GRAY(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateProfileNull() {
-        ColorProfiles.createProfile(null);
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.createProfile(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadProfileNull() throws IOException {
-        ColorProfiles.readProfile(null);
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.readProfile(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateProfileRawNull() {
-        ColorProfiles.createProfileRaw(null);
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.createProfileRaw(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadProfileRawNull() throws IOException {
-        ColorProfiles.readProfileRaw(null);
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.readProfileRaw(null));
     }
 
     @Test
@@ -110,74 +109,74 @@ public class ColorProfilesTest {
         assertArrayEquals(data, profileRaw.getData());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateProfileRawBadData() {
-        ColorProfiles.createProfileRaw(new byte[5]);
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.createProfileRaw(new byte[5]));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadProfileRawBadData() throws IOException {
         // NOTE: The array here is larger, as there's a bug in OpenJDK 15 & 16, that throws
         // ArrayIndexOutOfBoundsException if the stream is shorter than the profile signature...
-        ColorProfiles.readProfileRaw(new ByteArrayInputStream(new byte[40]));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.readProfileRaw(new ByteArrayInputStream(new byte[40])));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateProfileBadData() {
-        ColorProfiles.createProfile(new byte[5]);
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.createProfile(new byte[5]));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadProfileBadData() throws IOException {
-        ColorProfiles.readProfile(new ByteArrayInputStream(new byte[5]));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.readProfile(new ByteArrayInputStream(new byte[5])));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateProfileRawTruncated() throws IOException {
         byte[] data = ICC_Profile.getInstance(getClass().getResourceAsStream("/profiles/adobe_rgb_1998.icc")).getData();
-        ColorProfiles.createProfileRaw(Arrays.copyOf(data, 200));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.createProfileRaw(Arrays.copyOf(data, 200)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadProfileRawTruncated() throws IOException {
         byte[] data = ICC_Profile.getInstance(getClass().getResourceAsStream("/profiles/adobe_rgb_1998.icc")).getData();
-        ColorProfiles.readProfileRaw(new ByteArrayInputStream(data, 0, 200));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.readProfileRaw(new ByteArrayInputStream(data, 0, 200)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateProfileTruncated() throws IOException {
         byte[] data = ICC_Profile.getInstance(getClass().getResourceAsStream("/profiles/adobe_rgb_1998.icc")).getData();
-        ColorProfiles.createProfile(Arrays.copyOf(data, 200));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.createProfile(Arrays.copyOf(data, 200)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadProfileTruncated() throws IOException {
         byte[] data = ICC_Profile.getInstance(getClass().getResourceAsStream("/profiles/adobe_rgb_1998.icc")).getData();
-        ColorProfiles.readProfile(new ByteArrayInputStream(data, 0, 200));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.readProfile(new ByteArrayInputStream(data, 0, 200)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateProfileRawTruncatedHeader() throws IOException {
         byte[] data = ICC_Profile.getInstance(getClass().getResourceAsStream("/profiles/adobe_rgb_1998.icc")).getData();
-        ColorProfiles.createProfileRaw(Arrays.copyOf(data, 125));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.createProfileRaw(Arrays.copyOf(data, 125)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadProfileRawTruncatedHeader() throws IOException {
         byte[] data = ICC_Profile.getInstance(getClass().getResourceAsStream("/profiles/adobe_rgb_1998.icc")).getData();
-        ColorProfiles.readProfileRaw(new ByteArrayInputStream(data, 0, 125));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.readProfileRaw(new ByteArrayInputStream(data, 0, 125)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateProfileTruncatedHeader() throws IOException {
         byte[] data = ICC_Profile.getInstance(getClass().getResourceAsStream("/profiles/adobe_rgb_1998.icc")).getData();
-        ColorProfiles.createProfile(Arrays.copyOf(data, 125));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.createProfile(Arrays.copyOf(data, 125)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadProfileTruncatedHeader() throws IOException {
         byte[] data = ICC_Profile.getInstance(getClass().getResourceAsStream("/profiles/adobe_rgb_1998.icc")).getData();
-        ColorProfiles.readProfile(new ByteArrayInputStream(data, 0, 125));
+        assertThrows(IllegalArgumentException.class, () -> ColorProfiles.readProfile(new ByteArrayInputStream(data, 0, 125)));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/ColorSpacesTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/ColorSpacesTest.java
@@ -30,15 +30,16 @@
 
 package com.twelvemonkeys.imageio.color;
 
-import org.junit.Test;
+
 
 import java.awt.color.ColorSpace;
 import java.awt.color.ICC_ColorSpace;
 import java.awt.color.ICC_Profile;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 /**
  * ColorSpacesTest
@@ -154,9 +155,9 @@ public class ColorSpacesTest {
     }
 
     @SuppressWarnings("deprecation")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsCS_sRGBNull() {
-        ColorSpaces.isCS_sRGB(null);
+        assertThrows(IllegalArgumentException.class, () -> ColorSpaces.isCS_sRGB(null));
     }
 
     @SuppressWarnings("deprecation")
@@ -175,9 +176,9 @@ public class ColorSpacesTest {
     }
 
     @SuppressWarnings("deprecation")
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testIsCS_GRAYNull() {
-        ColorSpaces.isCS_GRAY(null);
+        assertThrows(IllegalArgumentException.class, () -> ColorSpaces.isCS_GRAY(null));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/DiscreteAlphaIndexColorModelTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/DiscreteAlphaIndexColorModelTest.java
@@ -31,21 +31,20 @@
 package com.twelvemonkeys.imageio.color;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
 
 import java.awt.image.*;
+import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 public class DiscreteAlphaIndexColorModelTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new DiscreteAlphaIndexColorModel(null);
+        assertThrows(IllegalArgumentException.class, () -> new DiscreteAlphaIndexColorModel(null));
     }
 
     @Test
@@ -202,7 +201,7 @@ public class DiscreteAlphaIndexColorModelTest {
         assertEquals(2, raster.getHeight());
 
         assertTrue(colorModel.isCompatibleRaster(raster));
-        assertThat(raster, CoreMatchers.is(WritableRaster.class)); // Specific subclasses are in sun.awt package
+        assertThat(raster, instanceOf(WritableRaster.class));  // Checks if raster is an instance of WritableRaster or its subclass
         assertThat(raster.getTransferType(), CoreMatchers.equalTo(DataBuffer.TYPE_BYTE));
     }
 

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/KCMSSanitizerStrategyTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/KCMSSanitizerStrategyTest.java
@@ -30,8 +30,6 @@
 
 package com.twelvemonkeys.imageio.color;
 
-import org.junit.Test;
-
 import java.awt.color.ColorSpace;
 import java.awt.color.ICC_ColorSpace;
 import java.awt.color.ICC_Profile;
@@ -39,16 +37,18 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assume.assumeFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
 import static org.mockito.Mockito.*;
 
 public class KCMSSanitizerStrategyTest {
     private static final byte[] XYZ = new byte[] {'X', 'Y', 'Z', ' '};
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFixProfileNullProfile() throws Exception {
-        new KCMSSanitizerStrategy().fixProfile(null);
+        assertThrows(IllegalArgumentException.class, () -> new KCMSSanitizerStrategy().fixProfile(null));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class KCMSSanitizerStrategyTest {
         try {
             Method isSealed = Class.class.getMethod("isSealed");
             Boolean result = (Boolean) isSealed.invoke(ICC_Profile.class);
-            assumeFalse("Can't mock ICC_Profile, class is sealed (as of JDK 19).", result);
+            assumeFalse(result, "Can't mock ICC_Profile, class is sealed (as of JDK 19).");
         }
         catch (ReflectiveOperationException ignore) {
             // We can't have sealed classes if we don't have the isSealed method...

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/LCMSSanitizerStrategyTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/LCMSSanitizerStrategyTest.java
@@ -30,19 +30,19 @@
 
 package com.twelvemonkeys.imageio.color;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 import java.awt.color.ICC_Profile;
 
 import static com.twelvemonkeys.imageio.color.KCMSSanitizerStrategyTest.assumeICC_ProfileNotSealed;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class LCMSSanitizerStrategyTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testFixProfileNullProfile() throws Exception {
-        new LCMSSanitizerStrategy().fixProfile(null);
+        assertThrows(IllegalArgumentException.class, () -> new LCMSSanitizerStrategy().fixProfile(null));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/ProfileDeferralActivatorTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/ProfileDeferralActivatorTest.java
@@ -1,6 +1,6 @@
 package com.twelvemonkeys.imageio.color;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.imageio.spi.ImageInputStreamSpi;
 import javax.imageio.spi.ServiceRegistry;

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/UInt32ColorModelTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/color/UInt32ColorModelTest.java
@@ -30,12 +30,11 @@
 
 package com.twelvemonkeys.imageio.color;
 
-import org.junit.Test;
-
 import java.awt.color.ColorSpace;
 import java.awt.image.ComponentColorModel;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UInt32ColorModelTest {
 

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/spi/ProviderInfoTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/spi/ProviderInfoTest.java
@@ -30,11 +30,11 @@
 
 package com.twelvemonkeys.imageio.spi;
 
-import org.junit.Test;
 
 import java.net.URL;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * ProviderInfoTest

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/spi/ReaderWriterProviderInfoTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/spi/ReaderWriterProviderInfoTest.java
@@ -30,9 +30,9 @@
 
 package com.twelvemonkeys.imageio.spi;
 
+import org.junit.jupiter.api.Test;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
 
 import javax.imageio.ImageReader;
 import javax.imageio.ImageWriter;
@@ -43,7 +43,7 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * ReaderWriterProviderInfoTest.

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamFileCacheTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamFileCacheTest.java
@@ -336,10 +336,10 @@ public class BufferedChannelImageInputStreamFileCacheTest {
 
 
             assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
-            assertThrows(EOFException.class, () -> stream.readByte());
-            assertThrows(EOFException.class, () -> stream.readShort());
-            assertThrows(EOFException.class, () -> stream.readInt());
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readByte);
+            assertThrows(EOFException.class, stream::readShort);
+            assertThrows(EOFException.class, stream::readInt);
+            assertThrows(EOFException.class, stream::readLong);
 
             stream.seek(0);
             for (byte value : bytes) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamFileCacheTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamFileCacheTest.java
@@ -30,8 +30,8 @@
 
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+
+import org.junit.jupiter.api.Test;
 
 import javax.imageio.stream.ImageInputStream;
 import java.io.ByteArrayInputStream;
@@ -44,7 +44,8 @@ import java.nio.channels.ReadableByteChannel;
 import java.util.Random;
 
 import static com.twelvemonkeys.imageio.stream.BufferedImageInputStreamTest.rangeEquals;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -69,7 +70,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
     @Test
     public void testCreate() throws IOException {
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileCache(new ByteArrayInputStream(new byte[0]), null))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
         }
     }
 
@@ -82,8 +83,8 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("stream"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("stream"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -96,8 +97,8 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("channel"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("channel"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -107,13 +108,13 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileCache(input, null))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             for (byte value : data) {
-                assertEquals("Wrong data read", value & 0xff, stream.read());
+                assertEquals(value & 0xff, stream.read(), "Wrong data read");
             }
 
-            assertEquals("Wrong data read", -1, stream.read());
+            assertEquals(-1, stream.read(), "Wrong data read");
         }
     }
 
@@ -123,16 +124,16 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileCache(input, null))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             byte[] result = new byte[1024];
 
             for (int i = 0; i < data.length / result.length; i++) {
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
 
-            assertEquals("Wrong data read", -1, stream.read());
+            assertEquals(-1, stream.read(), "Wrong data read");
         }
     }
 
@@ -142,14 +143,14 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileCache(input, null))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             byte[] result = new byte[7];
 
             for (int i = 0; i < data.length / result.length; i += 2) {
                 stream.readFully(result);
                 stream.skipBytes(result.length);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -160,7 +161,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileCache(input, null))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             byte[] result = new byte[9];
 
@@ -168,9 +169,9 @@ public class BufferedChannelImageInputStreamFileCacheTest {
                 // Read backwards
                 long newPos = data.length - result.length - i * result.length;
                 stream.seek(newPos);
-                assertEquals("Wrong stream position", newPos, stream.getStreamPosition());
+                assertEquals(newPos, stream.getStreamPosition(), "Wrong stream position");
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, (int) newPos, result, 0, result.length));
+                assertTrue(rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -181,7 +182,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileCache(input, null))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             byte[] buffer = new byte[data.length * 2];
             stream.read(buffer);
@@ -200,7 +201,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         // Create stream
         try (ImageInputStream stream = new BufferedChannelImageInputStream(new FileCache(input, null))) {
             for (int i = 1; i <= 64; i++) {
-                assertEquals(String.format("bit %d differ", i), (value << (i - 1L)) >>> 63L, stream.readBit());
+                assertEquals((value << (i - 1L)) >>> 63L, stream.readBit(), String.format("bit %d differ", i));
             }
         }
     }
@@ -215,7 +216,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
         try (ImageInputStream stream = new BufferedChannelImageInputStream(new FileCache(input, null))) {
             for (int i = 1; i <= 64; i++) {
                 stream.seek(0);
-                assertEquals(String.format("bit %d differ", i), value >>> (64L - i), stream.readBits(i));
+                assertEquals(value >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i % 8, stream.getBitOffset());
             }
         }
@@ -232,7 +233,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
             for (int i = 1; i <= 60; i++) {
                 stream.seek(0);
                 stream.setBitOffset(i % 8);
-                assertEquals(String.format("bit %d differ", i), (value << (i % 8)) >>> (64L - i), stream.readBits(i));
+                assertEquals((value << (i % 8)) >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i * 2 % 8, stream.getBitOffset());
             }
         }
@@ -251,12 +252,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, stream::readShort);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -267,12 +263,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, stream::readShort);
         }
     }
 
@@ -289,12 +280,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, stream::readInt);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -305,12 +291,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, stream::readInt);
         }
     }
 
@@ -327,12 +308,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, stream::readLong);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -343,12 +319,7 @@ public class BufferedChannelImageInputStreamFileCacheTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, stream::readLong);
         }
     }
 
@@ -363,36 +334,12 @@ public class BufferedChannelImageInputStreamFileCacheTest {
             assertEquals(-1, stream.read());
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readFully(new byte[1]);
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readByte();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+
+            assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
+            assertThrows(EOFException.class, () -> stream.readByte());
+            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, () -> stream.readLong());
 
             stream.seek(0);
             for (byte value : bytes) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamMemoryCacheTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamMemoryCacheTest.java
@@ -250,7 +250,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, stream::readShort);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -261,7 +261,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, stream::readShort);
         }
     }
 
@@ -278,7 +278,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, stream::readInt);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -289,7 +289,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, stream::readInt);
         }
     }
 
@@ -306,7 +306,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readLong);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -317,7 +317,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readLong);
         }
     }
 
@@ -333,10 +333,10 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
             assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
-            assertThrows(EOFException.class, () -> stream.readByte());
-            assertThrows(EOFException.class, () -> stream.readShort());
-            assertThrows(EOFException.class, () -> stream.readInt());
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readByte);
+            assertThrows(EOFException.class, stream::readShort);
+            assertThrows(EOFException.class, stream::readInt);
+            assertThrows(EOFException.class, stream::readLong);
 
             stream.seek(0);
             for (byte value : bytes) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamMemoryCacheTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamMemoryCacheTest.java
@@ -30,9 +30,6 @@
 
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-
 import javax.imageio.stream.ImageInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -43,8 +40,10 @@ import java.nio.ByteOrder;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Random;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static com.twelvemonkeys.imageio.stream.BufferedImageInputStreamTest.rangeEquals;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -69,7 +68,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
     @Test
     public void testCreate() throws IOException {
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new MemoryCache(new ByteArrayInputStream(new byte[0])))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
         }
     }
 
@@ -82,8 +81,8 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("stream"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("stream"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -96,8 +95,8 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("channel"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("channel"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -107,13 +106,13 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new MemoryCache(input))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             for (byte value : data) {
-                assertEquals("Wrong data read", value & 0xff, stream.read());
+                assertEquals(value & 0xff, stream.read(), "Wrong data read");
             }
 
-            assertEquals("Wrong data read", -1, stream.read());
+            assertEquals(-1, stream.read(), "Wrong data read");
         }
     }
 
@@ -123,16 +122,16 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new MemoryCache(input))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             byte[] result = new byte[1024];
 
             for (int i = 0; i < data.length / result.length; i++) {
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
 
-            assertEquals("Wrong data read", -1, stream.read());
+            assertEquals(-1, stream.read(), "Wrong data read");
         }
     }
 
@@ -142,14 +141,14 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new MemoryCache(input))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             byte[] result = new byte[7];
 
             for (int i = 0; i < data.length / result.length; i += 2) {
                 stream.readFully(result);
                 stream.skipBytes(result.length);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -160,7 +159,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new MemoryCache(input))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             byte[] result = new byte[9];
 
@@ -168,9 +167,9 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 // Read backwards
                 long newPos = data.length - result.length - i * result.length;
                 stream.seek(newPos);
-                assertEquals("Wrong stream position", newPos, stream.getStreamPosition());
+                assertEquals(newPos, stream.getStreamPosition(), "Wrong stream position");
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, (int) newPos, result, 0, result.length));
+                assertTrue(rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -181,7 +180,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         InputStream input = randomDataToInputStream(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new MemoryCache(input))) {
-            assertEquals("Stream length should be unknown", -1, stream.length());
+            assertEquals(-1, stream.length(), "Stream length should be unknown");
 
             byte[] buffer = new byte[data.length * 2];
             stream.read(buffer);
@@ -200,7 +199,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         // Create stream
         try (ImageInputStream stream = new BufferedChannelImageInputStream(new MemoryCache(input))) {
             for (int i = 1; i <= 64; i++) {
-                assertEquals(String.format("bit %d differ", i), (value << (i - 1L)) >>> 63L, stream.readBit());
+                assertEquals((value << (i - 1L)) >>> 63L, stream.readBit(), String.format("bit %d differ", i));
             }
         }
     }
@@ -215,7 +214,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
         try (ImageInputStream stream = new BufferedChannelImageInputStream(new MemoryCache(input))) {
             for (int i = 1; i <= 64; i++) {
                 stream.seek(0);
-                assertEquals(String.format("bit %d differ", i), value >>> (64L - i), stream.readBits(i));
+                assertEquals(value >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i % 8, stream.getBitOffset());
             }
         }
@@ -232,7 +231,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
             for (int i = 1; i <= 60; i++) {
                 stream.seek(0);
                 stream.setBitOffset(i % 8);
-                assertEquals(String.format("bit %d differ", i), (value << (i % 8)) >>> (64L - i), stream.readBits(i));
+                assertEquals((value << (i % 8)) >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i * 2 % 8, stream.getBitOffset());
             }
         }
@@ -251,12 +250,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readShort());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -267,12 +261,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readShort());
         }
     }
 
@@ -289,12 +278,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readInt());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -305,12 +289,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readInt());
         }
     }
 
@@ -327,12 +306,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readLong());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -343,12 +317,7 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readLong());
         }
     }
 
@@ -363,36 +332,11 @@ public class BufferedChannelImageInputStreamMemoryCacheTest {
             assertEquals(-1, stream.read());
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readFully(new byte[1]);
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readByte();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
+            assertThrows(EOFException.class, () -> stream.readByte());
+            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, () -> stream.readLong());
 
             stream.seek(0);
             for (byte value : bytes) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamTest.java
@@ -197,7 +197,7 @@ public class BufferedChannelImageInputStreamTest {
         // Create stream
         try (ImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(file))) {
             for (int i = 1; i <= 64; i++) {
-                assertEquals( (value << (i - 1L)) >>> 63L, stream.readBit(), String.format("bit %d differ", i));
+                assertEquals((value << (i - 1L)) >>> 63L, stream.readBit(), String.format("bit %d differ", i));
             }
         }
     }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamTest.java
@@ -167,7 +167,7 @@ public class BufferedChannelImageInputStreamTest {
                 stream.seek(newPos);
                 assertEquals(newPos, stream.getStreamPosition(), "Wrong stream position");
                 stream.readFully(result);
-                assertTrue( rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
+                assertTrue(rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamTest.java
@@ -30,9 +30,6 @@
 
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-
 import javax.imageio.stream.ImageInputStream;
 import java.io.EOFException;
 import java.io.File;
@@ -44,8 +41,10 @@ import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.util.Random;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static com.twelvemonkeys.imageio.stream.BufferedImageInputStreamTest.rangeEquals;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -71,7 +70,7 @@ public class BufferedChannelImageInputStreamTest {
     @Test
     public void testCreate() throws IOException {
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(File.createTempFile("empty", ".tmp")))) {
-            assertEquals("Data length should be same as stream length", 0, stream.length());
+            assertEquals(0, stream.length(), "Data length should be same as stream length");
         }
     }
 
@@ -84,8 +83,8 @@ public class BufferedChannelImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("inputstream"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("inputstream"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -98,8 +97,8 @@ public class BufferedChannelImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("channel"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("channel"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -109,10 +108,10 @@ public class BufferedChannelImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(file))) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             for (byte value : data) {
-                assertEquals("Wrong data read", value & 0xff, stream.read());
+                assertEquals(value & 0xff, stream.read(), "Wrong data read");
             }
         }
     }
@@ -123,13 +122,13 @@ public class BufferedChannelImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(file))) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             byte[] result = new byte[1024];
 
             for (int i = 0; i < data.length / result.length; i++) {
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -140,14 +139,14 @@ public class BufferedChannelImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(file))) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             byte[] result = new byte[7];
 
             for (int i = 0; i < data.length / result.length; i += 2) {
                 stream.readFully(result);
                 stream.skipBytes(result.length);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -158,7 +157,7 @@ public class BufferedChannelImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(file))) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             byte[] result = new byte[9];
 
@@ -166,9 +165,9 @@ public class BufferedChannelImageInputStreamTest {
                 // Read backwards
                 long newPos = stream.length() - result.length - i * result.length;
                 stream.seek(newPos);
-                assertEquals("Wrong stream position", newPos, stream.getStreamPosition());
+                assertEquals(newPos, stream.getStreamPosition(), "Wrong stream position");
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, (int) newPos, result, 0, result.length));
+                assertTrue( rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -179,7 +178,7 @@ public class BufferedChannelImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedChannelImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(file))) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             byte[] buffer = new byte[data.length * 2];
             stream.read(buffer);
@@ -198,7 +197,7 @@ public class BufferedChannelImageInputStreamTest {
         // Create stream
         try (ImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(file))) {
             for (int i = 1; i <= 64; i++) {
-                assertEquals(String.format("bit %d differ", i), (value << (i - 1L)) >>> 63L, stream.readBit());
+                assertEquals( (value << (i - 1L)) >>> 63L, stream.readBit(), String.format("bit %d differ", i));
             }
         }
     }
@@ -213,7 +212,7 @@ public class BufferedChannelImageInputStreamTest {
         try (ImageInputStream stream = new BufferedChannelImageInputStream(new FileInputStream(file))) {
             for (int i = 1; i <= 64; i++) {
                 stream.seek(0);
-                assertEquals(String.format("bit %d differ", i), value >>> (64L - i), stream.readBits(i));
+                assertEquals(value >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i % 8, stream.getBitOffset());
             }
         }
@@ -230,7 +229,7 @@ public class BufferedChannelImageInputStreamTest {
             for (int i = 1; i <= 60; i++) {
                 stream.seek(0);
                 stream.setBitOffset(i % 8);
-                assertEquals(String.format("bit %d differ", i), (value << (i % 8)) >>> (64L - i), stream.readBits(i));
+                assertEquals((value << (i % 8)) >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i * 2 % 8, stream.getBitOffset());
             }
         }
@@ -249,12 +248,7 @@ public class BufferedChannelImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readShort());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -265,12 +259,7 @@ public class BufferedChannelImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readShort());
         }
     }
 
@@ -287,12 +276,7 @@ public class BufferedChannelImageInputStreamTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readInt());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -302,13 +286,7 @@ public class BufferedChannelImageInputStreamTest {
             for (int i = 0; i < bytes.length / 4; i++) {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
-
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readInt());
         }
     }
 
@@ -324,13 +302,7 @@ public class BufferedChannelImageInputStreamTest {
             for (int i = 0; i < bytes.length / 8; i++) {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
-
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readLong());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -341,12 +313,7 @@ public class BufferedChannelImageInputStreamTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readLong());
         }
     }
 
@@ -361,36 +328,11 @@ public class BufferedChannelImageInputStreamTest {
             assertEquals(-1, stream.read());
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readFully(new byte[1]);
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readByte();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
+            assertThrows(EOFException.class, () -> stream.readByte());
+            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, () -> stream.readLong());
 
             stream.seek(0);
             for (byte value : bytes) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedChannelImageInputStreamTest.java
@@ -248,7 +248,7 @@ public class BufferedChannelImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, stream::readShort);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -259,7 +259,7 @@ public class BufferedChannelImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, stream::readShort);
         }
     }
 
@@ -276,7 +276,7 @@ public class BufferedChannelImageInputStreamTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, stream::readInt);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -286,7 +286,7 @@ public class BufferedChannelImageInputStreamTest {
             for (int i = 0; i < bytes.length / 4; i++) {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
-            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, stream::readInt);
         }
     }
 
@@ -302,7 +302,7 @@ public class BufferedChannelImageInputStreamTest {
             for (int i = 0; i < bytes.length / 8; i++) {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readLong);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -313,7 +313,7 @@ public class BufferedChannelImageInputStreamTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readLong);
         }
     }
 
@@ -329,10 +329,10 @@ public class BufferedChannelImageInputStreamTest {
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
             assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
-            assertThrows(EOFException.class, () -> stream.readByte());
-            assertThrows(EOFException.class, () -> stream.readShort());
-            assertThrows(EOFException.class, () -> stream.readInt());
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readByte);
+            assertThrows(EOFException.class, stream::readShort);
+            assertThrows(EOFException.class, stream::readInt);
+            assertThrows(EOFException.class, stream::readLong);
 
             stream.seek(0);
             for (byte value : bytes) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedFileImageInputStreamSpiTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedFileImageInputStreamSpiTest.java
@@ -1,13 +1,12 @@
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Test;
 
 import javax.imageio.spi.ImageInputStreamSpi;
 import java.io.File;
 import java.io.IOException;
-
-import static org.junit.Assert.assertNull;
-import static org.junit.Assume.assumeFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class BufferedFileImageInputStreamSpiTest extends ImageInputStreamSpiTest<File> {
     @Override
@@ -24,7 +23,7 @@ public class BufferedFileImageInputStreamSpiTest extends ImageInputStreamSpiTest
     public void testReturnNullWhenFileDoesNotExist() throws IOException {
         // This is really stupid behavior, but it is consistent with the JRE bundled SPIs.
         File input = new File("a-file-that-should-not-exist-ever.fnf");
-        assumeFalse("File should not exist: " + input.getPath(), input.exists());
+        assumeFalse(input.exists(), "File should not exist: " + input.getPath());
         assertNull(provider.createInputStreamInstance(input));
     }
 }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedFileImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedFileImageInputStreamTest.java
@@ -249,7 +249,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, stream::readShort);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -260,7 +260,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, stream::readShort);
         }
     }
 
@@ -277,7 +277,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, stream::readInt);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -288,7 +288,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, stream::readInt);
         }
     }
 
@@ -305,7 +305,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readLong);
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -315,7 +315,7 @@ public class BufferedFileImageInputStreamTest {
             for (int i = 0; i < bytes.length / 8; i++) {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readLong);
         }
     }
 
@@ -331,10 +331,10 @@ public class BufferedFileImageInputStreamTest {
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
             assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
-            assertThrows(EOFException.class, () -> stream.readByte());
-            assertThrows(EOFException.class, () -> stream.readShort());
-            assertThrows(EOFException.class, () -> stream.readInt());
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readByte);
+            assertThrows(EOFException.class, stream::readShort);
+            assertThrows(EOFException.class, stream::readInt);
+            assertThrows(EOFException.class, stream::readLong);
 
             stream.seek(0);
             for (byte value : bytes) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedFileImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedFileImageInputStreamTest.java
@@ -30,9 +30,6 @@
 
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-
 import javax.imageio.stream.ImageInputStream;
 import java.io.EOFException;
 import java.io.File;
@@ -43,8 +40,10 @@ import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.util.Random;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static com.twelvemonkeys.imageio.stream.BufferedImageInputStreamTest.rangeEquals;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -71,7 +70,7 @@ public class BufferedFileImageInputStreamTest {
     @Test
     public void testCreate() throws IOException {
         try (BufferedFileImageInputStream stream = new BufferedFileImageInputStream(File.createTempFile("empty", ".tmp"))) {
-            assertEquals("Data length should be same as stream length", 0, stream.length());
+            assertEquals(0, stream.length(), "Data length should be same as stream length");
         }
     }
 
@@ -85,8 +84,8 @@ public class BufferedFileImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("file"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("file"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -99,8 +98,8 @@ public class BufferedFileImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("raf"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue( message.contains("raf"), "Exception message does not contain parameter name");
+            assertTrue( message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -110,10 +109,10 @@ public class BufferedFileImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedFileImageInputStream stream = new BufferedFileImageInputStream(file)) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             for (byte value : data) {
-                assertEquals("Wrong data read", value & 0xff, stream.read());
+                assertEquals(value & 0xff, stream.read(), "Wrong data read");
             }
         }
     }
@@ -124,13 +123,13 @@ public class BufferedFileImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedFileImageInputStream stream = new BufferedFileImageInputStream(file)) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             byte[] result = new byte[1024];
 
             for (int i = 0; i < data.length / result.length; i++) {
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -141,14 +140,14 @@ public class BufferedFileImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedFileImageInputStream stream = new BufferedFileImageInputStream(file)) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             byte[] result = new byte[7];
 
             for (int i = 0; i < data.length / result.length; i += 2) {
                 stream.readFully(result);
                 stream.skipBytes(result.length);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -159,7 +158,7 @@ public class BufferedFileImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedFileImageInputStream stream = new BufferedFileImageInputStream(file)) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             byte[] result = new byte[9];
 
@@ -167,9 +166,9 @@ public class BufferedFileImageInputStreamTest {
                 // Read backwards
                 long newPos = stream.length() - result.length - i * result.length;
                 stream.seek(newPos);
-                assertEquals("Wrong stream position", newPos, stream.getStreamPosition());
+                assertEquals(newPos, stream.getStreamPosition(), "Wrong stream position");
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, (int) newPos, result, 0, result.length));
+                assertTrue(rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -180,7 +179,7 @@ public class BufferedFileImageInputStreamTest {
         File file = randomDataToFile(data);
 
         try (BufferedFileImageInputStream stream = new BufferedFileImageInputStream(file)) {
-            assertEquals("File length should be same as stream length", file.length(), stream.length());
+            assertEquals(file.length(), stream.length(), "File length should be same as stream length");
 
             byte[] buffer = new byte[data.length * 2];
             stream.read(buffer);
@@ -199,7 +198,7 @@ public class BufferedFileImageInputStreamTest {
         // Create stream
         try (ImageInputStream stream = new BufferedFileImageInputStream(file)) {
             for (int i = 1; i <= 64; i++) {
-                assertEquals(String.format("bit %d differ", i), (value << (i - 1L)) >>> 63L, stream.readBit());
+                assertEquals((value << (i - 1L)) >>> 63L, stream.readBit(), String.format("bit %d differ", i));
             }
         }
     }
@@ -214,7 +213,7 @@ public class BufferedFileImageInputStreamTest {
         try (ImageInputStream stream = new BufferedFileImageInputStream(file)) {
             for (int i = 1; i <= 64; i++) {
                 stream.seek(0);
-                assertEquals(String.format("bit %d differ", i), value >>> (64L - i), stream.readBits(i));
+                assertEquals(value >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i % 8, stream.getBitOffset());
             }
         }
@@ -231,7 +230,7 @@ public class BufferedFileImageInputStreamTest {
             for (int i = 1; i <= 60; i++) {
                 stream.seek(0);
                 stream.setBitOffset(i % 8);
-                assertEquals(String.format("bit %d differ", i), (value << (i % 8)) >>> (64L - i), stream.readBits(i));
+                assertEquals((value << (i % 8)) >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i * 2 % 8, stream.getBitOffset());
             }
         }
@@ -250,12 +249,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readShort());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -266,12 +260,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readShort());
         }
     }
 
@@ -288,12 +277,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readInt());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -304,12 +288,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readInt());
         }
     }
 
@@ -326,12 +305,7 @@ public class BufferedFileImageInputStreamTest {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readLong());
 
             stream.seek(0);
             stream.setByteOrder(ByteOrder.LITTLE_ENDIAN);
@@ -341,13 +315,7 @@ public class BufferedFileImageInputStreamTest {
             for (int i = 0; i < bytes.length / 8; i++) {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
-
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readLong());
         }
     }
 
@@ -362,36 +330,11 @@ public class BufferedFileImageInputStreamTest {
             assertEquals(-1, stream.read());
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readFully(new byte[1]);
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readByte();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
+            assertThrows(EOFException.class, () -> stream.readByte());
+            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, () -> stream.readLong());
 
             stream.seek(0);
             for (byte value : bytes) {
@@ -429,5 +372,5 @@ public class BufferedFileImageInputStreamTest {
             assertEquals(size, len + head);
             assertArrayEquals(bytes, result);
         }
-   }
+    }
 }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedImageInputStreamTest.java
@@ -72,8 +72,8 @@ public class BufferedImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue( message.contains("stream"), "Exception message does not contain parameter name");
-            assertTrue( message.contains("null"), "Exception message does not contain null");
+            assertTrue(message.contains("stream"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/BufferedImageInputStreamTest.java
@@ -33,7 +33,6 @@ package com.twelvemonkeys.imageio.stream;
 import com.twelvemonkeys.io.ole2.CompoundDocument;
 import com.twelvemonkeys.io.ole2.Entry;
 
-import org.junit.Test;
 
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.MemoryCacheImageInputStream;
@@ -42,8 +41,10 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static java.util.Arrays.fill;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -71,8 +72,8 @@ public class BufferedImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("stream"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue( message.contains("stream"), "Exception message does not contain parameter name");
+            assertTrue( message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -313,7 +314,7 @@ public class BufferedImageInputStreamTest {
 
         for (int i = 1; i < 64; i++) {
             stream.seek(0);
-            assertEquals(i + " bits differ", value >>> (64L - i), stream.readBits(i));
+            assertEquals(value >>> (64L - i), stream.readBits(i), i + " bits differ");
         }
     }
 
@@ -340,8 +341,8 @@ public class BufferedImageInputStreamTest {
 
         Entry catalog = root.getChildEntry("Catalog");
 
-        assertNotNull("Catalog should not be null", catalog);
-        assertNotNull("Input stream can never be null", catalog.getInputStream());
+        assertNotNull(catalog, "Catalog should not be null");
+        assertNotNull(catalog.getInputStream(), "Input stream can never be null");
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/ByteArrayImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/ByteArrayImageInputStreamTest.java
@@ -30,13 +30,14 @@
 
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Random;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static com.twelvemonkeys.imageio.stream.BufferedImageInputStreamTest.rangeEquals;
-import static org.junit.Assert.*;
 
 /**
  * ByteArrayImageInputStreamTest
@@ -51,7 +52,7 @@ public class ByteArrayImageInputStreamTest {
     @Test
     public void testCreate() {
         ByteArrayImageInputStream stream = new ByteArrayImageInputStream(new byte[0]);
-        assertEquals("Data length should be same as stream length", 0, stream.length());
+        assertEquals( 0, stream.length(), "Data length should be same as stream length");
     }
 
     @Test
@@ -63,8 +64,8 @@ public class ByteArrayImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("data"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("data"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -77,8 +78,8 @@ public class ByteArrayImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("data"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue( message.contains("data"), "Exception message does not contain parameter name");
+            assertTrue( message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -91,8 +92,8 @@ public class ByteArrayImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("offset"));
-            assertTrue("Exception message does not contain -1", message.contains("-1"));
+            assertTrue(message.contains("offset"), "Exception message does not contain parameter name");
+            assertTrue( message.contains("-1"), "Exception message does not contain -1");
         }
     }
 
@@ -105,8 +106,8 @@ public class ByteArrayImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("offset"));
-            assertTrue("Exception message does not contain 2", message.contains("2"));
+            assertTrue( message.contains("offset"), "Exception message does not contain parameter name");
+            assertTrue( message.contains("2"), "Exception message does not contain 2");
         }
     }
 
@@ -119,8 +120,8 @@ public class ByteArrayImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("length"));
-            assertTrue("Exception message does not contain -1", message.contains("-1"));
+            assertTrue(message.contains("length"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("-1"), "Exception message does not contain -1");
         }
     }
 
@@ -133,8 +134,8 @@ public class ByteArrayImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("length"));
-            assertTrue("Exception message does not contain ™", message.contains("2"));
+            assertTrue(message.contains("length"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("2"), "Exception message does not contain ™");
         }
     }
 
@@ -145,10 +146,10 @@ public class ByteArrayImageInputStreamTest {
 
         ByteArrayImageInputStream stream = new ByteArrayImageInputStream(data);
 
-        assertEquals("Data length should be same as stream length", data.length, stream.length());
+        assertEquals(data.length, stream.length(), "Data length should be same as stream length");
 
         for (byte b : data) {
-            assertEquals("Wrong data read", b & 0xff, stream.read());
+            assertEquals(b & 0xff, stream.read(), "Wrong data read");
         }
     }
 
@@ -161,10 +162,10 @@ public class ByteArrayImageInputStreamTest {
         int length = random.nextInt(data.length - offset);
         ByteArrayImageInputStream stream = new ByteArrayImageInputStream(data, offset, length);
 
-        assertEquals("Data length should be same as stream length", length, stream.length());
+        assertEquals(length, stream.length(), "Data length should be same as stream length");
 
         for (int i = offset; i < offset + length; i++) {
-            assertEquals("Wrong data read", data[i] & 0xff, stream.read());
+            assertEquals(data[i] & 0xff, stream.read(), "Wrong data read");
         }
     }
 
@@ -175,13 +176,13 @@ public class ByteArrayImageInputStreamTest {
 
         ByteArrayImageInputStream stream = new ByteArrayImageInputStream(data);
 
-        assertEquals("Data length should be same as stream length", data.length, stream.length());
+        assertEquals(data.length, stream.length(), "Data length should be same as stream length");
 
         byte[] result = new byte[1024];
 
         for (int i = 0; i < data.length / result.length; i++) {
             stream.readFully(result);
-            assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+            assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
         }
     }
 
@@ -194,13 +195,13 @@ public class ByteArrayImageInputStreamTest {
         int length = 10240;
         ByteArrayImageInputStream stream = new ByteArrayImageInputStream(data, offset, length);
 
-        assertEquals("Data length should be same as stream length", length, stream.length());
+        assertEquals(length, stream.length(), "Data length should be same as stream length");
 
         byte[] result = new byte[1024];
 
         for (int i = 0; i < length / result.length; i++) {
             stream.readFully(result);
-            assertTrue("Wrong data read: " + i, rangeEquals(data, offset + i * result.length, result, 0, result.length));
+            assertTrue(rangeEquals(data, offset + i * result.length, result, 0, result.length), "Wrong data read: " + i);
         }
     }
 
@@ -211,14 +212,14 @@ public class ByteArrayImageInputStreamTest {
 
         ByteArrayImageInputStream stream = new ByteArrayImageInputStream(data);
 
-        assertEquals("Data length should be same as stream length", data.length, stream.length());
+        assertEquals(data.length, stream.length(), "Data length should be same as stream length");
 
         byte[] result = new byte[7];
 
         for (int i = 0; i < data.length / result.length; i += 2) {
             stream.readFully(result);
             stream.skipBytes(result.length);
-            assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+            assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
         }
     }
 
@@ -229,7 +230,7 @@ public class ByteArrayImageInputStreamTest {
 
         ByteArrayImageInputStream stream = new ByteArrayImageInputStream(data);
 
-        assertEquals("Data length should be same as stream length", data.length, stream.length());
+        assertEquals(data.length, stream.length(), "Data length should be same as stream length");
 
         byte[] result = new byte[9];
 
@@ -237,9 +238,9 @@ public class ByteArrayImageInputStreamTest {
             // Read backwards
             long newPos = stream.length() - result.length - i * result.length;
             stream.seek(newPos);
-            assertEquals("Wrong stream position", newPos, stream.getStreamPosition());
+            assertEquals(newPos, stream.getStreamPosition(), "Wrong stream position");
             stream.readFully(result);
-            assertTrue("Wrong data read: " + i, rangeEquals(data, (int) newPos, result, 0, result.length));
+            assertTrue(rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
         }
     }
 }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/ByteArrayImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/ByteArrayImageInputStreamTest.java
@@ -52,7 +52,7 @@ public class ByteArrayImageInputStreamTest {
     @Test
     public void testCreate() {
         ByteArrayImageInputStream stream = new ByteArrayImageInputStream(new byte[0]);
-        assertEquals( 0, stream.length(), "Data length should be same as stream length");
+        assertEquals(0, stream.length(), "Data length should be same as stream length");
     }
 
     @Test
@@ -78,8 +78,8 @@ public class ByteArrayImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue( message.contains("data"), "Exception message does not contain parameter name");
-            assertTrue( message.contains("null"), "Exception message does not contain null");
+            assertTrue(message.contains("data"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -93,7 +93,7 @@ public class ByteArrayImageInputStreamTest {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
             assertTrue(message.contains("offset"), "Exception message does not contain parameter name");
-            assertTrue( message.contains("-1"), "Exception message does not contain -1");
+            assertTrue(message.contains("-1"), "Exception message does not contain -1");
         }
     }
 
@@ -106,8 +106,8 @@ public class ByteArrayImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue( message.contains("offset"), "Exception message does not contain parameter name");
-            assertTrue( message.contains("2"), "Exception message does not contain 2");
+            assertTrue(message.contains("offset"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("2"), "Exception message does not contain 2");
         }
     }
 

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/DirectImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/DirectImageInputStreamTest.java
@@ -30,10 +30,6 @@
 
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-
 import javax.imageio.stream.ImageInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -43,8 +39,12 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static com.twelvemonkeys.imageio.stream.BufferedImageInputStreamTest.rangeEquals;
-import static org.junit.Assert.*;
+
 import static org.mockito.Mockito.*;
 
 /**
@@ -66,7 +66,7 @@ public class DirectImageInputStreamTest {
     @Test
     public void testCreate() throws IOException {
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(new byte[0]), 0)) {
-            assertEquals("Data length should be same as stream length", 0, stream.length());
+            assertEquals(0, stream.length(), "Data length should be same as stream length");
         }
     }
 
@@ -78,8 +78,8 @@ public class DirectImageInputStreamTest {
         catch (IllegalArgumentException expected) {
             assertNotNull("Null exception message", expected.getMessage());
             String message = expected.getMessage().toLowerCase();
-            assertTrue("Exception message does not contain parameter name", message.contains("stream"));
-            assertTrue("Exception message does not contain null", message.contains("null"));
+            assertTrue(message.contains("stream"), "Exception message does not contain parameter name");
+            assertTrue(message.contains("null"), "Exception message does not contain null");
         }
     }
 
@@ -90,7 +90,7 @@ public class DirectImageInputStreamTest {
 
         try (DirectImageInputStream stream = new DirectImageInputStream(input)) {
             for (byte value : data) {
-                assertEquals("Wrong data read", value & 0xff, stream.read());
+                assertEquals(value & 0xff, stream.read(), "Wrong data read");
             }
         }
     }
@@ -105,7 +105,7 @@ public class DirectImageInputStreamTest {
 
             for (int i = 0; i < data.length / result.length; i++) {
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -121,7 +121,7 @@ public class DirectImageInputStreamTest {
             for (int i = 0; i < data.length / result.length; i += 2) {
                 stream.readFully(result);
                 stream.skipBytes(result.length);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, i * result.length, result, 0, result.length));
+                assertTrue(rangeEquals(data, i * result.length, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
@@ -137,15 +137,15 @@ public class DirectImageInputStreamTest {
             for (int i = 0; i < data.length / (2 * result.length); i++) {
                 long newPos = i * 2 * result.length;
                 stream.seek(newPos);
-                assertEquals("Wrong stream position", newPos, stream.getStreamPosition());
+                assertEquals(newPos, stream.getStreamPosition(), "Wrong stream position");
                 stream.readFully(result);
-                assertTrue("Wrong data read: " + i, rangeEquals(data, (int) newPos, result, 0, result.length));
+                assertTrue( rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Ignore("Bit reading requires backwards seek or buffer...")
+    @Disabled("Bit reading requires backwards seek or buffer...")
     @Test
     public void testReadBitRandom() throws IOException {
         byte[] bytes = new byte[8];
@@ -155,13 +155,13 @@ public class DirectImageInputStreamTest {
         // Create stream
         try (DirectImageInputStream stream = new DirectImageInputStream(input)) {
             for (int i = 1; i <= 64; i++) {
-                assertEquals(String.format("bit %d differ", i), (value << (i - 1L)) >>> 63L, stream.readBit());
+                assertEquals((value << (i - 1L)) >>> 63L, stream.readBit(), String.format("bit %d differ", i));
             }
         }
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Ignore("Bit reading requires backwards seek or buffer...")
+    @Disabled("Bit reading requires backwards seek or buffer...")
     @Test
     public void testReadBitsRandom() throws IOException {
         byte[] bytes = new byte[8];
@@ -172,14 +172,14 @@ public class DirectImageInputStreamTest {
         try (DirectImageInputStream stream = new DirectImageInputStream(input)) {
             for (int i = 1; i <= 64; i++) {
                 stream.seek(0);
-                assertEquals(String.format("bit %d differ", i), value >>> (64L - i), stream.readBits(i));
+                assertEquals(value >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i % 8, stream.getBitOffset());
             }
         }
     }
 
     @SuppressWarnings("ConstantConditions")
-    @Ignore("Bit reading requires backwards seek or buffer...")
+    @Disabled("Bit reading requires backwards seek or buffer...")
     @Test
     public void testReadBitsRandomOffset() throws IOException {
         byte[] bytes = new byte[8];
@@ -191,7 +191,7 @@ public class DirectImageInputStreamTest {
             for (int i = 1; i <= 60; i++) {
                 stream.seek(0);
                 stream.setBitOffset(i % 8);
-                assertEquals(String.format("bit %d differ", i), (value << (i % 8)) >>> (64L - i), stream.readBits(i));
+                assertEquals((value << (i % 8)) >>> (64L - i), stream.readBits(i), String.format("bit %d differ", i));
                 assertEquals(i * 2L % 8, stream.getBitOffset());
             }
         }
@@ -211,12 +211,7 @@ public class DirectImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readShort());
         }
 
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(bytes))) {
@@ -228,12 +223,7 @@ public class DirectImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readShort());
         }
     }
 
@@ -250,13 +240,7 @@ public class DirectImageInputStreamTest {
             for (int i = 0; i < bytes.length / 4; i++) {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
-
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readInt());
         }
 
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(bytes))) {
@@ -268,12 +252,7 @@ public class DirectImageInputStreamTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readInt());
         }
     }
 
@@ -289,13 +268,7 @@ public class DirectImageInputStreamTest {
             for (int i = 0; i < bytes.length / 8; i++) {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
-
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readLong());
         }
 
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(bytes))) {
@@ -306,13 +279,7 @@ public class DirectImageInputStreamTest {
             for (int i = 0; i < bytes.length / 8; i++) {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
-
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readLong());
         }
     }
 
@@ -327,36 +294,11 @@ public class DirectImageInputStreamTest {
             assertEquals(-1, stream.read());
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readFully(new byte[1]);
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readByte();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readShort();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readInt();
-                }
-            });
-            assertThrows(EOFException.class, new ThrowingRunnable() {
-                @Override
-                public void run() throws Throwable {
-                    stream.readLong();
-                }
-            });
+            assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
+            assertThrows(EOFException.class, () -> stream.readByte());
+            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, () -> stream.readLong());
         }
 
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(bytes))) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/DirectImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/DirectImageInputStreamTest.java
@@ -139,7 +139,7 @@ public class DirectImageInputStreamTest {
                 stream.seek(newPos);
                 assertEquals(newPos, stream.getStreamPosition(), "Wrong stream position");
                 stream.readFully(result);
-                assertTrue( rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
+                assertTrue(rangeEquals(data, (int) newPos, result, 0, result.length), "Wrong data read: " + i);
             }
         }
     }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/DirectImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/DirectImageInputStreamTest.java
@@ -211,7 +211,7 @@ public class DirectImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, stream::readShort);
         }
 
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(bytes))) {
@@ -223,7 +223,7 @@ public class DirectImageInputStreamTest {
                 assertEquals(buffer.getShort(), stream.readShort());
             }
 
-            assertThrows(EOFException.class, () -> stream.readShort());
+            assertThrows(EOFException.class, stream::readShort);
         }
     }
 
@@ -240,7 +240,7 @@ public class DirectImageInputStreamTest {
             for (int i = 0; i < bytes.length / 4; i++) {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
-            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, stream::readInt);
         }
 
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(bytes))) {
@@ -252,7 +252,7 @@ public class DirectImageInputStreamTest {
                 assertEquals(buffer.getInt(), stream.readInt());
             }
 
-            assertThrows(EOFException.class, () -> stream.readInt());
+            assertThrows(EOFException.class, stream::readInt);
         }
     }
 
@@ -268,7 +268,7 @@ public class DirectImageInputStreamTest {
             for (int i = 0; i < bytes.length / 8; i++) {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readLong);
         }
 
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(bytes))) {
@@ -279,7 +279,7 @@ public class DirectImageInputStreamTest {
             for (int i = 0; i < bytes.length / 8; i++) {
                 assertEquals(buffer.getLong(), stream.readLong());
             }
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readLong);
         }
     }
 
@@ -295,10 +295,10 @@ public class DirectImageInputStreamTest {
             assertEquals(-1, stream.read(new byte[1], 0, 1));
 
             assertThrows(EOFException.class, () -> stream.readFully(new byte[1]));
-            assertThrows(EOFException.class, () -> stream.readByte());
-            assertThrows(EOFException.class, () -> stream.readShort());
-            assertThrows(EOFException.class, () -> stream.readInt());
-            assertThrows(EOFException.class, () -> stream.readLong());
+            assertThrows(EOFException.class, stream::readByte);
+            assertThrows(EOFException.class, stream::readShort);
+            assertThrows(EOFException.class, stream::readInt);
+            assertThrows(EOFException.class, stream::readLong);
         }
 
         try (DirectImageInputStream stream = new DirectImageInputStream(new ByteArrayInputStream(bytes))) {

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/ImageInputStreamSpiTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/ImageInputStreamSpiTest.java
@@ -1,14 +1,14 @@
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.spi.ImageInputStreamSpi;
+import java.io.EOFException;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
 import java.util.Locale;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 abstract class ImageInputStreamSpiTest<T> {
     protected final ImageInputStreamSpi provider = createProvider();
@@ -42,14 +42,14 @@ abstract class ImageInputStreamSpiTest<T> {
         assertNotNull(provider.getDescription(Locale.ENGLISH));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createNull() throws IOException {
-        provider.createInputStreamInstance(null);
+        assertThrows(IllegalArgumentException.class, () -> provider.createInputStreamInstance(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void createNullCached() throws IOException {
-        provider.createInputStreamInstance(null, true, ImageIO.getCacheDirectory());
+        assertThrows(IllegalArgumentException.class, () -> provider.createInputStreamInstance(null, true, ImageIO.getCacheDirectory()));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/StreamProviderInfoTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/StreamProviderInfoTest.java
@@ -2,10 +2,9 @@ package com.twelvemonkeys.imageio.stream;
 
 import com.twelvemonkeys.imageio.spi.ProviderInfo;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 public class StreamProviderInfoTest {
     private final ProviderInfo providerInfo = new StreamProviderInfo();

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/SubImageInputStreamTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/stream/SubImageInputStreamTest.java
@@ -30,8 +30,6 @@
 
 package com.twelvemonkeys.imageio.stream;
 
-import org.junit.Test;
-
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageInputStreamImpl;
 import javax.imageio.stream.MemoryCacheImageInputStream;
@@ -40,7 +38,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * SubImageInputStreamTestCase
@@ -66,16 +65,18 @@ public class SubImageInputStreamTest {
         };
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullStream() throws IOException {
-        new SubImageInputStream(null, 1);
-        fail("Expected IllegalArgumentException with null stream");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new SubImageInputStream(null, 1);
+        }, "Expected IllegalArgumentException with null stream");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNegativeLength() throws IOException {
-        new SubImageInputStream(createStream(0), -1);
-        fail("Expected IllegalArgumentException with negative length");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new SubImageInputStream(createStream(0), -1);
+        }, "Expected IllegalArgumentException with negative length");
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IIOInputStreamAdapterTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IIOInputStreamAdapterTest.java
@@ -73,8 +73,8 @@ public class IIOInputStreamAdapterTest extends InputStreamAbstractTest {
             assertTrue(-1 != stream.read(), "Unexpected end of stream");
         }
 
-        assertEquals( -1, stream.read(), "Read value after end of stream");
-        assertEquals( -1, stream.read(), "Read value after end of stream");
+        assertEquals(-1, stream.read(), "Read value after end of stream");
+        assertEquals(-1, stream.read(), "Read value after end of stream");
 
         // Make sure underlying stream is positioned at end of substream after close
         stream.close();

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IIOInputStreamAdapterTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IIOInputStreamAdapterTest.java
@@ -31,15 +31,15 @@
 package com.twelvemonkeys.imageio.util;
 
 import com.twelvemonkeys.io.InputStreamAbstractTest;
-import org.junit.Test;
 
+import javax.imageio.ImageIO;
 import javax.imageio.stream.MemoryCacheImageInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * IIOInputStreamAdapter
@@ -54,9 +54,9 @@ public class IIOInputStreamAdapterTest extends InputStreamAbstractTest {
         return new IIOInputStreamAdapter(new MemoryCacheImageInputStream(new ByteArrayInputStream(pBytes)), pBytes.length);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new IIOInputStreamAdapter(null);
+        assertThrows(IllegalArgumentException.class, () -> new IIOInputStreamAdapter(null));
     }
 
     @Test
@@ -70,11 +70,11 @@ public class IIOInputStreamAdapterTest extends InputStreamAbstractTest {
 
         IIOInputStreamAdapter stream = new IIOInputStreamAdapter(input);
         for (int i = 0; i < 10; i++) {
-            assertTrue("Unexpected end of stream", -1 != stream.read());
+            assertTrue(-1 != stream.read(), "Unexpected end of stream");
         }
 
-        assertEquals("Read value after end of stream", -1, stream.read());
-        assertEquals("Read value after end of stream", -1, stream.read());
+        assertEquals( -1, stream.read(), "Read value after end of stream");
+        assertEquals( -1, stream.read(), "Read value after end of stream");
 
         // Make sure underlying stream is positioned at end of substream after close
         stream.close();
@@ -90,11 +90,11 @@ public class IIOInputStreamAdapterTest extends InputStreamAbstractTest {
         MemoryCacheImageInputStream input = new MemoryCacheImageInputStream(new ByteArrayInputStream(bytes));
         IIOInputStreamAdapter stream = new IIOInputStreamAdapter(input, 9);
         for (int i = 0; i < 9; i++) {
-            assertTrue("Unexpected end of stream", -1 != stream.read());
+            assertTrue(-1 != stream.read(), "Unexpected end of stream");
         }
 
-        assertEquals("Read value after end of stream", -1, stream.read());
-        assertEquals("Read value after end of stream", -1, stream.read());
+        assertEquals(-1, stream.read(), "Read value after end of stream");
+        assertEquals(-1, stream.read(), "Read value after end of stream");
 
         // Make sure we don't read outside stream boundaries
         assertTrue(input.getStreamPosition() <= 9);
@@ -109,7 +109,7 @@ public class IIOInputStreamAdapterTest extends InputStreamAbstractTest {
         MemoryCacheImageInputStream input = new MemoryCacheImageInputStream(new ByteArrayInputStream(bytes));
         IIOInputStreamAdapter stream = new IIOInputStreamAdapter(input, 10);
         for (int i = 0; i < 7; i++) {
-            assertTrue("Unexpected end of stream", -1 != stream.read());
+            assertTrue(-1 != stream.read(), "Unexpected end of stream");
         }
 
         // Make sure we don't read outside stream boundaries
@@ -132,7 +132,7 @@ public class IIOInputStreamAdapterTest extends InputStreamAbstractTest {
         assertEquals(10, input.getStreamPosition());
 
         IIOInputStreamAdapter stream = new IIOInputStreamAdapter(input);
-        assertEquals("Should not skip backwards", 0, stream.skip(-5));
+        assertEquals(0, stream.skip(-5), "Should not skip backwards");
         assertEquals(10, input.getStreamPosition());
     }
 
@@ -146,7 +146,7 @@ public class IIOInputStreamAdapterTest extends InputStreamAbstractTest {
         assertEquals(10, input.getStreamPosition());
 
         IIOInputStreamAdapter stream = new IIOInputStreamAdapter(input, 9);
-        assertEquals("Should not skip backwards", 0, stream.skip(-5));
+        assertEquals(0, stream.skip(-5), "Should not skip backwards");
         assertEquals(10, input.getStreamPosition());
 
     }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IIOOutputStreamAdapterTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IIOOutputStreamAdapterTest.java
@@ -31,14 +31,14 @@
 package com.twelvemonkeys.imageio.util;
 
 import com.twelvemonkeys.io.OutputStreamAbstractTest;
-import org.junit.Test;
 
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * IIOOutputStreamAdapterTestCase
@@ -53,9 +53,9 @@ public class IIOOutputStreamAdapterTest extends OutputStreamAbstractTest {
         return new IIOOutputStreamAdapter(new MemoryCacheImageOutputStream(new ByteArrayOutputStream()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new IIOOutputStreamAdapter(null);
+        assertThrows(IllegalArgumentException.class, () -> new IIOOutputStreamAdapter(null));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IIOUtilTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IIOUtilTest.java
@@ -1,8 +1,7 @@
 package com.twelvemonkeys.imageio.util;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * IIOUtilTest

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageReaderAbstractTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageReaderAbstractTest.java
@@ -540,7 +540,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
                     System.err.println("tempActual.getAbsolutePath(): " + tempActual.getAbsolutePath());
                     ImageIO.write(actual, "PNG", tempActual);
 
-                    assertEquals(String.format("%s ARGB at (%d, %d)", message, x, y), String.format("#%08x", expectedRGB), String.format("#%08x", actualRGB));
+                    assertEquals(String.format("#%08x", expectedRGB), String.format("#%08x", actualRGB), String.format("%s ARGB at (%d, %d)", message, x, y));
                 }
             }
         }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageReaderAbstractTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageReaderAbstractTest.java
@@ -323,10 +323,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         reader.setInput(data.getInputStream());
 
         try {
-            IndexOutOfBoundsException exception = assertThrows(IndexOutOfBoundsException.class, () -> {
+            assertThrows(IndexOutOfBoundsException.class, () -> {
                 reader.read(-1, reader.getDefaultReadParam());
             });
-            assertNotNull(exception);
         }
         finally {
             reader.dispose();

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageReaderAbstractTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageReaderAbstractTest.java
@@ -33,8 +33,7 @@ package com.twelvemonkeys.imageio.util;
 import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
 import com.twelvemonkeys.lang.Validate;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -63,7 +62,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import static java.lang.Math.min;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -129,7 +129,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             }
         }
 
-        assertTrue(String.format("%s not provided by %s for '%s'", pReaderClass.getSimpleName(), provider.getClass().getSimpleName(), pFormat), found);
+        assertTrue(found, String.format("%s not provided by %s for '%s'", pReaderClass.getSimpleName(), provider.getClass().getSimpleName(), pFormat));
     }
 
     private boolean isOurProvider(final ImageReaderSpi spi) {
@@ -164,7 +164,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         for (TestData data : testData) {
             ImageInputStream stream = data.getInputStream();
             assertNotNull(stream);
-            assertTrue("Provider is expected to be able to decode data: " + data, provider.canDecodeInput(stream));
+            assertTrue(provider.canDecodeInput(stream), "Provider is expected to be able to decode data: " + data);
         }
     }
 
@@ -184,7 +184,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             failBecause("Could not test data for read", e);
         }
 
-        assertFalse("ImageReader can read null input", canRead);
+        assertFalse(canRead, "ImageReader can read null input");
     }
 
     @Test
@@ -227,16 +227,16 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
                     failBecause(String.format("Image %s index %s could not be read: %s", data.getInput(), i, e), e);
                 }
 
-                assertNotNull(String.format("Image %s index %s was null!", data.getInput(), i), image);
+                assertNotNull(image, String.format("Image %s index %s was null!", data.getInput(), i));
 
                 assertEquals(
-                        String.format("Image %s index %s has wrong width: %s", data.getInput(), i, image.getWidth()),
                         data.getDimension(i).width,
-                        image.getWidth()
+                        image.getWidth(),
+                        String.format("Image %s index %s has wrong width: %s", data.getInput(), i, image.getWidth())
                 );
                 assertEquals(
-                        String.format("Image %s index %s has wrong height: %s", data.getInput(), i, image.getHeight()),
-                        data.getDimension(i).height, image.getHeight()
+                        data.getDimension(i).height, image.getHeight(),
+                        String.format("Image %s index %s has wrong height: %s", data.getInput(), i, image.getHeight())
                 );
             }
         }
@@ -306,67 +306,56 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         reader.dispose();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testReadNoInput() throws IOException {
         ImageReader reader = createReader();
         // Do not set input
 
-        try {
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
             reader.read(0);
-            fail("Read image with no input");
-        }
-        catch (IOException e) {
-            failBecause("Image could not be read", e);
-        }
+        });
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testReadIndexNegativeWithParam() throws IOException {
         ImageReader reader = createReader();
         TestData data = getTestData().get(0);
         reader.setInput(data.getInputStream());
 
         try {
-            reader.read(-1, reader.getDefaultReadParam());
-            fail("Read image with illegal index");
-        }
-        catch (IOException e) {
-            failBecause("Image could not be read", e);
+            IndexOutOfBoundsException exception = assertThrows(IndexOutOfBoundsException.class, () -> {
+                reader.read(-1, reader.getDefaultReadParam());
+            });
+            assertNotNull(exception);
         }
         finally {
             reader.dispose();
         }
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testReadIndexOutOfBoundsWithParam() throws IOException {
         ImageReader reader = createReader();
         TestData data = getTestData().get(0);
         reader.setInput(data.getInputStream());
-
         try {
-            reader.read(Short.MAX_VALUE, reader.getDefaultReadParam());
-            fail("Read image with index out of bounds");
-        }
-        catch (IOException e) {
-            failBecause("Image could not be read", e);
+            assertThrows(IndexOutOfBoundsException.class, () -> {
+                reader.read(Short.MAX_VALUE, reader.getDefaultReadParam());
+            });
         }
         finally {
             reader.dispose();
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testReadNoInputWithParam() throws IOException {
         ImageReader reader = createReader();
         // Do not set input
-
         try {
-            reader.read(0, reader.getDefaultReadParam());
-            fail("Read image with no input");
-        }
-        catch (IOException e) {
-            failBecause("Image could not be read", e);
+            assertThrows(IllegalStateException.class, () -> {
+                reader.read(0);
+            });
         }
         finally {
             reader.dispose();
@@ -387,9 +376,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             failBecause("Image could not be read", e);
         }
 
-        assertNotNull("Image was null!", image);
-        assertEquals("Read image has wrong width: " + image.getWidth(), data.getDimension(0).width, image.getWidth());
-        assertEquals("Read image has wrong height: " + image.getHeight(), data.getDimension(0).height, image.getHeight());
+        assertNotNull(image, "Image was null!");
+        assertEquals(data.getDimension(0).width, image.getWidth(), "Read image has wrong width: " + image.getWidth());
+        assertEquals(data.getDimension(0).height, image.getHeight(), "Read image has wrong height: " + image.getHeight());
 
         reader.dispose();
     }
@@ -408,9 +397,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             failBecause("Image could not be read", e);
         }
 
-        assertNotNull("Image was null!", image);
-        assertEquals("Read image has wrong width: " + image.getWidth(), data.getDimension(0).width, image.getWidth());
-        assertEquals("Read image has wrong height: " + image.getHeight(), data.getDimension(0).height, image.getHeight());
+        assertNotNull(image, "Image was null!");
+        assertEquals(data.getDimension(0).width, image.getWidth(), "Read image has wrong width: " + image.getWidth());
+        assertEquals(data.getDimension(0).height, image.getHeight(), "Read image has wrong height: " + image.getHeight());
 
         reader.dispose();
     }
@@ -429,9 +418,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             failBecause("Image could not be read", e);
         }
 
-        assertNotNull("Image was null!", image);
-        assertEquals("Read image has wrong width: " + image.getWidth(), data.getDimension(0).width, image.getWidth());
-        assertEquals("Read image has wrong height: " + image.getHeight(), data.getDimension(0).height, image.getHeight());
+        assertNotNull(image, "Image was null!");
+        assertEquals(data.getDimension(0).width, image.getWidth(), "Read image has wrong width: " + image.getWidth());
+        assertEquals(data.getDimension(0).height, image.getHeight(), "Read image has wrong height: " + image.getHeight());
 
         reader.dispose();
     }
@@ -454,9 +443,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
                 failBecause("Image could not be read", e);
             }
 
-            assertNotNull("Image was null!", image);
-            assertEquals("Read image has wrong width: " + image.getWidth(), 10, image.getWidth());
-            assertEquals("Read image has wrong height: " + image.getHeight(), 10, image.getHeight());
+            assertNotNull(image, "Image was null!");
+            assertEquals(10, image.getWidth(), "Read image has wrong width: " + image.getWidth());
+            assertEquals(10, image.getHeight(), "Read image has wrong height: " + image.getHeight());
         }
 
         reader.dispose();
@@ -479,9 +468,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             failBecause("Image could not be read", e);
         }
 
-        assertNotNull("Image was null!", image);
-        assertEquals("Read image has wrong width: ", (data.getDimension(0).width + 4) / 5, image.getWidth());
-        assertEquals("Read image has wrong height: ", (data.getDimension(0).height + 4) / 5, image.getHeight());
+        assertNotNull(image, "Image was null!");
+        assertEquals((data.getDimension(0).width + 4) / 5, image.getWidth(), "Read image has wrong width: ");
+        assertEquals((data.getDimension(0).height + 4) / 5, image.getHeight(), "Read image has wrong height: ");
 
         reader.dispose();
     }
@@ -516,8 +505,8 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
 
     @SuppressWarnings("SameParameterValue")
     protected final void assertSubsampledImageDataEquals(String message, BufferedImage expected, BufferedImage actual, ImageReadParam param) throws IOException {
-        assertNotNull("Expected image was null", expected);
-        assertNotNull("Actual image was null!", actual);
+        assertNotNull(expected, "Expected image was null");
+        assertNotNull(actual, "Actual image was null!");
 
         if (expected == actual) {
             return;
@@ -528,9 +517,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         int xSub = param.getSourceXSubsampling();
         int ySub = param.getSourceYSubsampling();
 
-        assertEquals("Subsampled image has wrong width: ", (expected.getWidth() - xOff + xSub - 1) / xSub, actual.getWidth());
-        assertEquals("Subsampled image has wrong height: ", (expected.getHeight() - yOff + ySub - 1) / ySub, actual.getHeight());
-        assertEquals("Subsampled has different type", expected.getType(), actual.getType());
+        assertEquals((expected.getWidth() - xOff + xSub - 1) / xSub, actual.getWidth(), "Subsampled image has wrong width: ");
+        assertEquals((expected.getHeight() - yOff + ySub - 1) / ySub, actual.getHeight(), "Subsampled image has wrong height: ");
+        assertEquals(expected.getType(), actual.getType(), "Subsampled has different type");
 
         for (int y = 0; y < actual.getHeight(); y++) {
             for (int x = 0; x < actual.getWidth(); x++) {
@@ -558,8 +547,8 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
     }
 
     public static void assertImageDataEquals(String message, BufferedImage expected, BufferedImage actual) {
-        assertNotNull("Expected image was null", expected);
-        assertNotNull("Actual image was null!", actual);
+        assertNotNull(expected, "Expected image was null");
+        assertNotNull(actual, "Actual image was null!");
 
         if (expected == actual) {
             return;
@@ -570,10 +559,10 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
                 int expectedRGB = expected.getRGB(x, y);
                 int actualRGB = actual.getRGB(x, y);
 
-                assertEquals(String.format("%s alpha at (%d, %d)", message, x, y), (expectedRGB >> 24) & 0xff, (actualRGB >> 24) & 0xff, 5);
-                assertEquals(String.format("%s red at (%d, %d)", message, x, y), (expectedRGB >> 16) & 0xff, (actualRGB >> 16) & 0xff, 5);
-                assertEquals(String.format("%s green at (%d, %d)", message, x, y), (expectedRGB >> 8) & 0xff, (actualRGB >> 8) & 0xff, 5);
-                assertEquals(String.format("%s blue at (%d, %d)", message, x, y), expectedRGB & 0xff, actualRGB & 0xff, 5);
+                assertEquals((expectedRGB >> 24) & 0xff, (actualRGB >> 24) & 0xff, 5, String.format("%s alpha at (%d, %d)", message, x, y));
+                assertEquals((expectedRGB >> 16) & 0xff, (actualRGB >> 16) & 0xff, 5, String.format("%s red at (%d, %d)", message, x, y));
+                assertEquals((expectedRGB >> 8) & 0xff, (actualRGB >> 8) & 0xff, 5, String.format("%s green at (%d, %d)", message, x, y));
+                assertEquals(expectedRGB & 0xff, actualRGB & 0xff, 5, String.format("%s blue at (%d, %d)", message, x, y));
             }
         }
     }
@@ -595,9 +584,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             failBecause("Image could not be read", e);
         }
 
-        assertNotNull("Image was null!", image);
-        assertEquals("Read image has wrong width: " + image.getWidth(), 10, image.getWidth());
-        assertEquals("Read image has wrong height: " + image.getHeight(), 10, image.getHeight());
+        assertNotNull(image, "Image was null!");
+        assertEquals(10, image.getWidth(), "Read image has wrong width: " + image.getWidth());
+        assertEquals(10, image.getHeight(), "Read image has wrong height: " + image.getHeight());
 
         reader.dispose();
     }
@@ -622,9 +611,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
 
             final BufferedImage image = reader.read(imageIndex, param);
 
-            assertNotNull("Image was null!", image);
-            assertEquals("Read image has wrong width: " + image.getWidth(), r.width, image.getWidth());
-            assertEquals("Read image has wrong height: " + image.getHeight(), r.height, image.getHeight());
+            assertNotNull(image, "Image was null!");
+            assertEquals(r.width, image.getWidth(), "Read image has wrong width: " + image.getWidth());
+            assertEquals(r.height, image.getHeight(), "Read image has wrong height: " + image.getHeight());
 
             try {
                 assertImageDataEquals("Images differ", roi, image);
@@ -678,9 +667,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
                 failBecause("Image could not be read", e);
             }
 
-            assertNotNull("Image was null!", image);
-            assertEquals("Read image has wrong width: " + image.getWidth(), 10, image.getWidth());
-            assertEquals("Read image has wrong height: " + image.getHeight(), 10, image.getHeight());
+            assertNotNull(image, "Image was null!");
+            assertEquals(10, image.getWidth(), "Read image has wrong width: " + image.getWidth());
+            assertEquals(10, image.getHeight(), "Read image has wrong height: " + image.getHeight());
         }
 
         reader.dispose();
@@ -705,9 +694,9 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         catch (IOException e) {
             failBecause("Image could not be read", e);
         }
-        assertNotNull("Image was null!", image);
-        assertEquals("Read image has wrong width: " + image.getWidth(), 5, image.getWidth());
-        assertEquals("Read image has wrong height: " + image.getHeight(), 5, image.getHeight());
+        assertNotNull(image, "Image was null!");
+        assertEquals(5, image.getWidth(), "Read image has wrong width: " + image.getWidth());
+        assertEquals(5, image.getHeight(), "Read image has wrong height: " + image.getHeight());
 
         reader.dispose();
     }
@@ -798,11 +787,11 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             failBecause("Image could not be read", e);
         }
 
-        assertNotNull("Image was null!", image);
-        assertEquals("Read image has wrong width: " + image.getWidth(),
-                data.getDimension(0).width, image.getWidth());
-        assertEquals("Read image has wrong height: " + image.getHeight(),
-                data.getDimension(0).height, image.getHeight());
+        assertNotNull(image, "Image was null!");
+        assertEquals( data.getDimension(0).width, image.getWidth(),
+                "Read image has wrong width: " + image.getWidth());
+        assertEquals( data.getDimension(0).height, image.getHeight(),
+                "Read image has wrong height: " + image.getHeight());
 
         reader.dispose();
     }
@@ -821,11 +810,11 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             failBecause("Image could not be read", e);
         }
 
-        assertNotNull("Image was null!", image);
-        assertEquals("Read image has wrong width: " + image.getWidth(),
-                data.getDimension(0).width, image.getWidth());
-        assertEquals("Read image has wrong height: " + image.getHeight(),
-                data.getDimension(0).height, image.getHeight());
+        assertNotNull(image, "Image was null!");
+        assertEquals(data.getDimension(0).width, image.getWidth(),
+                "Read image has wrong width: " + image.getWidth());
+        assertEquals(data.getDimension(0).height, image.getHeight(),
+                "Read image has wrong height: " + image.getHeight());
 
         reader.dispose();
     }
@@ -954,7 +943,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         catch (IOException e) {
             fail("Could not read image width: " + e);
         }
-        assertEquals("Wrong width reported", data.getDimension(0).width, width);
+        assertEquals(data.getDimension(0).width, width, "Wrong width reported");
         reader.dispose();
     }
 
@@ -993,7 +982,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         catch (IOException e) {
             fail("Could not read image width: " + e);
         }
-        assertEquals("Wrong width reported", 0, width);
+        assertEquals(0, width, "Wrong width reported");
         reader.dispose();
     }
 
@@ -1010,7 +999,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         catch (IOException e) {
             fail("Could not read image height: " + e);
         }
-        assertEquals("Wrong height reported", data.getDimension(0).height, height);
+        assertEquals(data.getDimension(0).height, height, "Wrong height reported");
         reader.dispose();
     }
 
@@ -1028,7 +1017,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         catch (IOException e) {
             fail("Could not read image height: " + e);
         }
-        assertEquals("Wrong height reported", 0, height);
+        assertEquals(0, height, "Wrong height reported");
         reader.dispose();
     }
 
@@ -1067,7 +1056,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             fail("Could not read image aspect ratio" + e);
         }
         Dimension d = data.getDimension(0);
-        assertEquals("Wrong aspect aspect ratio", d.getWidth() / d.getHeight(), aspectRatio, 0.001);
+        assertEquals(d.getWidth() / d.getHeight(), aspectRatio, 0.001, "Wrong aspect aspect ratio");
         reader.dispose();
     }
 
@@ -1085,7 +1074,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         catch (IOException e) {
             fail("Could not read image aspect ratio" + e);
         }
-        assertEquals("Wrong aspect aspect ratio", 0f, aspectRatio, 0f);
+        assertEquals(0f, aspectRatio, 0f, "Wrong aspect aspect ratio");
         reader.dispose();
     }
 
@@ -1381,7 +1370,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
                 }
             }
 
-            assertTrue("ImageTypeSpecifier from getRawImageType should be in the iterator from getImageTypes", rawFound);
+            assertTrue(rawFound, "ImageTypeSpecifier from getRawImageType should be in the iterator from getImageTypes");
         }
 
         reader.dispose();
@@ -1487,7 +1476,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
             }
             catch (IllegalArgumentException expected) {
                 String message = expected.getMessage().toLowerCase();
-                assertTrue("Wrong message: " + message, message.contains("dest"));
+                assertTrue(message.contains("dest"), "Wrong message: " + message);
             }
         }
         reader.dispose();
@@ -1637,7 +1626,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         BufferedImage two = reader.read(0);
 
         // Test for same BufferedImage instance
-        assertNotSame("Multiple reads return same (mutable) image", one, two);
+        assertNotSame(one, two, "Multiple reads return same (mutable) image");
 
         // Test for same backing storage (array)
         one.setRGB(0, 0, Color.BLACK.getRGB());
@@ -1721,7 +1710,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
                         BufferedImage one = reader.readThumbnail(i, j);
                         BufferedImage two = reader.readThumbnail(i, j);
 
-                        assertNotSame("Multiple reads return same (mutable) image", one, two);
+                        assertNotSame(one, two, "Multiple reads return same (mutable) image");
 
                         Graphics2D g = one.createGraphics();
                         try {
@@ -1786,13 +1775,13 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         reader.dispose();
     }
 
-    @Ignore("TODO: Implement")
+    @Disabled("TODO: Implement")
     @Test
     public void testSetDestinationBands() {
         throw new UnsupportedOperationException("Method testSetDestinationBands not implemented"); // TODO: Implement
     }
 
-    @Ignore("TODO: Implement")
+    @Disabled("TODO: Implement")
     @Test
     public void testSetSourceBands() {
         throw new UnsupportedOperationException("Method testSetDestinationBands not implemented"); // TODO: Implement
@@ -1893,7 +1882,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         public ImageInputStream getInputStream() {
             try {
                 ImageInputStream stream = ImageIO.createImageInputStream(input);
-                assertNotNull("Could not create ImageInputStream for input: " + input, stream);
+                assertNotNull(stream, "Could not create ImageInputStream for input: " + input);
 
                 return stream;
             }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageReaderAbstractTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageReaderAbstractTest.java
@@ -311,7 +311,7 @@ public abstract class ImageReaderAbstractTest<T extends ImageReader> {
         ImageReader reader = createReader();
         // Do not set input
 
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+        assertThrows(IllegalStateException.class, () -> {
             reader.read(0);
         });
     }

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageTypeSpecifiersTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageTypeSpecifiersTest.java
@@ -32,14 +32,13 @@ package com.twelvemonkeys.imageio.util;
 
 import com.twelvemonkeys.lang.Validate;
 
-import org.junit.Test;
 
 import javax.imageio.ImageTypeSpecifier;
 import java.awt.color.*;
 import java.awt.image.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ImageTypeSpecifiersTest {
 

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageWriterAbstractTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageWriterAbstractTest.java
@@ -169,11 +169,7 @@ public abstract class ImageWriterAbstractTest<T extends ImageWriter> {
         ImageWriter writer = createWriter();
 
         assertThrows(IllegalStateException.class, () -> {
-            try {
                 writer.write(getTestData(0));
-            } catch (IOException e) {
-                fail(e.getMessage()); // Fail if IOException is thrown
-            }
         }, "Expected IllegalStateException when no output is set on writer");
     }
 

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageWriterAbstractTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageWriterAbstractTest.java
@@ -32,7 +32,6 @@ package com.twelvemonkeys.imageio.util;
 
 import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
 
-import org.junit.Test;
 import org.mockito.InOrder;
 
 import javax.imageio.ImageIO;
@@ -50,10 +49,8 @@ import java.lang.reflect.ParameterizedType;
 import java.net.URL;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -145,7 +142,7 @@ public abstract class ImageWriterAbstractTest<T extends ImageWriter> {
                 throw new AssertionError(e.getMessage(), e);
             }
 
-            assertTrue("No image data written", buffer.size() > 0);
+            assertTrue(buffer.size() > 0, "No image data written");
         }
     }
 
@@ -164,26 +161,27 @@ public abstract class ImageWriterAbstractTest<T extends ImageWriter> {
             throw new AssertionError(e.getMessage(), e);
         }
 
-        assertEquals("Image data written", 0, buffer.size());
+        assertEquals( 0, buffer.size(), "Image data written");
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testWriteNoOutput() throws IOException {
         ImageWriter writer = createWriter();
 
-        try {
-            writer.write(getTestData(0));
-        }
-        catch (IOException e) {
-            fail(e.getMessage());
-        }
+        assertThrows(IllegalStateException.class, () -> {
+            try {
+                writer.write(getTestData(0));
+            } catch (IOException e) {
+                fail(e.getMessage()); // Fail if IOException is thrown
+            }
+        }, "Expected IllegalStateException when no output is set on writer");
     }
 
     @Test
     public void testGetDefaultWriteParam() throws IOException {
         ImageWriter writer = createWriter();
         ImageWriteParam param = writer.getDefaultWriteParam();
-        assertNotNull("Default ImageWriteParam is null", param);
+        assertNotNull(param, "Default ImageWriteParam is null");
     }
 
     // TODO: Test writing with params

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageWriterAbstractTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/ImageWriterAbstractTest.java
@@ -161,7 +161,7 @@ public abstract class ImageWriterAbstractTest<T extends ImageWriter> {
             throw new AssertionError(e.getMessage(), e);
         }
 
-        assertEquals( 0, buffer.size(), "Image data written");
+        assertEquals(0, buffer.size(), "Image data written");
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IndexedImageTypeSpecifierTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/IndexedImageTypeSpecifierTest.java
@@ -30,17 +30,14 @@
 
 package com.twelvemonkeys.imageio.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.IndexColorModel;
 
 import javax.imageio.ImageTypeSpecifier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * IndexedImageTypeSpecifierTestCase
@@ -82,9 +79,9 @@ public class IndexedImageTypeSpecifierTest {
         assertNotEquals(spec.hashCode(), different.hashCode());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNull() {
-        new IndexedImageTypeSpecifier(null);
+        assertThrows(IllegalArgumentException.class, () -> new IndexedImageTypeSpecifier(null));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/RasterUtilsTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/RasterUtilsTest.java
@@ -1,15 +1,13 @@
 package com.twelvemonkeys.imageio.util;
 
-import org.junit.Test;
-
 import javax.imageio.ImageTypeSpecifier;
 import java.awt.*;
 import java.awt.color.ColorSpace;
 import java.awt.image.*;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * RasterUtilsTest.
@@ -19,15 +17,15 @@ import static org.junit.Assert.assertSame;
  * @version $Id: RasterUtilsTest.java,v 1.0 05/05/2021 haraldk Exp$
  */
 public class RasterUtilsTest {
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testAsByteRasterFromNull() {
-        RasterUtils.asByteRaster((Raster) null);
+        assertThrows(NullPointerException.class, () -> RasterUtils.asByteRaster((Raster) null));
     }
 
     @SuppressWarnings("RedundantCast")
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testAsByteRasterWritableFromNull() {
-        RasterUtils.asByteRaster((WritableRaster) null);
+        assertThrows(NullPointerException.class, () -> RasterUtils.asByteRaster((WritableRaster) null));
     }
 
     @Test

--- a/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/UInt32ImageTypeSpecifierTest.java
+++ b/imageio/imageio-core/src/test/java/com/twelvemonkeys/imageio/util/UInt32ImageTypeSpecifierTest.java
@@ -32,8 +32,6 @@ package com.twelvemonkeys.imageio.util;
 
 import com.twelvemonkeys.imageio.color.ColorSpaces;
 
-import org.junit.Test;
-
 import javax.imageio.ImageTypeSpecifier;
 import java.awt.color.ColorSpace;
 import java.awt.image.ComponentColorModel;
@@ -42,7 +40,9 @@ import java.awt.image.PixelInterleavedSampleModel;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UInt32ImageTypeSpecifierTest {
     private static final ColorSpace sRGB = ColorSpace.getInstance(ColorSpace.CS_sRGB);

--- a/imageio/imageio-hdr/src/test/java/com/twelvemonkeys/imageio/plugins/hdr/tonemap/DefaultToneMapperTest.java
+++ b/imageio/imageio-hdr/src/test/java/com/twelvemonkeys/imageio/plugins/hdr/tonemap/DefaultToneMapperTest.java
@@ -1,8 +1,7 @@
 package com.twelvemonkeys.imageio.plugins.hdr.tonemap;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DefaultToneMapperTest {
 

--- a/imageio/imageio-hdr/src/test/java/com/twelvemonkeys/imageio/plugins/hdr/tonemap/GammaToneMapperTest.java
+++ b/imageio/imageio-hdr/src/test/java/com/twelvemonkeys/imageio/plugins/hdr/tonemap/GammaToneMapperTest.java
@@ -1,8 +1,7 @@
 package com.twelvemonkeys.imageio.plugins.hdr.tonemap;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GammaToneMapperTest {
     private final GammaToneMapper mapper = new GammaToneMapper();

--- a/imageio/imageio-hdr/src/test/java/com/twelvemonkeys/imageio/plugins/hdr/tonemap/NullToneMapperTest.java
+++ b/imageio/imageio-hdr/src/test/java/com/twelvemonkeys/imageio/plugins/hdr/tonemap/NullToneMapperTest.java
@@ -1,8 +1,7 @@
 package com.twelvemonkeys.imageio.plugins.hdr.tonemap;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class NullToneMapperTest {
     private final NullToneMapper mapper = new NullToneMapper();

--- a/imageio/imageio-icns/src/test/java/com/twelvemonkeys/imageio/plugins/icns/ICNSImageReaderTest.java
+++ b/imageio/imageio-icns/src/test/java/com/twelvemonkeys/imageio/plugins/icns/ICNSImageReaderTest.java
@@ -32,8 +32,9 @@ package com.twelvemonkeys.imageio.plugins.icns;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 
 import javax.imageio.spi.ImageReaderSpi;
 import java.awt.*;
@@ -126,14 +127,14 @@ public class ICNSImageReaderTest extends ImageReaderAbstractTest<ICNSImageReader
     }
 
     @Test
-    @Ignore("Known issue: Subsampled reading not supported")
+    @Disabled("Known issue: Subsampled reading not supported")
     @Override
     public void testReadWithSubsampleParamPixels() throws IOException {
         super.testReadWithSubsampleParamPixels();
     }
 
     @Test
-    @Ignore("Known issue: Source region reading not supported")
+    @Disabled("Known issue: Source region reading not supported")
     @Override
     public void testReadWithSourceRegionParamEqualImage() throws IOException {
         super.testReadWithSourceRegionParamEqualImage();

--- a/imageio/imageio-icns/src/test/java/com/twelvemonkeys/imageio/plugins/icns/ICNSImageWriterTest.java
+++ b/imageio/imageio-icns/src/test/java/com/twelvemonkeys/imageio/plugins/icns/ICNSImageWriterTest.java
@@ -32,8 +32,6 @@ package com.twelvemonkeys.imageio.plugins.icns;
 
 import com.twelvemonkeys.imageio.util.ImageWriterAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriter;
@@ -45,8 +43,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertTrue;
 
 /**
  * ICNSImageWriterTest.
@@ -78,15 +77,14 @@ public class ICNSImageWriterTest extends ImageWriterAbstractTest<ICNSImageWriter
         );
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteNonSquare() throws IOException {
         // ICNS only supports square icons (except some arcane 16x12 we don't currently support)
         ImageWriter writer = createWriter();
         try (ImageOutputStream stream = ImageIO.createImageOutputStream(new ByteArrayOutputStream())) {
 
             writer.setOutput(stream);
-
-            writer.write(new BufferedImage(32, 64, BufferedImage.TYPE_INT_ARGB));
+            assertThrows(IllegalArgumentException.class, () -> writer.write(new BufferedImage(32, 64, BufferedImage.TYPE_INT_ARGB)));
 
         }
         finally {
@@ -94,7 +92,7 @@ public class ICNSImageWriterTest extends ImageWriterAbstractTest<ICNSImageWriter
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteBadSize() throws IOException {
         // ICNS only supports sizes in multiples of 2 (16, 32, 64, ..., 1024 + 48 and 96)
         ImageWriter writer = createWriter();
@@ -102,7 +100,7 @@ public class ICNSImageWriterTest extends ImageWriterAbstractTest<ICNSImageWriter
 
             writer.setOutput(stream);
 
-            writer.write(new BufferedImage(17, 17, BufferedImage.TYPE_INT_ARGB));
+            assertThrows(IllegalArgumentException.class, () -> writer.write(new BufferedImage(17, 17, BufferedImage.TYPE_INT_ARGB)));
 
         }
         finally {
@@ -121,7 +119,7 @@ public class ICNSImageWriterTest extends ImageWriterAbstractTest<ICNSImageWriter
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testWriteSequenceNotStarted() throws IOException {
         // ICNS only supports sizes in multiples of 2 (16, 32, 64, ..., 1024 + 48 and 96)
         ImageWriter writer = createWriter();
@@ -130,7 +128,7 @@ public class ICNSImageWriterTest extends ImageWriterAbstractTest<ICNSImageWriter
             writer.setOutput(stream);
 
             BufferedImage image = new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB);
-            writer.writeToSequence(new IIOImage(image, null, null), writer.getDefaultWriteParam());
+            assertThrows(IllegalStateException.class, () -> writer.writeToSequence(new IIOImage(image, null, null), writer.getDefaultWriteParam()));
 
         }
         finally {
@@ -138,21 +136,21 @@ public class ICNSImageWriterTest extends ImageWriterAbstractTest<ICNSImageWriter
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testEndSequenceNotStarted() throws IOException {
         // ICNS only supports sizes in multiples of 2 (16, 32, 64, ..., 1024 + 48 and 96)
         ImageWriter writer = createWriter();
         try (ImageOutputStream stream = ImageIO.createImageOutputStream(new ByteArrayOutputStream())) {
 
             writer.setOutput(stream);
-            writer.endWriteSequence();
+            assertThrows(IllegalStateException.class, () -> writer.endWriteSequence());
         }
         finally {
             writer.dispose();
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testPrepareSequenceAlreadyStarted() throws IOException {
         // ICNS only supports sizes in multiples of 2 (16, 32, 64, ..., 1024 + 48 and 96)
         ImageWriter writer = createWriter();
@@ -160,7 +158,7 @@ public class ICNSImageWriterTest extends ImageWriterAbstractTest<ICNSImageWriter
 
             writer.setOutput(stream);
             writer.prepareWriteSequence(null);
-            writer.prepareWriteSequence(null);
+            assertThrows(IllegalStateException.class, () -> writer.prepareWriteSequence(null));
         }
         finally {
             writer.dispose();

--- a/imageio/imageio-iff/src/test/java/com/twelvemonkeys/imageio/plugins/iff/IFFImageMetadataTest.java
+++ b/imageio/imageio-iff/src/test/java/com/twelvemonkeys/imageio/plugins/iff/IFFImageMetadataTest.java
@@ -2,8 +2,6 @@ package com.twelvemonkeys.imageio.plugins.iff;
 
 import com.twelvemonkeys.imageio.util.ImageTypeSpecifiers;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -15,8 +13,9 @@ import javax.imageio.metadata.IIOMetadataNode;
 import java.awt.image.*;
 import java.nio.charset.StandardCharsets;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static java.awt.image.BufferedImage.*;
-import static org.junit.Assert.*;
 
 public class IFFImageMetadataTest {
 
@@ -42,20 +41,14 @@ public class IFFImageMetadataTest {
         // Other formats
         assertNull(metadata.getNativeMetadataFormatName());
         assertNull(metadata.getExtraMetadataFormatNames());
-        assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-            @Override
-            public void run() {
-                metadata.getAsTree("com_foo_bar_1.0");
-            }
+        assertThrows(IllegalArgumentException.class, () -> {
+            metadata.getAsTree("com_foo_bar_1.0");
         });
 
         // Read-only
         assertTrue(metadata.isReadOnly());
-        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
-            @Override
-            public void run() throws Throwable {
-                metadata.mergeTree(IIOMetadataFormatImpl.standardMetadataFormatName, new IIOMetadataNode(IIOMetadataFormatImpl.standardMetadataFormatName));
-            }
+        assertThrows(IllegalStateException.class, () -> {
+            metadata.mergeTree(IIOMetadataFormatImpl.standardMetadataFormatName, new IIOMetadataNode(IIOMetadataFormatImpl.standardMetadataFormatName));
         });
     }
 

--- a/imageio/imageio-iff/src/test/java/com/twelvemonkeys/imageio/plugins/iff/IFFImageReaderTest.java
+++ b/imageio/imageio-iff/src/test/java/com/twelvemonkeys/imageio/plugins/iff/IFFImageReaderTest.java
@@ -32,8 +32,6 @@ package com.twelvemonkeys.imageio.plugins.iff;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.spi.ImageReaderSpi;
 import java.awt.*;
@@ -45,8 +43,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * IFFImageReaderTestCase
  *
@@ -144,9 +142,9 @@ public class IFFImageReaderTest extends ImageReaderAbstractTest<IFFImageReader> 
         for (int i = 0; i < 32; i++) {
             // Make sure the color model is really EHB
             try {
-                assertEquals("red", (reds[i] & 0xff) / 2, reds[i + 32] & 0xff);
-                assertEquals("blue", (blues[i] & 0xff) / 2, blues[i + 32] & 0xff);
-                assertEquals("green", (greens[i] & 0xff) / 2, greens[i + 32] & 0xff);
+                assertEquals((reds[i] & 0xff) / 2, reds[i + 32] & 0xff, "red");
+                assertEquals((blues[i] & 0xff) / 2, blues[i + 32] & 0xff, "blue");
+                assertEquals((greens[i] & 0xff) / 2, greens[i + 32] & 0xff, "green");
             }
             catch (AssertionError err) {
                 throw new AssertionError("Color " + i + " " + err.getMessage(), err);

--- a/imageio/imageio-iff/src/test/java/com/twelvemonkeys/imageio/plugins/iff/IFFImageWriterTest.java
+++ b/imageio/imageio-iff/src/test/java/com/twelvemonkeys/imageio/plugins/iff/IFFImageWriterTest.java
@@ -33,8 +33,6 @@ package com.twelvemonkeys.imageio.plugins.iff;
 import com.twelvemonkeys.image.MonochromeColorModel;
 import com.twelvemonkeys.imageio.util.ImageWriterAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriter;
 import javax.imageio.spi.ImageWriterSpi;
@@ -49,8 +47,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * JPEG2000ImageWriterTest
  *
@@ -104,7 +102,7 @@ public class IFFImageWriterTest extends ImageWriterAbstractTest<IFFImageWriter> 
                     stream.close(); // Force data to be written
                 }
     
-                assertTrue("No image data written", buffer.size() > 0);
+                assertTrue(buffer.size() > 0, "No image data written");
     
                 ImageInputStream input = ImageIO.createImageInputStream(new ByteArrayInputStream(buffer.toByteArray()));
                 BufferedImage written = ImageIO.read(input);
@@ -129,14 +127,14 @@ public class IFFImageWriterTest extends ImageWriterAbstractTest<IFFImageWriter> 
 
                 if (expected.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_GRAY) {
                     // NOTE: For some reason, gray data seems to be one step off...
-                    assertEquals("R(" + x + "," + y + ")", expectedRGB & 0xff0000, actualRGB & 0xff0000, 0x10000);
-                    assertEquals("G(" + x + "," + y + ")", expectedRGB & 0x00ff00, actualRGB & 0x00ff00, 0x100);
-                    assertEquals("B(" + x + "," + y + ")", expectedRGB & 0x0000ff, actualRGB & 0x0000ff, 0x1);
+                    assertEquals(expectedRGB & 0xff0000, actualRGB & 0xff0000, 0x10000, "R(" + x + "," + y + ")");
+                    assertEquals(expectedRGB & 0x00ff00, actualRGB & 0x00ff00, 0x100, "G(" + x + "," + y + ")");
+                    assertEquals(expectedRGB & 0x0000ff, actualRGB & 0x0000ff, 0x1, "B(" + x + "," + y + ")");
                 }
                 else {
-                    assertEquals("R(" + x + "," + y + ")", expectedRGB & 0xff0000, actualRGB & 0xff0000);
-                    assertEquals("G(" + x + "," + y + ")", expectedRGB & 0x00ff00, actualRGB & 0x00ff00);
-                    assertEquals("B(" + x + "," + y + ")", expectedRGB & 0x0000ff, actualRGB & 0x0000ff);
+                    assertEquals(expectedRGB & 0xff0000, actualRGB & 0xff0000, "R(" + x + "," + y + ")");
+                    assertEquals(expectedRGB & 0x00ff00, actualRGB & 0x00ff00, "G(" + x + "," + y + ")");
+                    assertEquals(expectedRGB & 0x0000ff, actualRGB & 0x0000ff, "B(" + x + "," + y + ")");
                 }
             }
         }

--- a/imageio/imageio-iff/src/test/java/com/twelvemonkeys/imageio/plugins/iff/RGB8RLEDecoderTest.java
+++ b/imageio/imageio-iff/src/test/java/com/twelvemonkeys/imageio/plugins/iff/RGB8RLEDecoderTest.java
@@ -5,15 +5,13 @@ import com.twelvemonkeys.io.enc.Decoder;
 import com.twelvemonkeys.io.enc.DecoderAbstractTest;
 import com.twelvemonkeys.io.enc.Encoder;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * RGB8RLEDecoderTest.
@@ -42,36 +40,39 @@ public class RGB8RLEDecoderTest extends DecoderAbstractTest {
         ByteArrayInputStream bytes = new ByteArrayInputStream(new byte[0]);
 
         int count = decoder.decode(bytes, ByteBuffer.allocate(BUFFER_SIZE));
-        assertEquals("Should not be able to read any bytes", 0, count);
+        assertEquals(0, count, "Should not be able to read any bytes");
     }
 
-    @Test(expected = EOFException.class)
+    @Test
     public final void testDecodePartial() throws IOException {
         Decoder decoder = createDecoder();
         ByteArrayInputStream bytes = new ByteArrayInputStream(new byte[] {0});
 
-        decoder.decode(bytes, ByteBuffer.allocate(BUFFER_SIZE));
-        fail("Should not be able to read any bytes");
+        assertThrows(EOFException.class, () -> {
+            decoder.decode(bytes, ByteBuffer.allocate(BUFFER_SIZE));
+        }, "Should not be able to read any bytes");
     }
 
-    @Test(expected = EOFException.class)
+    @Test
     public final void testDecodePartialToo() throws IOException {
         Decoder decoder = createDecoder();
         ByteArrayInputStream bytes = new ByteArrayInputStream(new byte[] {0, 0, 0, 1, 0, 0});
 
-        decoder.decode(bytes, ByteBuffer.allocate(BUFFER_SIZE));
-        fail("Should not be able to read any bytes");
+        assertThrows(EOFException.class, () -> {
+            decoder.decode(bytes, ByteBuffer.allocate(BUFFER_SIZE));
+        }, "Should not be able to read any bytes");
     }
 
-    @Test(expected = DecodeException.class)
+    @Test
     public final void testDecodeZeroRun() throws IOException {
         // The spec says that 0-runs should be used to signal that the run is > 127,
         // and contained in the next byte, however, this is not used in practise and not supported.
         Decoder decoder = createDecoder();
         ByteArrayInputStream bytes = new ByteArrayInputStream(new byte[] {0, 0, 0, 0});
 
-        decoder.decode(bytes, ByteBuffer.allocate(BUFFER_SIZE));
-        fail("Should not be able to read any bytes");
+        assertThrows(DecodeException.class, () -> {
+            decoder.decode(bytes, ByteBuffer.allocate(BUFFER_SIZE));
+        }, "Should not be able to read any bytes");
     }
 
     @Test

--- a/imageio/imageio-jpeg-jai-interop/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/jaiinterop/JAITIFFImageReaderInteroperabilityTest.java
+++ b/imageio/imageio-jpeg-jai-interop/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/jaiinterop/JAITIFFImageReaderInteroperabilityTest.java
@@ -33,9 +33,6 @@ package com.twelvemonkeys.imageio.plugins.jpeg.jaiinterop;
 import com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageReaderSpi;
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.spi.IIORegistry;
@@ -47,7 +44,9 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests the JAI TIFFImageReader delegating to our JPEGImageReader.
@@ -99,7 +98,7 @@ public class JAITIFFImageReaderInteroperabilityTest extends ImageReaderAbstractT
         return Collections.emptyList();
     }
 
-    @Ignore("Fails in TIFFImageReader")
+    @Disabled("Fails in TIFFImageReader")
     @Override
     public void testSetDestinationIllegal() {
     }

--- a/imageio/imageio-jpeg-jep262-interop/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/jep262interop/JEP262TIFFImageReaderInteroperabilityTest.java
+++ b/imageio/imageio-jpeg-jep262-interop/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/jep262interop/JEP262TIFFImageReaderInteroperabilityTest.java
@@ -33,10 +33,6 @@ package com.twelvemonkeys.imageio.plugins.jpeg.jep262interop;
 import com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageReaderSpi;
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.AssumptionViolatedException;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.spi.IIORegistry;
@@ -48,7 +44,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 /**
  * Tests the JEP 262 TIFFImageReader delegating to our JPEGImageReader.
@@ -74,7 +73,8 @@ public class JEP262TIFFImageReaderInteroperabilityTest extends ImageReaderAbstra
         }
 
         // Skip tests if we have no Spi (ie. pre JDK 9)
-        throw new AssumptionViolatedException("Provider " + JEP_262_PROVIDER_CLASS_NAME + " not found");
+        assumeTrue(providers.hasNext(), "Provider " + JEP_262_PROVIDER_CLASS_NAME + " not found");
+        return providers.next();
     }
 
     @Override
@@ -101,7 +101,7 @@ public class JEP262TIFFImageReaderInteroperabilityTest extends ImageReaderAbstra
         return Collections.emptyList();
     }
 
-    @Ignore("Fails in TIFFImageReader")
+    @Disabled("Fails in TIFFImageReader")
     @Override
     public void testSetDestinationIllegal() {
     }

--- a/imageio/imageio-jpeg-jep262-interop/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/jep262interop/JEP262TIFFImageReaderInteroperabilityTest.java
+++ b/imageio/imageio-jpeg-jep262-interop/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/jep262interop/JEP262TIFFImageReaderInteroperabilityTest.java
@@ -68,10 +68,6 @@ public class JEP262TIFFImageReaderInteroperabilityTest extends ImageReaderAbstra
             }
         }, true);
 
-        if (providers.hasNext()) {
-            return providers.next();
-        }
-
         // Skip tests if we have no Spi (ie. pre JDK 9)
         assumeTrue(providers.hasNext(), "Provider " + JEP_262_PROVIDER_CLASS_NAME + " not found");
         return providers.next();

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/AbstractThumbnailReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/AbstractThumbnailReaderTest.java
@@ -38,8 +38,7 @@ import javax.imageio.stream.ImageInputStream;
 import java.io.IOException;
 import java.net.URL;
 
-import static org.junit.Assert.assertNotNull;
-
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * AbstractThumbnailReaderTest
  *
@@ -57,7 +56,7 @@ public abstract class AbstractThumbnailReaderTest {
     protected final ImageInputStream createStream(final String name) throws IOException {
         URL resource = getClass().getResource(name);
         ImageInputStream stream = ImageIO.createImageInputStream(resource);
-        assertNotNull("Could not create stream for resource " + resource, stream);
+        assertNotNull(stream, "Could not create stream for resource " + resource);
         return stream;
     }
 }

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/EXIFThumbnailReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/EXIFThumbnailReaderTest.java
@@ -41,9 +41,6 @@ import com.twelvemonkeys.imageio.metadata.tiff.TIFF;
 import com.twelvemonkeys.imageio.metadata.tiff.TIFFEntry;
 import com.twelvemonkeys.imageio.metadata.tiff.TIFFReader;
 
-import org.junit.After;
-import org.junit.Test;
-
 import javax.imageio.IIOException;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -56,8 +53,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
 
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * EXIFThumbnailReaderTest
  *
@@ -69,7 +67,7 @@ public class EXIFThumbnailReaderTest extends AbstractThumbnailReaderTest {
 
     private final ImageReader thumbnailReader = ImageIO.getImageReadersByFormatName("jpeg").next();
 
-    @After
+    @AfterEach
     public void tearDown() {
         thumbnailReader.dispose();
     }
@@ -94,48 +92,48 @@ public class EXIFThumbnailReaderTest extends AbstractThumbnailReaderTest {
         assertNull(EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList())), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromMissingThumbnail() throws IOException {
-        EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(Collections.<Entry>emptyList())), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(Collections.<Entry>emptyList())), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromUnsupportedThumbnailCompression() throws IOException {
         List<TIFFEntry> entries = Collections.singletonList(new TIFFEntry(TIFF.TAG_COMPRESSION, 42));
-        EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromMissingOffsetUncompressed() throws IOException {
         List<TIFFEntry> entries = Arrays.asList(
                 new TIFFEntry(TIFF.TAG_COMPRESSION, 1),
                 new TIFFEntry(TIFF.TAG_IMAGE_WIDTH, 16),
                 new TIFFEntry(TIFF.TAG_IMAGE_HEIGHT, 9)
         );
-        EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromMissingWidthUncompressed() throws IOException {
         List<TIFFEntry> entries = Arrays.asList(
                 new TIFFEntry(TIFF.TAG_COMPRESSION, 1),
                 new TIFFEntry(TIFF.TAG_STRIP_OFFSETS, 0),
                 new TIFFEntry(TIFF.TAG_IMAGE_HEIGHT, 9)
         );
-        EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromMissingHeightUncompressed() throws IOException {
         List<TIFFEntry> entries = Arrays.asList(
                 new TIFFEntry(TIFF.TAG_COMPRESSION, 1),
                 new TIFFEntry(TIFF.TAG_STRIP_OFFSETS, 0),
                 new TIFFEntry(TIFF.TAG_IMAGE_WIDTH, 16)
         );
-        EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromUnsupportedPhotometricUncompressed() throws IOException {
         List<TIFFEntry> entries = Arrays.asList(
                 new TIFFEntry(TIFF.TAG_COMPRESSION, 1),
@@ -144,10 +142,10 @@ public class EXIFThumbnailReaderTest extends AbstractThumbnailReaderTest {
                 new TIFFEntry(TIFF.TAG_IMAGE_HEIGHT, 9),
                 new TIFFEntry(TIFF.TAG_PHOTOMETRIC_INTERPRETATION, 42)
         );
-        EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromUnsupportedBitsPerSampleUncompressed() throws IOException {
         List<TIFFEntry> entries = Arrays.asList(
                 new TIFFEntry(TIFF.TAG_COMPRESSION, 1),
@@ -156,10 +154,10 @@ public class EXIFThumbnailReaderTest extends AbstractThumbnailReaderTest {
                 new TIFFEntry(TIFF.TAG_IMAGE_HEIGHT, 9),
                 new TIFFEntry(TIFF.TAG_BITS_PER_SAMPLE, new int[]{5, 6, 5})
         );
-        EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9 * 3]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromUnsupportedSamplesPerPixelUncompressed() throws IOException {
         List<TIFFEntry> entries = Arrays.asList(
                 new TIFFEntry(TIFF.TAG_COMPRESSION, 1),
@@ -168,10 +166,10 @@ public class EXIFThumbnailReaderTest extends AbstractThumbnailReaderTest {
                 new TIFFEntry(TIFF.TAG_IMAGE_HEIGHT, 90),
                 new TIFFEntry(TIFF.TAG_SAMPLES_PER_PIXEL, 1)
         );
-        EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[6 + 16 * 9]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromTruncatedUncompressed() throws IOException {
         List<TIFFEntry> entries = Arrays.asList(
                 new TIFFEntry(TIFF.TAG_COMPRESSION, 1),
@@ -179,7 +177,7 @@ public class EXIFThumbnailReaderTest extends AbstractThumbnailReaderTest {
                 new TIFFEntry(TIFF.TAG_IMAGE_WIDTH, 160),
                 new TIFFEntry(TIFF.TAG_IMAGE_HEIGHT, 90)
         );
-        EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
     @Test
@@ -200,19 +198,19 @@ public class EXIFThumbnailReaderTest extends AbstractThumbnailReaderTest {
         assertNotNull(reader.read());
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromMissingOffsetJPEG() throws IOException {
         List<TIFFEntry> entries = Collections.singletonList(new TIFFEntry(TIFF.TAG_COMPRESSION, 6));
-        EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromTruncatedJPEG() throws IOException {
         List<TIFFEntry> entries = Arrays.asList(
                 new TIFFEntry(TIFF.TAG_COMPRESSION, 6),
                 new TIFFEntry(TIFF.TAG_JPEG_INTERCHANGE_FORMAT, 0)
         );
-        EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader);
+        assertThrows(IIOException.class, () -> EXIFThumbnail.from(new EXIF(new byte[42]), new EXIFDirectory(new IFD(Collections.<Entry>emptyList()), new IFD(entries)), thumbnailReader));
     }
 
 

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/FastCMYKToRGBTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/FastCMYKToRGBTest.java
@@ -30,16 +30,14 @@
 
 package com.twelvemonkeys.imageio.plugins.jpeg;
 
-import org.junit.Test;
-
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 /**
  * FastCMYKToRGBTest
  *
@@ -63,7 +61,7 @@ public class FastCMYKToRGBTest {
         assertNotNull(pixel);
         assertEquals(3, pixel.length);
         byte[] expected = {(byte) 255, (byte) 255, (byte) 255};
-        assertArrayEquals(String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)), expected, pixel);
+        assertArrayEquals(expected, pixel, String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)));
     }
 
     @Test
@@ -77,7 +75,7 @@ public class FastCMYKToRGBTest {
         assertEquals(1, pixel.length);
         int expected = 0xFFFFFF;
         int rgb = pixel[0] & 0xFFFFFF;
-        assertEquals(String.format("Was: 0x%08x, expected: 0x%08x", rgb, expected), expected, rgb);
+        assertEquals(expected, rgb, String.format("Was: 0x%08x, expected: 0x%08x", rgb, expected));
     }
 
     @Test
@@ -95,7 +93,7 @@ public class FastCMYKToRGBTest {
             assertNotNull(pixel);
             assertEquals(3, pixel.length);
             byte[] expected = {(byte) 0, (byte) 0, (byte) 0};
-            assertArrayEquals(String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)), expected, pixel);
+            assertArrayEquals( expected, pixel, String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)));
         }
     }
 
@@ -115,7 +113,7 @@ public class FastCMYKToRGBTest {
             assertEquals(1, pixel.length);
             int expected = 0x0;
             int rgb = pixel[0] & 0xFFFFFF;
-            assertEquals(String.format("Was: 0x%08x, expected: 0x%08x", rgb, expected), expected, rgb);
+            assertEquals(expected, rgb, String.format("Was: 0x%08x, expected: 0x%08x", rgb, expected));
         }
     }
 
@@ -134,7 +132,7 @@ public class FastCMYKToRGBTest {
             assertNotNull(pixel);
             assertEquals(3, pixel.length);
             byte[] expected = {(byte) (255 - i), (byte) i, (byte) (127 - i)};
-            assertArrayEquals(String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)), expected, pixel);
+            assertArrayEquals(expected, pixel, String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)));
         }
     }
 
@@ -153,7 +151,7 @@ public class FastCMYKToRGBTest {
             assertNotNull(pixel);
             assertEquals(3, pixel.length);
             byte[] expected = {(byte) (255 - i), (byte) i, (byte) (127 - i)};
-            assertArrayEquals(String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)), expected, pixel);
+            assertArrayEquals(expected, pixel, String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)));
         }
     }
 
@@ -172,7 +170,7 @@ public class FastCMYKToRGBTest {
             assertNotNull(pixel);
             assertEquals(4, pixel.length);
             byte[] expected = {(byte) (255 - i), (byte) i, (byte) (127 - i), (byte) 0xff};
-            assertArrayEquals(String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)), expected, pixel);
+            assertArrayEquals(expected, pixel, String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)));
         }
     }
 
@@ -192,7 +190,7 @@ public class FastCMYKToRGBTest {
             assertEquals(1, pixel.length);
             int expected = (((byte) (255 - i)) & 0xFF) << 16 | (((byte) i) & 0xFF) << 8 | ((byte) (127 - i)) & 0xFF;
             int rgb = pixel[0] & 0xFFFFFF;
-            assertEquals(String.format("Was: 0x%08x, expected: 0x%08x", rgb, expected), expected, rgb);
+            assertEquals(expected, rgb, String.format("Was: 0x%08x, expected: 0x%08x", rgb, expected));
         }
     }
 
@@ -212,7 +210,7 @@ public class FastCMYKToRGBTest {
             assertEquals(1, pixel.length);
             int expected = (((byte) (127 - i)) & 0xFF) << 16 | (((byte) i) & 0xFF) << 8 | ((byte) (255 - i)) & 0xFF;
             int rgb = pixel[0] & 0xFFFFFF;
-            assertEquals(String.format("Was: 0x%08x, expected: 0x%08x", rgb, expected), expected, rgb);
+            assertEquals( expected, rgb, String.format("Was: 0x%08x, expected: 0x%08x", rgb, expected));
         }
     }
 
@@ -231,7 +229,7 @@ public class FastCMYKToRGBTest {
             assertNotNull(pixel);
             assertEquals(1, pixel.length);
             int expected = 0xFF << 24 | (((byte) (255 - i)) & 0xFF) << 16 | (((byte) i) & 0xFF) << 8 | ((byte) (127 - i)) & 0xFF;
-            assertEquals(String.format("Was: 0x%08x, expected: 0x%08x", pixel[0], expected), expected, pixel[0]);
+            assertEquals(expected, pixel[0], String.format("Was: 0x%08x, expected: 0x%08x", pixel[0], expected));
         }
     }
 }

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JFIFThumbnailReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JFIFThumbnailReaderTest.java
@@ -34,8 +34,6 @@ import com.twelvemonkeys.imageio.metadata.jpeg.JPEG;
 import com.twelvemonkeys.imageio.metadata.jpeg.JPEGSegment;
 import com.twelvemonkeys.imageio.metadata.jpeg.JPEGSegmentUtil;
 
-import org.junit.Test;
-
 import javax.imageio.IIOException;
 import javax.imageio.stream.ImageInputStream;
 import java.awt.image.BufferedImage;
@@ -43,7 +41,8 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * JFIFThumbnailReaderTest
@@ -82,9 +81,9 @@ public class JFIFThumbnailReaderTest extends AbstractThumbnailReaderTest {
         assertNull(JFIFThumbnail.from(new JFIF(1, 1, 0, 1, 1, 0, 0, new byte[0])));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromTruncated() throws IOException {
-        JFIFThumbnail.from(new JFIF(1, 1, 0, 1, 1, 255, 170, new byte[99]));
+        assertThrows(IIOException.class, () -> JFIFThumbnail.from(new JFIF(1, 1, 0, 1, 1, 255, 170, new byte[99])));
     }
 
     @Test

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JFXXThumbnailReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JFXXThumbnailReaderTest.java
@@ -34,9 +34,6 @@ import com.twelvemonkeys.imageio.metadata.jpeg.JPEG;
 import com.twelvemonkeys.imageio.metadata.jpeg.JPEGSegment;
 import com.twelvemonkeys.imageio.metadata.jpeg.JPEGSegmentUtil;
 
-import org.junit.After;
-import org.junit.Test;
-
 import javax.imageio.IIOException;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -46,7 +43,9 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * JFXXThumbnailReaderTest
@@ -70,7 +69,7 @@ public class JFXXThumbnailReaderTest extends AbstractThumbnailReaderTest {
         return JFXXThumbnail.from(JFXX.read(new DataInputStream(jfxx.segmentData()), jfxx.length()), thumbnailReader);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         thumbnailReader.dispose();
     }
@@ -80,37 +79,37 @@ public class JFXXThumbnailReaderTest extends AbstractThumbnailReaderTest {
         assertNull(JFXXThumbnail.from(null, thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromNullThumbnail() throws IOException {
-        JFXXThumbnail.from(new JFXX(JFXX.JPEG, null), thumbnailReader);
+        assertThrows(IIOException.class, () -> JFXXThumbnail.from(new JFXX(JFXX.JPEG, null), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromEmpty() throws IOException {
-        JFXXThumbnail.from(new JFXX(JFXX.JPEG, new byte[0]), thumbnailReader);
+        assertThrows(IIOException.class, () -> JFXXThumbnail.from(new JFXX(JFXX.JPEG, new byte[0]), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromTruncatedJPEG() throws IOException {
-        JFXXThumbnail.from(new JFXX(JFXX.JPEG, new byte[99]), thumbnailReader);
+        assertThrows(IIOException.class, () -> JFXXThumbnail.from(new JFXX(JFXX.JPEG, new byte[99]), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromTruncatedRGB() throws IOException {
         byte[] thumbnail = new byte[765];
         thumbnail[0] = (byte) 160;
         thumbnail[1] = 90;
 
-        JFXXThumbnail.from(new JFXX(JFXX.RGB, thumbnail), thumbnailReader);
+        assertThrows(IIOException.class, () -> JFXXThumbnail.from(new JFXX(JFXX.RGB, thumbnail), thumbnailReader));
     }
 
-    @Test(expected = IIOException.class)
+    @Test
     public void testFromTruncatedIndexed() throws IOException {
         byte[] thumbnail = new byte[365];
         thumbnail[0] = (byte) 160;
         thumbnail[1] = 90;
 
-        JFXXThumbnail.from(new JFXX(JFXX.INDEXED, thumbnail), thumbnailReader);
+        assertThrows(IIOException.class, () -> JFXXThumbnail.from(new JFXX(JFXX.INDEXED, thumbnail), thumbnailReader));
     }
 
     @Test

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImage10MetadataTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImage10MetadataTest.java
@@ -32,7 +32,6 @@ package com.twelvemonkeys.imageio.plugins.jpeg;
 
 import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
 
-import org.junit.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -48,8 +47,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.twelvemonkeys.imageio.util.IIOUtil.lookupProviderByName;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * JPEGImage10MetadataTest.

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
@@ -813,16 +813,13 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
             ImageReadParam param = reader.getDefaultReadParam();
             param.setDestination(image);
             assertThrows(IIOException.class, () -> {
-                try {
                     reader.read(0, param);
-                } catch (IOException e) {
-                    // Even if we get an exception here, the image should contain 10-15% of the image
-                    assertRGBEquals(0xffffffff, image.getRGB(0, 0));   // white area
-                    assertRGBEquals(0xff0000ff, image.getRGB(67, 22)); // blue area
-                    assertRGBEquals(0xffff00ff, image.getRGB(83, 22)); // purple area
-                    throw e;
-                }
             });
+
+            // Even if we get an exception here, the image should contain 10-15% of the image
+            assertRGBEquals(0xffffffff, image.getRGB(0, 0));   // white area
+            assertRGBEquals(0xff0000ff, image.getRGB(67, 22)); // blue area
+            assertRGBEquals(0xffff00ff, image.getRGB(83, 22)); // purple area
         }
         finally {
             reader.dispose();

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
@@ -604,7 +604,7 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
     @Test
     public void testBrokenGetRawImageTypeIgnoreMetadata() throws IOException {
         JPEGImageReader reader = createReader();
-        assertTimeout(ofMillis(200), () -> {
+        assertTimeoutPreemptively(ofMillis(200), () -> {
             try {
                 for (TestData broken : getBrokenTestData()) {
                     reader.setInput(broken.getInputStream(), true, true);
@@ -654,7 +654,7 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
     @Test
     public void testBrokenGetImageTypesIgnoreMetadata() throws IOException {
         JPEGImageReader reader = createReader();
-        assertTimeout(ofMillis(200), () -> {
+        assertTimeoutPreemptively(ofMillis(200), () -> {
             try {
                 for (TestData broken : getBrokenTestData()) {
                     reader.setInput(broken.getInputStream(), true, true);
@@ -2003,7 +2003,7 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
     @Test
     public void testInfiniteLoopCorrupt() throws IOException {
         ImageReader reader = createReader();
-        assertTimeout(Duration.ofSeconds(1), () -> {
+        assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
             try (ImageInputStream iis = ImageIO.createImageInputStream(getClassLoaderResource("/broken-jpeg/110115680-6d6dce80-7d84-11eb-99df-4cb21df3b09f.jpeg"))) {
                 reader.setInput(iis);
 
@@ -2019,7 +2019,7 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
     @Test
     public void testInfiniteLoopCorruptRaster() throws IOException {
         ImageReader reader = createReader();
-        assertTimeout(Duration.ofSeconds(1), () -> {
+        assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
             try (ImageInputStream iis = ImageIO.createImageInputStream(getClassLoaderResource("/broken-jpeg/110115680-6d6dce80-7d84-11eb-99df-4cb21df3b09f.jpeg"))) {
                 reader.setInput(iis);
 

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
@@ -1565,7 +1565,7 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
             fail("Expected tree is null, actual tree is non-null");
         }
 
-        assertEquals(String.format("%s: Node names differ", message), expectedTree.getNodeName(), actualTree.getNodeName());
+        assertEquals(expectedTree.getNodeName(), actualTree.getNodeName(), String.format("%s: Node names differ", message));
 
         NamedNodeMap expectedAttributes = expectedTree.getAttributes();
         NamedNodeMap actualAttributes = actualTree.getAttributes();
@@ -1579,7 +1579,7 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
                 nodeValue = StringUtil.capitalize(nodeValue);
             }
 
-            assertEquals(String.format("%s: \"%s\" attribute for <%s> differ", message, item.getNodeName(), expectedTree.getNodeName()), nodeValue, actualAttributes.getNamedItem(item.getNodeName()).getNodeValue());
+            assertEquals(nodeValue, actualAttributes.getNamedItem(item.getNodeName()).getNodeValue());
         }
 
         // Test for equal user objects.

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageWriterTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageWriterTest.java
@@ -35,7 +35,7 @@ import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.imageio.util.IIOUtil;
 import com.twelvemonkeys.imageio.util.ImageWriterAbstractTest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.NodeList;
 
 import javax.imageio.IIOImage;
@@ -64,8 +64,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGSegmentImageInputStreamTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGSegmentImageInputStreamTest.java
@@ -232,7 +232,7 @@ public class JPEGSegmentImageInputStreamTest {
 
     @Test
     public void testInfiniteLoopCorrupt() throws IOException {
-        assertTimeout(Duration.ofSeconds(1), () -> {
+        assertTimeoutPreemptively(Duration.ofSeconds(1), () -> {
             try (ImageInputStream stream = new JPEGSegmentImageInputStream(ImageIO.createImageInputStream(getClassLoaderResource("/broken-jpeg/110115680-6d6dce80-7d84-11eb-99df-4cb21df3b09f.jpeg")))) {
                 long length = 0;
                 while (stream.read() != -1) {

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/LuminanceToGrayTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/LuminanceToGrayTest.java
@@ -30,14 +30,14 @@
 
 package com.twelvemonkeys.imageio.plugins.jpeg;
 
-import org.junit.Test;
 
 import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LuminanceToGrayTest {
     @Test
@@ -56,7 +56,7 @@ public class LuminanceToGrayTest {
             assertNotNull(pixel);
             assertEquals(1, pixel.length);
             byte[] expected = {(byte) i};
-            assertArrayEquals(String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)), expected, pixel);
+            assertArrayEquals(expected, pixel, String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)));
         }
     }
 
@@ -76,7 +76,7 @@ public class LuminanceToGrayTest {
             assertNotNull(pixel);
             assertEquals(1, pixel.length);
             byte[] expected = {(byte) i};
-            assertArrayEquals(String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)), expected, pixel);
+            assertArrayEquals(expected, pixel, String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)));
         }
     }
 
@@ -96,7 +96,7 @@ public class LuminanceToGrayTest {
             assertNotNull(pixel);
             assertEquals(2, pixel.length);
             byte[] expected = {(byte) i, (byte) (255 - i)};
-            assertArrayEquals(String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)), expected, pixel);
+            assertArrayEquals(expected, pixel, String.format("Was: %s, expected: %s", Arrays.toString(pixel), Arrays.toString(expected)));
         }
     }
 }

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/AbstractEntryTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/AbstractEntryTest.java
@@ -30,9 +30,8 @@
 
 package com.twelvemonkeys.imageio.metadata;
 
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * AbstractEntryTest
@@ -51,9 +50,9 @@ public class AbstractEntryTest extends EntryAbstractTest {
         return new AbstractEntry(identifier, value) {};
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateEntryNullId() {
-        createEntry(null, new Object());
+        assertThrows(IllegalArgumentException.class, () -> createEntry(null, new Object()));
     }
 
     @Test

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/CompoundDirectoryAbstractTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/CompoundDirectoryAbstractTest.java
@@ -30,14 +30,12 @@
 
 package com.twelvemonkeys.imageio.metadata;
 
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * CompoundDirectoryTest
@@ -60,9 +58,9 @@ public abstract class CompoundDirectoryAbstractTest extends DirectoryAbstractTes
         return createCompoundDirectory(Collections.<Directory>singleton(createSingleDirectory(entries)));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullDirectories() {
-        createCompoundDirectory(Collections.<Directory>singleton(null));
+        assertThrows(IllegalArgumentException.class, () -> createCompoundDirectory(Collections.<Directory>singleton(null)));
     }
 
     @Test
@@ -103,12 +101,12 @@ public abstract class CompoundDirectoryAbstractTest extends DirectoryAbstractTes
         assertSame(three, directory.getDirectory(2));
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testOutOfBounds() {
         Directory only = createSingleDirectory(null);
         CompoundDirectory directory = createCompoundDirectory(Collections.<Directory>singleton(only));
 
-        directory.getDirectory(directory.directoryCount());
+        assertThrows(IndexOutOfBoundsException.class, () -> directory.getDirectory(directory.directoryCount()));
     }
 
     protected static final class TestDirectory extends AbstractDirectory {

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/DirectoryAbstractTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/DirectoryAbstractTest.java
@@ -31,11 +31,11 @@
 package com.twelvemonkeys.imageio.metadata;
 
 import com.twelvemonkeys.lang.ObjectAbstractTest;
-import org.junit.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * DirectoryTest
@@ -65,9 +65,9 @@ public abstract class DirectoryAbstractTest extends ObjectAbstractTest {
         assertEquals(0, directory.size());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullEntries() {
-        createDirectory(Collections.<Entry>singleton(null));
+        assertThrows(IllegalArgumentException.class, () -> createDirectory(Collections.<Entry>singleton(null)));
     }
 
     @Test

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/EntryAbstractTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/EntryAbstractTest.java
@@ -31,11 +31,11 @@
 package com.twelvemonkeys.imageio.metadata;
 
 import com.twelvemonkeys.lang.ObjectAbstractTest;
-import org.junit.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * EntryTest

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/MetadataReaderAbstractTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/MetadataReaderAbstractTest.java
@@ -35,7 +35,6 @@ import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
 
 import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
@@ -44,7 +43,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * ReaderAbstractTest
@@ -71,9 +71,9 @@ public abstract class MetadataReaderAbstractTest {
 
     protected abstract MetadataReader createReader();
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testReadNull() throws IOException {
-        createReader().read(null);
+        assertThrows(IllegalArgumentException.class, () -> createReader().read(null));
     }
 
     @Test

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/MetadataWriterAbstractTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/MetadataWriterAbstractTest.java
@@ -31,8 +31,8 @@
 package com.twelvemonkeys.imageio.metadata;
 
 import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
-import org.junit.Test;
 
+import org.junit.jupiter.api.Test;
 import javax.imageio.ImageIO;
 import javax.imageio.spi.IIORegistry;
 import javax.imageio.stream.ImageInputStream;
@@ -42,6 +42,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * ReaderAbstractTest
@@ -68,14 +70,17 @@ public abstract class MetadataWriterAbstractTest {
 
     protected abstract MetadataWriter createWriter();
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteNullDirectory() throws IOException {
-        createWriter().write(null, new MemoryCacheImageOutputStream(new ByteArrayOutputStream()));
+
+        assertThrows(IllegalArgumentException.class, () ->  createWriter().write(null, new MemoryCacheImageOutputStream(new ByteArrayOutputStream())));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteNullStream() throws IOException {
-        createWriter().write(new AbstractDirectory(new ArrayList<Entry>()) {
-        }, null);
+        assertThrows(IllegalArgumentException.class, () ->
+                createWriter().write(new AbstractDirectory(new ArrayList<Entry>()) {
+                }, null)
+        );
     }
 }

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/exif/EXIFReaderTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/exif/EXIFReaderTest.java
@@ -36,17 +36,16 @@ import com.twelvemonkeys.imageio.metadata.MetadataReaderAbstractTest;
 import com.twelvemonkeys.imageio.metadata.tiff.TIFF;
 import com.twelvemonkeys.imageio.stream.SubImageInputStream;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
 
 /**
  * EXIFReaderTest
@@ -83,14 +82,16 @@ public class EXIFReaderTest extends MetadataReaderAbstractTest {
         assertEquals(exif.size(), exif.getDirectory(0).size() + exif.getDirectory(1).size());
     }
 
-    @Test(expected = IndexOutOfBoundsException.class)
+    @Test
     public void testDirectoryOutOfBounds() throws IOException {
         InputStream data = getData();
 
         CompoundDirectory exif = (CompoundDirectory) createReader().read(ImageIO.createImageInputStream(data));
 
         assertEquals(2, exif.directoryCount());
-        assertNotNull(exif.getDirectory(exif.directoryCount()));
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            exif.getDirectory(exif.directoryCount());
+        });
     }
 
     @Test

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/exif/EXIFWriterTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/exif/EXIFWriterTest.java
@@ -37,7 +37,6 @@ import com.twelvemonkeys.imageio.metadata.tiff.TIFFReader;
 import com.twelvemonkeys.imageio.metadata.tiff.TIFFWriter;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
-import org.junit.Test;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageOutputStream;
@@ -47,8 +46,8 @@ import java.io.InputStream;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * TIFFWriterTest

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/exif/RationalTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/exif/RationalTest.java
@@ -30,9 +30,8 @@
 
 package com.twelvemonkeys.imageio.metadata.exif;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * RationalTest
@@ -43,19 +42,19 @@ import static org.junit.Assert.assertEquals;
  */
 @SuppressWarnings("deprecation")
 public class RationalTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testZeroDenominator() {
-        new Rational(1, 0);
+        assertThrows(IllegalArgumentException.class, () -> new Rational(1, 0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLongMinValueNumerator() {
-        new Rational(Long.MIN_VALUE, 1);
+        assertThrows(IllegalArgumentException.class, () -> new Rational(Long.MIN_VALUE, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLongMinValueDenominator() {
-        new Rational(1, Long.MIN_VALUE);
+        assertThrows(IllegalArgumentException.class, () -> new Rational(1, Long.MIN_VALUE));
     }
 
     @Test

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/iptc/IPTCReaderTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/iptc/IPTCReaderTest.java
@@ -33,14 +33,13 @@ package com.twelvemonkeys.imageio.metadata.iptc;
 import com.twelvemonkeys.imageio.metadata.Directory;
 import com.twelvemonkeys.imageio.metadata.MetadataReaderAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
 
 /**
  * IPTCReaderTest

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/iptc/IPTCWriterTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/iptc/IPTCWriterTest.java
@@ -34,7 +34,6 @@ import com.twelvemonkeys.imageio.metadata.Directory;
 import com.twelvemonkeys.imageio.metadata.MetadataWriter;
 import com.twelvemonkeys.imageio.metadata.MetadataWriterAbstractTest;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
-import org.junit.Test;
 
 import javax.imageio.stream.MemoryCacheImageOutputStream;
 import java.io.ByteArrayOutputStream;
@@ -43,8 +42,9 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * IPTCWriterTest.
@@ -72,8 +72,7 @@ public class IPTCWriterTest extends MetadataWriterAbstractTest {
     public void testRewriteExisting() throws IOException {
         IPTCReader reader = createReader();
         Directory iptc = reader.read(getDataAsIIS());
-        assumeNotNull(iptc);
-
+        assumeTrue(iptc != null, "IPTC object should not be null");
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         MemoryCacheImageOutputStream stream = new MemoryCacheImageOutputStream(bytes);
         createWriter().write(iptc, stream);

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/jpeg/JPEGQualityTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/jpeg/JPEGQualityTest.java
@@ -31,8 +31,6 @@
 package com.twelvemonkeys.imageio.metadata.jpeg;
 
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -47,8 +45,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * JPEGQualityTest
@@ -97,7 +96,7 @@ public class JPEGQualityTest {
         }
     }
 
-    @Ignore("Need a JPEG test image with bad DQT data...")
+    @Disabled("Need a JPEG test image with bad DQT data...")
     @Test
     public void testGetQualityBadData() throws IOException {
         ImageInputStream stream = ImageIO.createImageInputStream(getClass().getResourceAsStream("/bad-data"));
@@ -257,9 +256,9 @@ public class JPEGQualityTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetQTablesNull() throws IOException {
-        JPEGQuality.getQTables(null);
+        assertThrows(IllegalArgumentException.class, () -> JPEGQuality.getQTables(null));
     }
 
     @Test

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/jpeg/JPEGSegmentTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/jpeg/JPEGSegmentTest.java
@@ -31,11 +31,11 @@
 package com.twelvemonkeys.imageio.metadata.jpeg;
 
 import com.twelvemonkeys.lang.ObjectAbstractTest;
-import org.junit.Test;
 
 import java.nio.charset.Charset;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.assertEquals;
 
 /**
  * JPEGSegmentTest

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/jpeg/JPEGSegmentUtilTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/jpeg/JPEGSegmentUtilTest.java
@@ -31,7 +31,6 @@
 package com.twelvemonkeys.imageio.metadata.jpeg;
 
 import com.twelvemonkeys.imageio.stream.URLImageInputStreamSpi;
-import org.junit.Test;
 
 import javax.imageio.IIOException;
 import javax.imageio.ImageIO;
@@ -46,8 +45,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * JPEGSegmentUtilTest
@@ -148,7 +147,7 @@ public class JPEGSegmentUtilTest {
         }
 
         ICC_Profile profile = ICC_Profile.getInstance(new SequenceInputStream(Collections.enumeration(Arrays.asList(streams))));
-        assertNotNull("Profile could not be read, probably bad data", profile);
+        assertNotNull(profile, "Profile could not be read, probably bad data");
     }
 
     @Test
@@ -156,9 +155,9 @@ public class JPEGSegmentUtilTest {
         List<JPEGSegment> segments = JPEGSegmentUtil.readSegments(getData("/jpeg/9788245605525.jpg"), JPEGSegmentUtil.ALL_SEGMENTS);
         assertEquals(7, segments.size());
 
-        assertEquals(segments.toString(), JPEG.SOF0, segments.get(3).marker());
-        assertEquals(segments.toString(), null, segments.get(3).identifier());
-        assertEquals(segments.toString(), JPEG.SOS, segments.get(segments.size() - 1).marker());
+        assertEquals(JPEG.SOF0, segments.get(3).marker(), segments.toString());
+        assertEquals(null, segments.get(3).identifier(), segments.toString());
+        assertEquals(JPEG.SOS, segments.get(segments.size() - 1).marker(), segments.toString());
     }
 
     @Test
@@ -166,9 +165,9 @@ public class JPEGSegmentUtilTest {
         List<JPEGSegment> segments = JPEGSegmentUtil.readSegments(getData("/jpeg/ts_open_300dpi.jpg"), JPEGSegmentUtil.ALL_SEGMENTS);
         assertEquals(27, segments.size());
 
-        assertEquals(segments.toString(), JPEG.SOF0, segments.get(23).marker());
-        assertEquals(segments.toString(), null, segments.get(23).identifier());
-        assertEquals(segments.toString(), JPEG.SOS, segments.get(segments.size() - 1).marker());
+        assertEquals(JPEG.SOF0, segments.get(23).marker(), segments.toString());
+        assertEquals(null, segments.get(23).identifier(), segments.toString());
+        assertEquals(JPEG.SOS, segments.get(segments.size() - 1).marker(), segments.toString());
     }
 
     @Test

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/psd/PSDReaderTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/psd/PSDReaderTest.java
@@ -33,15 +33,14 @@ package com.twelvemonkeys.imageio.metadata.psd;
 import com.twelvemonkeys.imageio.metadata.Directory;
 import com.twelvemonkeys.imageio.metadata.MetadataReaderAbstractTest;
 import com.twelvemonkeys.imageio.stream.SubImageInputStream;
-import org.junit.Test;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PhotoshopReaderTest

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/BigTIFFWriterTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/BigTIFFWriterTest.java
@@ -34,8 +34,6 @@ import com.twelvemonkeys.imageio.metadata.*;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageOutputStream;
 import javax.imageio.stream.ImageOutputStreamImpl;
@@ -47,8 +45,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * TIFFWriterTest

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/HalfTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/HalfTest.java
@@ -2,15 +2,13 @@ package com.twelvemonkeys.imageio.metadata.tiff;
 
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
 
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * HalfTest.
@@ -39,7 +37,7 @@ public class HalfTest {
     @Test
     public void testExactEncoding() {
         for (short half = -2048; half < 2048; half++) {
-            assertEquals(String.valueOf(half), half, Half.shortBitsToFloat(Half.floatToShortBits(half)), 0);
+            assertEquals(half, Half.shortBitsToFloat(Half.floatToShortBits(half)), 0, String.valueOf(half));
         }
     }
 
@@ -103,14 +101,14 @@ public class HalfTest {
         // TODO: More... But we just delegate to Float.toString, so no worries... :-)
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testParseHalfNull() {
-        Half.parseHalf(null);
+        assertThrows(NullPointerException.class, () -> Half.parseHalf(null));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void testParseHalfBad() {
-        Half.parseHalf("foo");
+        assertThrows(NumberFormatException.class, () -> Half.parseHalf("foo"));
     }
 
     @Test
@@ -120,14 +118,14 @@ public class HalfTest {
         // TODO: More... But we just delegate to Float.valueOf, so no worries... :-)
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testValueOfNull() {
-        Half.valueOf(null);
+        assertThrows(NullPointerException.class, () -> Half.valueOf(null));
     }
 
-    @Test(expected = NumberFormatException.class)
+    @Test
     public void testValueOfBad() {
-        Half.valueOf("foo");
+        assertThrows(NumberFormatException.class, () -> Half.valueOf("foo"));
     }
 
     @Test

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/RationalTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/RationalTest.java
@@ -30,9 +30,8 @@
 
 package com.twelvemonkeys.imageio.metadata.tiff;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * RationalTest
@@ -42,20 +41,20 @@ import static org.junit.Assert.assertEquals;
  * @version $Id: RationalTest.java,v 1.0 Nov 18, 2009 3:23:17 PM haraldk Exp$
  */
 public class RationalTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testZeroDenominator() {
-        new Rational(1, 0);
+        assertThrows(IllegalArgumentException.class, () -> new Rational(1, 0));
     }
 
     // TODO: Find a solution to this problem, as we should be able to work with it...
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLongMinValueNumerator() {
-        new Rational(Long.MIN_VALUE, 1);
+        assertThrows(IllegalArgumentException.class, () -> new Rational(Long.MIN_VALUE, 1));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testLongMinValueDenominator() {
-        new Rational(1, Long.MIN_VALUE);
+        assertThrows(IllegalArgumentException.class, () -> new Rational(1, Long.MIN_VALUE));
     }
 
     @Test
@@ -162,8 +161,8 @@ public class RationalTest {
         assertEquals(Rational.ZERO, new Rational(0, 386).divides(x));
     }
 
-    @Test(expected = ArithmeticException.class)
+    @Test
     public void testDivideZero() {
-        new Rational(3037141, 3247033).divides(new Rational(0, 1));
+        assertThrows(ArithmeticException.class, () -> new Rational(3037141, 3247033).divides(new Rational(0, 1)));
     }
 }

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFEntryTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFEntryTest.java
@@ -32,7 +32,10 @@ package com.twelvemonkeys.imageio.metadata.tiff;
 
 import com.twelvemonkeys.imageio.metadata.Entry;
 import com.twelvemonkeys.imageio.metadata.EntryAbstractTest;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * TIFFEntryTest
@@ -51,9 +54,9 @@ public class TIFFEntryTest extends EntryAbstractTest {
         return new TIFFEntry(identifier, (short) type, value);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateEXIFEntryIllegalType() {
-        createEXIFEntry(0, null, -1);
+        assertThrows(IllegalArgumentException.class, () -> createEXIFEntry(0, null, -1));
     }
     
     // TODO: TIFF/EXIF specific tests

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFReaderTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFReaderTest.java
@@ -372,7 +372,7 @@ public class TIFFReaderTest extends MetadataReaderAbstractTest {
         // This EXIF segment has an interesting bug...
         // The bits per sample value (0x 0008 0008 0008) overwrites half the IFD1 link offset (should be 0x00000000),
         // effectively making it a loop back to the IFD0 at offset 0x0000008...
-        assertTimeout(Duration.ofMillis(200), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(200), () -> {
             try (ImageInputStream stream = ImageIO.createImageInputStream(getResource("/exif/exif-loop.bin"))) {
                 CompoundDirectory directory = (CompoundDirectory) createReader().read(stream);
                 assertEquals(1, directory.directoryCount());
@@ -395,7 +395,7 @@ public class TIFFReaderTest extends MetadataReaderAbstractTest {
                 0, 0, 0, 0,     //
                 0, 0, 0, 8,     // IFD1 pointer
         };
-        assertTimeout(Duration.ofMillis(100), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(100), () -> {
             try (ImageInputStream stream = new ByteArrayImageInputStream(looping)) {
                 CompoundDirectory directory = (CompoundDirectory) createReader().read(stream);
 
@@ -417,7 +417,7 @@ public class TIFFReaderTest extends MetadataReaderAbstractTest {
                 0, 0, 0, 8,     // sub IFD pointer -> IFD0
                 0, 0, 0, 0,     // End of IFD chain
         };
-        assertTimeout(Duration.ofMillis(100), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(100), () -> {
             try (ImageInputStream stream = new ByteArrayImageInputStream(looping)) {
                 CompoundDirectory directory = (CompoundDirectory) createReader().read(stream);
 
@@ -445,7 +445,7 @@ public class TIFFReaderTest extends MetadataReaderAbstractTest {
                 0, 0, 0, 1,     // count
                 0, 0, 0, 26,    // sub IFD pointer -> sub IFD
         };
-        assertTimeout(Duration.ofMillis(100), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(100), () -> {
             try (ImageInputStream stream = new ByteArrayImageInputStream(looping)) {
                 CompoundDirectory directory = (CompoundDirectory) createReader().read(stream);
 
@@ -473,7 +473,7 @@ public class TIFFReaderTest extends MetadataReaderAbstractTest {
                 0, 0, 0, 1,     // count
                 0, 0, 0, 8,     // sub IFD pointer -> IFD0
         };
-        assertTimeout(Duration.ofMillis(100), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(100), () -> {
             try (ImageInputStream stream = new ByteArrayImageInputStream(looping)) {
                 CompoundDirectory directory = (CompoundDirectory) createReader().read(stream);
 

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFWriterTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/tiff/TIFFWriterTest.java
@@ -34,7 +34,6 @@ import com.twelvemonkeys.imageio.metadata.*;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
 
-import org.junit.Test;
 
 import javax.imageio.ImageIO;
 import javax.imageio.stream.ImageOutputStream;
@@ -47,7 +46,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * TIFFWriterTest
@@ -272,7 +272,7 @@ public class TIFFWriterTest extends MetadataWriterAbstractTest {
         Directory read = new TIFFReader().read(new ByteArrayImageInputStream(data));
 
         assertNotNull(read.getEntryById(TIFF.TAG_SOFTWARE));
-        assertTrue("value not an string array", read.getEntryById(TIFF.TAG_SOFTWARE).getValue() instanceof String[]);
+        assertTrue(read.getEntryById(TIFF.TAG_SOFTWARE).getValue() instanceof String[], "value not an string array");
         assertArrayEquals(strings, (String[]) read.getEntryById(TIFF.TAG_SOFTWARE).getValue());
     }
 

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/xmp/XMPEntryTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/xmp/XMPEntryTest.java
@@ -32,11 +32,10 @@ package com.twelvemonkeys.imageio.metadata.xmp;
 
 import com.twelvemonkeys.imageio.metadata.Entry;
 import com.twelvemonkeys.imageio.metadata.EntryAbstractTest;
-import org.junit.Test;
 
 import java.util.*;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * XMPEntryTest

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/xmp/XMPReaderTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/xmp/XMPReaderTest.java
@@ -496,7 +496,7 @@ public class XMPReaderTest extends MetadataReaderAbstractTest {
 
     @Test
     public void testNoExternalRequest() throws Exception {
-        assertTimeout(Duration.ofMillis(2500L), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(2500L), () -> {
             String maliciousXML = resourceAsString("/xmp/xmp-jpeg-xxe.xml");
 
             try (HTTPServer server = new HTTPServer()) {

--- a/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/xmp/XMPScannerTest.java
+++ b/imageio/imageio-metadata/src/test/java/com/twelvemonkeys/imageio/metadata/xmp/XMPScannerTest.java
@@ -30,15 +30,14 @@
 
 package com.twelvemonkeys.imageio.metadata.xmp;
 
-import org.junit.Test;
-
 import java.io.*;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
 
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * XMPScannerTestCase

--- a/imageio/imageio-pcx/src/test/java/com/twelvemonkeys/imageio/plugins/dcx/DCXImageReaderTest.java
+++ b/imageio/imageio-pcx/src/test/java/com/twelvemonkeys/imageio/plugins/dcx/DCXImageReaderTest.java
@@ -32,8 +32,6 @@ package com.twelvemonkeys.imageio.plugins.dcx;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
@@ -44,8 +42,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * DCXImageReaderTest

--- a/imageio/imageio-pcx/src/test/java/com/twelvemonkeys/imageio/plugins/pcx/PCXImageReaderTest.java
+++ b/imageio/imageio-pcx/src/test/java/com/twelvemonkeys/imageio/plugins/pcx/PCXImageReaderTest.java
@@ -32,8 +32,6 @@ package com.twelvemonkeys.imageio.plugins.pcx;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.spi.ImageReaderSpi;
@@ -45,8 +43,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * PCXImageReaderTest

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/PICTImageReaderTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/PICTImageReaderTest.java
@@ -34,9 +34,6 @@ import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStreamSpi;
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import javax.imageio.spi.IIORegistry;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
@@ -47,8 +44,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 import static com.twelvemonkeys.imageio.plugins.pict.PICTImageReaderSpi.isOtherFormat;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * ICOImageReaderTestCase
@@ -142,7 +142,7 @@ public class PICTImageReaderTest extends ImageReaderAbstractTest<PICTImageReader
         assertTrue(isOtherFormat(new ByteArrayImageInputStream(new byte[] {'M', 'M', 0, 43, 0, 0, 0, 0})));
     }
 
-    @Ignore("Known issue")
+    @Disabled("Known issue")
     @Test
     @Override
     public void testReadWithSubsampleParamPixels() throws IOException {

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/PICTImageWriterTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/PICTImageWriterTest.java
@@ -33,8 +33,6 @@ package com.twelvemonkeys.imageio.plugins.pict;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.imageio.util.ImageWriterAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageWriter;
 import javax.imageio.spi.ImageWriterSpi;
@@ -48,7 +46,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PICTImageWriterTest
@@ -100,7 +99,7 @@ public class PICTImageWriterTest extends ImageWriterAbstractTest<PICTImageWriter
                 stream.close(); // Force data to be written
             }
 
-            assertTrue("No image data written", buffer.size() > 0);
+            assertTrue(buffer.size() > 0, "No image data written");
 
             ImageInputStream input = new ByteArrayImageInputStream(buffer.toByteArray());
             BufferedImage written = ImageIO.read(input);
@@ -124,13 +123,13 @@ public class PICTImageWriterTest extends ImageWriterAbstractTest<PICTImageWriter
                     if (original.getColorModel().getColorSpace().getType() == ColorSpace.TYPE_GRAY) {
                         // NOTE: For some reason, gray data seems to be one step off...
                         // ...and vary with different backing CMSs... :-(
-                        assertTrue(String.format("original 0x%08x != gray! (%d,%d)", originalRGB, x, y), expectedR == expectedG && expectedG == expectedB);
-                        assertTrue(String.format("written  0x%08x != gray! (%d,%d)", writtenRGB, x, y), actualR == actualG && actualG == actualB);
+                        assertTrue(expectedR == expectedG && expectedG == expectedB, String.format("original 0x%08x != gray! (%d,%d)", originalRGB, x, y));
+                        assertTrue(actualR == actualG && actualG == actualB, String.format("written  0x%08x != gray! (%d,%d)", writtenRGB, x, y));
                     }
                     else {
-                        assertEquals(String.format("Test data %d R(%d,%d)", i, x, y), expectedR, actualR);
-                        assertEquals(String.format("Test data %d G(%d,%d)", i, x, y), expectedG, actualG);
-                        assertEquals(String.format("Test data %d B(%d,%d)", i, x, y), expectedB, actualB);
+                        assertEquals(expectedR, actualR, String.format("Test data %d R(%d,%d)", i, x, y));
+                        assertEquals(expectedG, actualG, String.format("Test data %d G(%d,%d)", i, x, y));
+                        assertEquals(expectedB, actualB, String.format("Test data %d B(%d,%d)", i, x, y));
                     }
                 }
             }

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTBMPDecompressorTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTBMPDecompressorTest.java
@@ -2,11 +2,10 @@ package com.twelvemonkeys.imageio.plugins.pict;
 
 import com.twelvemonkeys.imageio.plugins.pict.QuickTime.ImageDesc;
 
-import org.junit.Test;
-
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * QTBMPDecompressorTest.

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTGenericDecompressorTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTGenericDecompressorTest.java
@@ -2,9 +2,8 @@ package com.twelvemonkeys.imageio.plugins.pict;
 
 import com.twelvemonkeys.imageio.plugins.pict.QuickTime.ImageDesc;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * QTBMPDecompressorTest.

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressorTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressorTest.java
@@ -2,9 +2,8 @@ package com.twelvemonkeys.imageio.plugins.pict;
 
 import com.twelvemonkeys.imageio.plugins.pict.QuickTime.ImageDesc;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * QTBMPDecompressorTest.

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pntg/PNTGImageReaderTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pntg/PNTGImageReaderTest.java
@@ -10,8 +10,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * PNTGImageReaderTest.
@@ -59,7 +59,7 @@ public class PNTGImageReaderTest extends ImageReaderAbstractTest<PNTGImageReader
         for (TestData data : testData) {
             ImageInputStream stream = data.getInputStream();
             assertNotNull(stream);
-            assertTrue("Provider is expected to be able to decode data: " + data, provider.canDecodeInput(stream));
+            assertTrue(provider.canDecodeInput(stream), "Provider is expected to be able to decode data: " + data);
         }
     }
 }

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pntg/PNTGMetadataTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pntg/PNTGMetadataTest.java
@@ -2,7 +2,7 @@ package com.twelvemonkeys.imageio.plugins.pntg;
 
 import com.twelvemonkeys.imageio.util.ImageTypeSpecifiers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.awt.image.*;
 

--- a/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PAMImageReaderSpiTest.java
+++ b/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PAMImageReaderSpiTest.java
@@ -30,15 +30,15 @@
 
 package com.twelvemonkeys.imageio.plugins.pnm;
 
-import org.junit.Test;
-
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.spi.ImageWriterSpi;
 
+import org.junit.jupiter.api.Test;
 import static com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfoTest.assertClassExists;
 import static com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfoTest.assertClassesExist;
-import static org.junit.Assert.assertNotNull;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PAMImageReaderSpiTest.

--- a/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PAMImageReaderTest.java
+++ b/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PAMImageReaderTest.java
@@ -31,8 +31,6 @@ package com.twelvemonkeys.imageio.plugins.pnm;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
@@ -44,8 +42,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PAMImageReaderTest extends ImageReaderAbstractTest<PNMImageReader> {
     @Override
@@ -133,7 +131,7 @@ public class PAMImageReaderTest extends ImageReaderAbstractTest<PNMImageReader> 
 
     @Test
     public void testXVThumbNotIncorrectlyRecognizedAsPAM() throws IOException {
-        assertTrue("Should recognize PAM format", provider.canDecodeInput(new TestData(getClassLoaderResource("/pam/rgba.pam"), new Dimension()).getInputStream())); // Sanity
-        assertFalse("Should distinguish xv-thumbs from PAM format", provider.canDecodeInput(new TestData(getClassLoaderResource("/xv-thumb/xv-thumb.xvt"), new Dimension()).getInputStream()));
+        assertTrue(provider.canDecodeInput(new TestData(getClassLoaderResource("/pam/rgba.pam"), new Dimension()).getInputStream()), "Should recognize PAM format"); // Sanity
+        assertFalse(provider.canDecodeInput(new TestData(getClassLoaderResource("/xv-thumb/xv-thumb.xvt"), new Dimension()).getInputStream()), "Should distinguish xv-thumbs from PAM format");
     }
 }

--- a/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PAMImageWriterSpiTest.java
+++ b/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PAMImageWriterSpiTest.java
@@ -32,8 +32,6 @@ package com.twelvemonkeys.imageio.plugins.pnm;
 
 import com.twelvemonkeys.imageio.color.ColorSpaces;
 
-import org.junit.Test;
-
 import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageWriter;
 import javax.imageio.spi.ImageReaderSpi;
@@ -44,9 +42,9 @@ import java.awt.image.*;
 
 import static com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfoTest.assertClassExists;
 import static com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfoTest.assertClassesExist;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PAMImageWriterSpiTest.

--- a/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PNMImageReaderSpiTest.java
+++ b/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PNMImageReaderSpiTest.java
@@ -30,15 +30,15 @@
 
 package com.twelvemonkeys.imageio.plugins.pnm;
 
-import org.junit.Test;
-
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.spi.ImageWriterSpi;
 
 import static com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfoTest.assertClassExists;
 import static com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfoTest.assertClassesExist;
-import static org.junit.Assert.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PNMImageReaderSpiTest.

--- a/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PNMImageReaderTest.java
+++ b/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PNMImageReaderTest.java
@@ -31,8 +31,6 @@ package com.twelvemonkeys.imageio.plugins.pnm;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import javax.imageio.ImageTypeSpecifier;
@@ -42,6 +40,8 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 public class PNMImageReaderTest extends ImageReaderAbstractTest<PNMImageReader> {
     @Override

--- a/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PNMImageWriterSpiTest.java
+++ b/imageio/imageio-pnm/src/test/java/com/twelvemonkeys/imageio/plugins/pnm/PNMImageWriterSpiTest.java
@@ -30,7 +30,6 @@
 
 package com.twelvemonkeys.imageio.plugins.pnm;
 
-import org.junit.Test;
 
 import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageWriter;
@@ -42,9 +41,8 @@ import java.awt.image.*;
 
 import static com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfoTest.assertClassExists;
 import static com.twelvemonkeys.imageio.spi.ReaderWriterProviderInfoTest.assertClassesExist;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PNMImageWriterSpiTest.

--- a/imageio/imageio-psd/src/test/java/com/twelvemonkeys/imageio/plugins/psd/HorizontalDeDifferencingStreamTest.java
+++ b/imageio/imageio-psd/src/test/java/com/twelvemonkeys/imageio/plugins/psd/HorizontalDeDifferencingStreamTest.java
@@ -34,8 +34,6 @@ import com.twelvemonkeys.io.FastByteArrayOutputStream;
 import com.twelvemonkeys.io.LittleEndianDataInputStream;
 import com.twelvemonkeys.io.LittleEndianDataOutputStream;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -45,8 +43,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * HorizontalDeDifferencingStreamTest

--- a/imageio/imageio-psd/src/test/java/com/twelvemonkeys/imageio/plugins/psd/PSDImageReaderTest.java
+++ b/imageio/imageio-psd/src/test/java/com/twelvemonkeys/imageio/plugins/psd/PSDImageReaderTest.java
@@ -701,7 +701,7 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
 
     @Test
     public void testBrokenPackBitsThrowsEOFException() throws IOException {
-        assertTimeout(Duration.ofMillis(1000), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(1000), () -> {
             PSDImageReader imageReader = createReader();
 
             try (ImageInputStream stream = ImageIO.createImageInputStream(getClassLoaderResource("/broken-psd/short-packbits.psd"))) {

--- a/imageio/imageio-psd/src/test/java/com/twelvemonkeys/imageio/plugins/psd/PSDImageReaderTest.java
+++ b/imageio/imageio-psd/src/test/java/com/twelvemonkeys/imageio/plugins/psd/PSDImageReaderTest.java
@@ -33,7 +33,6 @@ package com.twelvemonkeys.imageio.plugins.psd;
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 import com.twelvemonkeys.imageio.util.ProgressListenerBase;
 
-import org.junit.Test;
 import org.w3c.dom.NodeList;
 
 import javax.imageio.ImageIO;
@@ -49,13 +48,15 @@ import java.awt.color.*;
 import java.awt.image.*;
 import java.io.EOFException;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * PSDImageReaderTest
@@ -244,7 +245,7 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
                 fail("Expected IndexOutOfBoundsException");
             }
             catch (IndexOutOfBoundsException expected) {
-                assertTrue(expected.getMessage(), expected.getMessage().toLowerCase().contains("index"));
+                assertTrue(expected.getMessage().toLowerCase().contains("index"), expected.getMessage());
             }
 
             try {
@@ -252,7 +253,7 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
                 fail("Expected IndexOutOfBoundsException");
             }
             catch (IndexOutOfBoundsException expected) {
-                assertTrue(expected.getMessage(), expected.getMessage().toLowerCase().contains("index"));
+                assertTrue(expected.getMessage().toLowerCase().contains("index"), expected.getMessage());
             }
 
             try {
@@ -261,7 +262,7 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
             }
             catch (IndexOutOfBoundsException expected) {
                 // Sloppy...
-                assertTrue(expected.getMessage(), expected.getMessage().toLowerCase().contains("-2"));
+                assertTrue(expected.getMessage().toLowerCase().contains("-2"), expected.getMessage());
             }
 
             try {
@@ -269,7 +270,7 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
                 fail("Expected IndexOutOfBoundsException");
             }
             catch (IndexOutOfBoundsException expected) {
-                assertTrue(expected.getMessage(), expected.getMessage().toLowerCase().contains("index"));
+                assertTrue(expected.getMessage().toLowerCase().contains("index"), expected.getMessage());
             }
         }
     }
@@ -312,7 +313,7 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
                 @Override
                 public void thumbnailProgress(final ImageReader pSource, final float pPercentageDone) {
                     // Optional
-                    assertEquals("Listener invoked out of sequence", 1, seqeunce.size());
+                    assertEquals(1, seqeunce.size(), "Listener invoked out of sequence");
                     assertTrue(pPercentageDone >= lastPercentageDone);
                     lastPercentageDone = pPercentageDone;
                 }
@@ -321,7 +322,7 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
             BufferedImage thumbnail = imageReader.readThumbnail(0, 0);
             assertNotNull(thumbnail);
 
-            assertEquals("Listeners not invoked", 2, seqeunce.size());
+            assertEquals(2, seqeunce.size(), "Listeners not invoked");
             assertEquals("started", seqeunce.get(0));
             assertEquals("complete", seqeunce.get(1));
         }
@@ -376,7 +377,7 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
                     }
                 }
 
-                assertTrue("RAW image type not in type iterator", found);
+                assertTrue(found, "RAW image type not in type iterator");
             }
         }
     }
@@ -698,27 +699,28 @@ public class PSDImageReaderTest extends ImageReaderAbstractTest<PSDImageReader> 
         }
     }
 
-    @Test(timeout = 1000)
+    @Test
     public void testBrokenPackBitsThrowsEOFException() throws IOException {
-        PSDImageReader imageReader = createReader();
+        assertTimeout(Duration.ofMillis(1000), () -> {
+            PSDImageReader imageReader = createReader();
 
-        try (ImageInputStream stream = ImageIO.createImageInputStream(getClassLoaderResource("/broken-psd/short-packbits.psd"))) {
-            imageReader.setInput(stream);
+            try (ImageInputStream stream = ImageIO.createImageInputStream(getClassLoaderResource("/broken-psd/short-packbits.psd"))) {
+                imageReader.setInput(stream);
 
-            assertEquals(1, imageReader.getNumImages(true));
+                assertEquals(1, imageReader.getNumImages(true));
 
-            assertEquals(427, imageReader.getWidth(0));
-            assertEquals(107, imageReader.getHeight(0));
+                assertEquals(427, imageReader.getWidth(0));
+                assertEquals(107, imageReader.getHeight(0));
 
-            try {
-                imageReader.read(0);
+                try {
+                    imageReader.read(0);
 
-                fail("Expected EOFException, is the test broken?");
+                    fail("Expected EOFException, is the test broken?");
+                } catch (EOFException expected) {
+                    assertTrue(expected.getMessage().contains("PackBits"));
+                }
             }
-            catch (EOFException expected) {
-                assertTrue(expected.getMessage().contains("PackBits"));
-            }
-        }
+        });
     }
 
 

--- a/imageio/imageio-psd/src/test/java/com/twelvemonkeys/imageio/plugins/psd/PSDUtilDecompressorStreamTest.java
+++ b/imageio/imageio-psd/src/test/java/com/twelvemonkeys/imageio/plugins/psd/PSDUtilDecompressorStreamTest.java
@@ -33,14 +33,14 @@ package com.twelvemonkeys.imageio.plugins.psd;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.imageio.stream.DirectImageInputStream;
 
-import org.junit.Test;
 
 import javax.imageio.stream.ImageInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import static com.twelvemonkeys.imageio.plugins.psd.PSDUtil.createDecompressorStream;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PSDUtilDecompressorStreamTest {
 

--- a/imageio/imageio-reference/src/test/java/com/twelvemonkeys/imageio/reference/JPEGImageReaderTest.java
+++ b/imageio/imageio-reference/src/test/java/com/twelvemonkeys/imageio/reference/JPEGImageReaderTest.java
@@ -34,8 +34,7 @@ import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 import com.twelvemonkeys.lang.SystemUtil;
 
 import com.sun.imageio.plugins.jpeg.JPEGImageReader;
-import org.junit.Ignore;
-import org.junit.Test;
+
 
 import javax.imageio.spi.IIORegistry;
 import javax.imageio.spi.ImageReaderSpi;
@@ -46,7 +45,10 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.twelvemonkeys.imageio.util.IIOUtil.lookupProviderByName;
-import static org.junit.Assume.assumeTrue;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assumptions.*;
 
 /**
  * JPEGImageReaderTest
@@ -90,7 +92,7 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
     @Override
     public void testSetDestination() throws IOException {
         // Known bug in Sun JPEGImageReader before Java 6
-        assumeTrue("Test skipped due to known bug in Java 1.5, please test again with Java 6 or later", IS_JAVA_6_OR_LATER);
+        assumeTrue(IS_JAVA_6_OR_LATER, "Test skipped due to known bug in Java 1.5, please test again with Java 6 or later");
         super.testSetDestination();
     }
 
@@ -98,19 +100,19 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
     @Override
     public void testSetDestinationType() throws IOException {
         // Known bug in Sun JPEGImageReader before Java 6
-        assumeTrue("Test skipped due to known bug in Java 1.5, please test again with Java 6 or later", IS_JAVA_6_OR_LATER);
+        assumeTrue(IS_JAVA_6_OR_LATER, "Test skipped due to known bug in Java 1.5, please test again with Java 6 or later");
         super.testSetDestinationType();
     }
 
     @Test
-    @Ignore("Known issue")
+    @Disabled("Known issue")
     @Override
     public void testReadAsRenderedImageIndexOutOfBounds() throws IOException {
         super.testReadAsRenderedImageIndexOutOfBounds();
     }
 
     @Test
-    @Ignore("No test data with JFIF thumbnail")
+    @Disabled("No test data with JFIF thumbnail")
     @Override
     public void testNotBadCachingThumbnails() throws IOException {
         super.testNotBadCachingThumbnails();

--- a/imageio/imageio-reference/src/test/java/com/twelvemonkeys/imageio/reference/PNGImageReaderTest.java
+++ b/imageio/imageio-reference/src/test/java/com/twelvemonkeys/imageio/reference/PNGImageReaderTest.java
@@ -34,7 +34,6 @@ import com.twelvemonkeys.imageio.util.IIOUtil;
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
 import com.sun.imageio.plugins.png.PNGImageReader;
-import org.junit.Test;
 
 import javax.imageio.IIOException;
 import javax.imageio.spi.IIORegistry;
@@ -44,6 +43,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * PNGImageReaderTest

--- a/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/RLEDecoderTest.java
+++ b/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/RLEDecoderTest.java
@@ -34,15 +34,14 @@ import com.twelvemonkeys.io.enc.Decoder;
 import com.twelvemonkeys.io.enc.DecoderAbstractTest;
 import com.twelvemonkeys.io.enc.Encoder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * RLEDecoderTest.

--- a/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/RLEEncoderTest.java
+++ b/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/RLEEncoderTest.java
@@ -34,13 +34,14 @@ import com.twelvemonkeys.io.enc.Decoder;
 import com.twelvemonkeys.io.enc.Encoder;
 import com.twelvemonkeys.io.enc.EncoderAbstractTest;
 
-import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * RLEEncoderTest.

--- a/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/TGAImageReaderTest.java
+++ b/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/TGAImageReaderTest.java
@@ -32,7 +32,6 @@ package com.twelvemonkeys.imageio.plugins.tga;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Test;
 import org.w3c.dom.NodeList;
 
 import javax.imageio.ImageIO;
@@ -49,7 +48,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * TGAImageReaderTest
@@ -204,7 +204,7 @@ public class TGAImageReaderTest extends ImageReaderAbstractTest<TGAImageReader> 
                 }
             }
 
-            assertTrue("No Software TextEntry", softwareFound);
+            assertTrue(softwareFound, "No Software TextEntry");
         }
         finally {
             reader.dispose();

--- a/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/TGAImageWriteParamTest.java
+++ b/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/TGAImageWriteParamTest.java
@@ -32,16 +32,13 @@ package com.twelvemonkeys.imageio.plugins.tga;
 
 import com.twelvemonkeys.imageio.util.ImageTypeSpecifiers;
 
-import org.junit.Test;
-
 import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageWriteParam;
 import java.awt.image.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 /**
  * TGAImageWriteParamTest.

--- a/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/TGAImageWriterTest.java
+++ b/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/TGAImageWriterTest.java
@@ -35,7 +35,6 @@ import com.twelvemonkeys.imageio.util.ImageTypeSpecifiers;
 import com.twelvemonkeys.imageio.util.ImageWriterAbstractTest;
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
 
-import org.junit.Test;
 import org.w3c.dom.NodeList;
 
 import javax.imageio.*;
@@ -56,8 +55,11 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.twelvemonkeys.imageio.util.ImageReaderAbstractTest.assertImageDataEquals;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeNotNull;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
 
 /**
  * TGAImageWriterTest
@@ -99,7 +101,8 @@ public class TGAImageWriterTest extends ImageWriterAbstractTest<TGAImageWriter> 
         ImageWriter writer = createWriter();
         ImageReader reader = ImageIO.getImageReader(writer);
 
-        assumeNotNull(reader);
+
+        assumeTrue(reader != null, "Reader should not be null");
 
         for (RenderedImage testData : getTestData()) {
             ByteArrayOutputStream buffer = new ByteArrayOutputStream();
@@ -128,7 +131,7 @@ public class TGAImageWriterTest extends ImageWriterAbstractTest<TGAImageWriter> 
         ImageWriter writer = createWriter();
         ImageReader reader = ImageIO.getImageReader(writer);
 
-        assumeNotNull(reader);
+        assumeTrue(reader != null, "Reader should not be null");
 
         ImageWriteParam param = writer.getDefaultWriteParam();
         param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
@@ -161,7 +164,7 @@ public class TGAImageWriterTest extends ImageWriterAbstractTest<TGAImageWriter> 
         ImageWriter writer = createWriter();
         ImageReader reader = ImageIO.getImageReader(writer);
 
-        assumeNotNull(reader);
+        assumeTrue(reader != null, "Reader should not be null");
 
         try (ImageInputStream input = ImageIO.createImageInputStream(getClassLoaderResource("/tga/UTC24.TGA"))) {
             reader.setInput(input);
@@ -197,7 +200,7 @@ public class TGAImageWriterTest extends ImageWriterAbstractTest<TGAImageWriter> 
         ImageWriter writer = createWriter();
         ImageReader reader = ImageIO.getImageReader(writer);
 
-        assumeNotNull(reader);
+        assumeTrue(reader != null, "Reader should not be null");
 
         try (ImageInputStream input = ImageIO.createImageInputStream(getClassLoaderResource("/tga/CTC24.TGA"))) {
             reader.setInput(input);

--- a/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/TGAMetadataTest.java
+++ b/imageio/imageio-tga/src/test/java/com/twelvemonkeys/imageio/plugins/tga/TGAMetadataTest.java
@@ -32,8 +32,6 @@ package com.twelvemonkeys.imageio.plugins.tga;
 
 import com.twelvemonkeys.imageio.util.ImageTypeSpecifiers;
 
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -44,7 +42,8 @@ import javax.imageio.metadata.IIOMetadataNode;
 import java.awt.image.*;
 import java.util.Calendar;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * TGAMetadataTest.
@@ -73,21 +72,11 @@ public class TGAMetadataTest {
         // Other formats
         assertNull(metadata.getNativeMetadataFormatName());
         assertNull(metadata.getExtraMetadataFormatNames());
-        assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-            @Override
-            public void run() {
-                metadata.getAsTree("com_foo_bar_1.0");
-            }
-        });
+        assertThrows(IllegalArgumentException.class, () -> metadata.getAsTree("com_foo_bar_1.0"));
 
         // Read-only
         assertTrue(metadata.isReadOnly());
-        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
-            @Override
-            public void run() throws Throwable {
-                metadata.mergeTree(IIOMetadataFormatImpl.standardMetadataFormatName, new IIOMetadataNode(IIOMetadataFormatImpl.standardMetadataFormatName));
-            }
-        });
+        assertThrows(IllegalStateException.class, () -> metadata.mergeTree(IIOMetadataFormatImpl.standardMetadataFormatName, new IIOMetadataNode(IIOMetadataFormatImpl.standardMetadataFormatName)));
     }
 
     @Test

--- a/imageio/imageio-thumbsdb/src/test/java/com/twelvemonkeys/imageio/plugins/thumbsdb/ThumbsDBImageReaderTest.java
+++ b/imageio/imageio-thumbsdb/src/test/java/com/twelvemonkeys/imageio/plugins/thumbsdb/ThumbsDBImageReaderTest.java
@@ -36,9 +36,6 @@ import com.twelvemonkeys.io.ole2.CompoundDocument;
 import com.twelvemonkeys.io.ole2.Entry;
 import com.twelvemonkeys.lang.SystemUtil;
 
-import org.junit.Ignore;
-import org.junit.Test;
-
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.MemoryCacheImageInputStream;
@@ -49,7 +46,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * ICOImageReaderTest
@@ -144,7 +143,7 @@ public class ThumbsDBImageReaderTest extends ImageReaderAbstractTest<ThumbsDBIma
     }
 
     @Test
-    @Ignore("Known issue")
+    @Disabled("Known issue")
     @Override
     public void testNotBadCaching() throws IOException {
         super.testNotBadCaching();

--- a/imageio/imageio-thumbsdb/src/test/java/com/twelvemonkeys/imageio/plugins/thumbsdb/ThumbsDBProviderInfoTest.java
+++ b/imageio/imageio-thumbsdb/src/test/java/com/twelvemonkeys/imageio/plugins/thumbsdb/ThumbsDBProviderInfoTest.java
@@ -37,7 +37,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * ThumbsDBProviderInfoTest.

--- a/imageio/imageio-tiff-jai-interop/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/jaiinterop/TIFFImageMetadataJAInteroperabilityTest.java
+++ b/imageio/imageio-tiff-jai-interop/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/jaiinterop/TIFFImageMetadataJAInteroperabilityTest.java
@@ -35,8 +35,6 @@ import com.twelvemonkeys.imageio.metadata.tiff.TIFF;
 import com.twelvemonkeys.imageio.metadata.tiff.TIFFEntry;
 import com.twelvemonkeys.imageio.plugins.tiff.TIFFImageMetadata;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageWriter;
@@ -47,8 +45,8 @@ import java.awt.image.BufferedImage;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests our TIFFImageMetadata works with JAI TIFFImageWriter.

--- a/imageio/imageio-tiff-jdk-interop/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/jdkinterop/TIFFImageReaderJDKJPEGInteroperabilityTest.java
+++ b/imageio/imageio-tiff-jdk-interop/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/jdkinterop/TIFFImageReaderJDKJPEGInteroperabilityTest.java
@@ -30,8 +30,6 @@
 
 package com.twelvemonkeys.imageio.plugins.tiff.jdkinterop;
 
-import static org.junit.Assert.fail;
-
 import java.awt.*;
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,8 +40,9 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ImageReaderSpi;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.twelvemonkeys.imageio.plugins.tiff.TIFFImageReader;
 import com.twelvemonkeys.imageio.plugins.tiff.TIFFImageReaderSpi;
@@ -88,7 +87,7 @@ public class TIFFImageReaderJDKJPEGInteroperabilityTest extends ImageReaderAbstr
         return Collections.emptyList();
     }
 
-    @Ignore("Fails in TIFFImageReader")
+    @Disabled("Fails in TIFFImageReader")
     @Override
     public void testSetDestinationIllegal() {
     }

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/BigTIFFImageWriterTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/BigTIFFImageWriterTest.java
@@ -34,8 +34,6 @@ import com.twelvemonkeys.imageio.metadata.tiff.TIFF;
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import com.twelvemonkeys.imageio.util.ImageWriterAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.spi.ImageWriterSpi;
@@ -49,7 +47,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.twelvemonkeys.imageio.util.ImageReaderAbstractTest.assertRGBEquals;
-import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * BigTIFFImageWriterTest

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/BitPaddingStreamTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/BitPaddingStreamTest.java
@@ -30,15 +30,13 @@
 
 package com.twelvemonkeys.imageio.plugins.tiff;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * BitPaddingStreamTest.
@@ -49,24 +47,24 @@ import static org.junit.Assert.assertEquals;
  */
 public class BitPaddingStreamTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullStream() {
-        new BitPaddingStream(null, 1, 12, 4, ByteOrder.BIG_ENDIAN);
+        assertThrows(IllegalArgumentException.class, () -> new BitPaddingStream(null, 1, 12, 4, ByteOrder.BIG_ENDIAN));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateBadBits() {
-        new BitPaddingStream(new ByteArrayInputStream(new byte[6]), 1, 7, 4, ByteOrder.BIG_ENDIAN);
+        assertThrows(IllegalArgumentException.class, () -> new BitPaddingStream(new ByteArrayInputStream(new byte[6]), 1, 7, 4, ByteOrder.BIG_ENDIAN));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateBadBitsLarge() {
-        new BitPaddingStream(new ByteArrayInputStream(new byte[6]), 1, 37, 4, ByteOrder.BIG_ENDIAN);
+        assertThrows(IllegalArgumentException.class, () -> new BitPaddingStream(new ByteArrayInputStream(new byte[6]), 1, 37, 4, ByteOrder.BIG_ENDIAN));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullByteOrder() {
-        new BitPaddingStream(new ByteArrayInputStream(new byte[6]), 1, 12, 4, null);
+        assertThrows(IllegalArgumentException.class, () -> new BitPaddingStream(new ByteArrayInputStream(new byte[6]), 1, 12, 4, null));
     }
 
     @Test

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxDecoderStreamTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxDecoderStreamTest.java
@@ -30,16 +30,16 @@
 
 package com.twelvemonkeys.imageio.plugins.tiff;
 
-import org.junit.Before;
-import org.junit.Test;
 
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferByte;
 import java.io.*;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * CCITTFaxDecoderStreamTest
@@ -138,7 +138,7 @@ public class CCITTFaxDecoderStreamTest {
     // 1 1 0 0 1 1 x x
     final BufferedImage image = new BufferedImage(6, 4, BufferedImage.TYPE_BYTE_BINARY);
 
-    @Before
+    @BeforeEach
     public void init() {
 
         for (int y = 0; y < 4; y++) {
@@ -289,8 +289,8 @@ public class CCITTFaxDecoderStreamTest {
         byte[] imageData = Arrays.copyOf(((DataBufferByte) image.getData().getDataBuffer()).getData(), 6);
         assertArrayEquals(imageData, bytes);
 
-         assertEquals("Should contain no more data", -1, stream.read());
-         assertEquals("Should contain no more data", -1, stream.read(new byte[1]));
+         assertEquals(-1, stream.read(), "Should contain no more data");
+         assertEquals(-1, stream.read(new byte[1]), "Should contain no more data");
     }
 
     @Test
@@ -370,12 +370,14 @@ public class CCITTFaxDecoderStreamTest {
     }
 
     @SuppressWarnings("StatementWithEmptyBody")
-    @Test(expected = IOException.class)
+    @Test
     public void testAIOBEInCorruptStreamShouldThrowIOException() throws IOException {
         // From #645
-        try (InputStream ccittFaxDecoderStream = new CCITTFaxDecoderStream(getResourceAsStream("/ccitt/645.ccitt"), 7, 4, 0, false)) {
-            while(ccittFaxDecoderStream.read() != -1); // Just read until the end
-        }
+        assertThrows(IOException.class, () -> {
+            try (InputStream ccittFaxDecoderStream = new CCITTFaxDecoderStream(getResourceAsStream("/ccitt/645.ccitt"), 7, 4, 0, false)) {
+                while (ccittFaxDecoderStream.read() != -1) ; // Just read until the end
+            }
+        });
     }
 
     @Test

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxEncoderStreamTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/CCITTFaxEncoderStreamTest.java
@@ -31,8 +31,6 @@
 package com.twelvemonkeys.imageio.plugins.tiff;
 
 import com.twelvemonkeys.imageio.plugins.tiff.CCITTFaxEncoderStream.Code;
-import org.junit.Before;
-import org.junit.Test;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -46,7 +44,10 @@ import java.io.*;
 import java.net.URL;
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * CCITTFaxEncoderStreamTest
@@ -64,7 +65,7 @@ public class CCITTFaxEncoderStreamTest {
     // 1 1 0 0 1 1 x x
     BufferedImage image;
 
-    @Before
+    @BeforeEach
     public void init() {
         image = new BufferedImage(6, 4, BufferedImage.TYPE_BYTE_BINARY);
         for (int y = 0; y < 4; y++) {

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/ExtraSamplesColorModelTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/ExtraSamplesColorModelTest.java
@@ -33,14 +33,13 @@ package com.twelvemonkeys.imageio.plugins.tiff;
 import com.twelvemonkeys.image.ResampleOp;
 import com.twelvemonkeys.imageio.color.ColorSpaces;
 
-import org.junit.Test;
-
 import java.awt.*;
 import java.awt.color.ColorSpace;
 import java.awt.image.*;
 import java.util.Hashtable;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.*;
 
 public class ExtraSamplesColorModelTest {
 

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/HorizontalDeDifferencingStreamTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/HorizontalDeDifferencingStreamTest.java
@@ -33,13 +33,12 @@ package com.twelvemonkeys.imageio.plugins.tiff;
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
 import com.twelvemonkeys.io.LittleEndianDataInputStream;
 import com.twelvemonkeys.io.LittleEndianDataOutputStream;
-import org.junit.Test;
 
 import java.io.*;
 import java.nio.ByteOrder;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 /**
  * HorizontalDeDifferencingStreamTest

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/HorizontalDifferencingStreamTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/HorizontalDifferencingStreamTest.java
@@ -33,13 +33,13 @@ package com.twelvemonkeys.imageio.plugins.tiff;
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
 import com.twelvemonkeys.io.LittleEndianDataInputStream;
 import com.twelvemonkeys.io.LittleEndianDataOutputStream;
-import org.junit.Test;
 
 import java.io.*;
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * HorizontalDifferencingStreamTest

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/LZWDecoderTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/LZWDecoderTest.java
@@ -35,15 +35,16 @@ import com.twelvemonkeys.io.enc.Decoder;
 import com.twelvemonkeys.io.enc.DecoderAbstractTest;
 import com.twelvemonkeys.io.enc.DecoderStream;
 import com.twelvemonkeys.io.enc.Encoder;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * LZWDecoderTest
@@ -90,7 +91,7 @@ public class LZWDecoderTest extends DecoderAbstractTest {
             while ((data = actual.read()) !=  -1) {
                 count++;
 
-                assertEquals(String.format("Incorrect data at offset 0x%04x", count), expected.read(), data);
+                assertEquals(expected.read(), data, String.format("Incorrect data at offset 0x%04x", count));
             }
 
             assertEquals(-1, data);
@@ -112,24 +113,26 @@ public class LZWDecoderTest extends DecoderAbstractTest {
         return null;
     }
 
-    @Ignore
-    @Test(timeout = 3000)
+    @Disabled
+    @Test
     public void testSpeed() throws IOException {
-        byte[] bytes = FileUtil.read(getClass().getResourceAsStream("/lzw/lzw-long.bin"));
+        assertTimeout(Duration.ofMillis(3000), () -> {
+            byte[] bytes = FileUtil.read(getClass().getResourceAsStream("/lzw/lzw-long.bin"));
 
 
-        for (int i = 0; i < SPEED_TEST_ITERATIONS; i++) {
-            ByteBuffer buffer = ByteBuffer.allocate(1024);
-            ByteArrayInputStream input = new ByteArrayInputStream(bytes);
-            LZWDecoder decoder = new LZWDecoder.LZWSpecDecoder();
+            for (int i = 0; i < SPEED_TEST_ITERATIONS; i++) {
+                ByteBuffer buffer = ByteBuffer.allocate(1024);
+                ByteArrayInputStream input = new ByteArrayInputStream(bytes);
+                LZWDecoder decoder = new LZWDecoder.LZWSpecDecoder();
 
-            int read, total = 0;
-            while((read = decoder.decode(input, buffer)) > 0) {
-                buffer.clear();
-                total += read;
+                int read, total = 0;
+                while ((read = decoder.decode(input, buffer)) > 0) {
+                    buffer.clear();
+                    total += read;
+                }
+
+                assertEquals(49152, total);
             }
-
-            assertEquals(49152, total);
-        }
+        });
     }
 }

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/LZWDecoderTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/LZWDecoderTest.java
@@ -116,7 +116,7 @@ public class LZWDecoderTest extends DecoderAbstractTest {
     @Disabled
     @Test
     public void testSpeed() throws IOException {
-        assertTimeout(Duration.ofMillis(3000), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(3000), () -> {
             byte[] bytes = FileUtil.read(getClass().getResourceAsStream("/lzw/lzw-long.bin"));
 
 

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/LZWEncoderTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/LZWEncoderTest.java
@@ -179,7 +179,7 @@ public class LZWEncoderTest {
     @Disabled
     @Test
     public void testSpeed() throws IOException {
-        assertTimeout(Duration.ofMillis(10000), () -> {
+        assertTimeoutPreemptively(Duration.ofMillis(10000), () -> {
             for (int run = 0; run < SPEED_TEST_RUNS; run++) {
                 byte[] bytes = new byte[LENGTH];
                 LZWEncoder encoder = new LZWEncoder(bytes.length);

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/LZWEncoderTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/LZWEncoderTest.java
@@ -32,16 +32,18 @@ package com.twelvemonkeys.imageio.plugins.tiff;
 
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
 import com.twelvemonkeys.io.enc.Decoder;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 
 /**
  * LZWEncoderTest
@@ -84,7 +86,7 @@ public class LZWEncoderTest {
             buffer.flip();
 
             while (buffer.hasRemaining()) {
-                assertEquals(String.format("Diff at index %s", index), bytes[index], buffer.get());
+                assertEquals(bytes[index], buffer.get(), String.format("Diff at index %s", index));
                 index++;
             }
 
@@ -123,7 +125,7 @@ public class LZWEncoderTest {
                 while (buffer.hasRemaining()) {
                     byte expected = bytes[index];
                     byte actual = buffer.get();
-                    assertEquals(String.format("Diff at index %s: 0x%02x != 0x%02x", index, expected, actual), expected, actual);
+                    assertEquals(expected, actual, String.format("Diff at index %s: 0x%02x != 0x%02x", index, expected, actual));
                     index++;
                 }
 
@@ -161,7 +163,7 @@ public class LZWEncoderTest {
                 while (buffer.hasRemaining()) {
                     byte expected = bytes[index];
                     byte actual = buffer.get();
-                    assertEquals(String.format("Diff at index %s: 0x%02x != 0x%02x", index, expected, actual), expected, actual);
+                    assertEquals(expected, actual, String.format("Diff at index %s: 0x%02x != 0x%02x", index, expected, actual));
 //                    System.err.println(String.format("Equal at index %s: 0x%02x (%d)", index, expected & 0xff, expected));
                     index++;
                 }
@@ -174,24 +176,26 @@ public class LZWEncoderTest {
         assertEquals(-1, inputStream.read());
     }
 
-    @Ignore
-    @Test(timeout = 10000)
+    @Disabled
+    @Test
     public void testSpeed() throws IOException {
-        for (int run = 0; run < SPEED_TEST_RUNS; run++) {
-            byte[] bytes = new byte[LENGTH];
-            LZWEncoder encoder = new LZWEncoder(bytes.length);
+        assertTimeout(Duration.ofMillis(10000), () -> {
+            for (int run = 0; run < SPEED_TEST_RUNS; run++) {
+                byte[] bytes = new byte[LENGTH];
+                LZWEncoder encoder = new LZWEncoder(bytes.length);
 
-            for (int i = 0; i < bytes.length; i++) {
-                bytes[i] = (byte) i;
+                for (int i = 0; i < bytes.length; i++) {
+                    bytes[i] = (byte) i;
+                }
+
+                FastByteArrayOutputStream stream = new FastByteArrayOutputStream((LENGTH * 3) / 4);
+
+                for (int i = 0; i < ITERATIONS; i++) {
+                    encoder.encode(stream, ByteBuffer.wrap(bytes, i * LENGTH / ITERATIONS, LENGTH / ITERATIONS));
+                }
+
+                assertEquals(719, stream.size());
             }
-
-            FastByteArrayOutputStream stream = new FastByteArrayOutputStream((LENGTH * 3) / 4);
-
-            for (int i = 0; i < ITERATIONS; i++) {
-                encoder.encode(stream, ByteBuffer.wrap(bytes, i * LENGTH / ITERATIONS, LENGTH / ITERATIONS));
-            }
-
-            assertEquals(719, stream.size());
-        }
+        });
     }
 }

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageMetadataTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageMetadataTest.java
@@ -675,7 +675,7 @@ public class TIFFImageMetadataTest {
         NodeList expectedChildNodes = expected.getChildNodes();
         NodeList actualChildNodes = actual.getChildNodes();
 
-        assertEquals( expectedChildNodes.getLength(), actualChildNodes.getLength(),
+        assertEquals(expectedChildNodes.getLength(), actualChildNodes.getLength(),
                 message + " child length differs: " + toString(expectedChildNodes) + " != " + toString(actualChildNodes));
 
         for (int i = 0; i < expectedChildNodes.getLength(); i++) {

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageMetadataTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageMetadataTest.java
@@ -30,8 +30,9 @@
 package com.twelvemonkeys.imageio.plugins.tiff;
 
 import static com.twelvemonkeys.imageio.plugins.tiff.TIFFImageMetadataFormat.SUN_NATIVE_IMAGE_METADATA_FORMAT_NAME;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
@@ -46,7 +47,6 @@ import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.spi.IIORegistry;
 import javax.imageio.stream.ImageInputStream;
 
-import org.junit.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -373,28 +373,28 @@ public class TIFFImageMetadataTest {
         assertEquals(TIFFBaseline.RESOLUTION_UNIT_NONE, ((Number) ifd.getEntryById(TIFF.TAG_RESOLUTION_UNIT).getValue()).intValue());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMergeTreeUnsupportedFormat() throws IOException {
         IIOMetadata metadata = createMetadata("/tiff/sm_colors_tile.tif");
 
         String nativeFormat = "com_foo_bar_tiff_42";
-        metadata.mergeTree(nativeFormat, new IIOMetadataNode(nativeFormat));
+        assertThrows(IllegalArgumentException.class, () -> metadata.mergeTree(nativeFormat, new IIOMetadataNode(nativeFormat)));
     }
 
-    @Test(expected = IIOInvalidTreeException.class)
+    @Test
     public void testMergeTreeFormatMisMatch() throws IOException {
         IIOMetadata metadata = createMetadata("/tiff/sm_colors_tile.tif");
 
         String nativeFormat = SUN_NATIVE_IMAGE_METADATA_FORMAT_NAME;
-        metadata.mergeTree(nativeFormat, new IIOMetadataNode("com_foo_bar_tiff_42"));
+        assertThrows(IIOInvalidTreeException.class, () -> metadata.mergeTree(nativeFormat, new IIOMetadataNode("com_foo_bar_tiff_42")));
     }
 
-    @Test(expected = IIOInvalidTreeException.class)
+    @Test
     public void testMergeTreeInvalid() throws IOException {
         IIOMetadata metadata = createMetadata("/tiff/sm_colors_tile.tif");
 
         String nativeFormat = SUN_NATIVE_IMAGE_METADATA_FORMAT_NAME;
-        metadata.mergeTree(nativeFormat, new IIOMetadataNode(nativeFormat)); // Requires at least one child node
+        assertThrows(IIOInvalidTreeException.class, () ->metadata.mergeTree(nativeFormat, new IIOMetadataNode(nativeFormat))); // Requires at least one child node
     }
 
     // TODO: Test that failed merge leaves metadata unchanged
@@ -489,28 +489,28 @@ public class TIFFImageMetadataTest {
         assertEquals(copyrightString, ifd.getEntryById(TIFF.TAG_COPYRIGHT).getValue());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testSetFromTreeUnsupportedFormat() throws IOException {
         IIOMetadata metadata = createMetadata("/tiff/sm_colors_tile.tif");
 
         String nativeFormat = "com_foo_bar_tiff_42";
-        metadata.setFromTree(nativeFormat, new IIOMetadataNode(nativeFormat));
+        assertThrows(IllegalArgumentException.class, () -> metadata.setFromTree(nativeFormat, new IIOMetadataNode(nativeFormat)));
     }
 
-    @Test(expected = IIOInvalidTreeException.class)
+    @Test
     public void testSetFromTreeFormatMisMatch() throws IOException {
         IIOMetadata metadata = createMetadata("/tiff/sm_colors_tile.tif");
 
         String nativeFormat = SUN_NATIVE_IMAGE_METADATA_FORMAT_NAME;
-        metadata.setFromTree(nativeFormat, new IIOMetadataNode("com_foo_bar_tiff_42"));
+        assertThrows(IIOInvalidTreeException.class, () -> metadata.setFromTree(nativeFormat, new IIOMetadataNode("com_foo_bar_tiff_42")));
     }
 
-    @Test(expected = IIOInvalidTreeException.class)
+    @Test
     public void testSetFromTreeInvalid() throws IOException {
         IIOMetadata metadata = createMetadata("/tiff/sm_colors_tile.tif");
 
         String nativeFormat = SUN_NATIVE_IMAGE_METADATA_FORMAT_NAME;
-        metadata.setFromTree(nativeFormat, new IIOMetadataNode(nativeFormat)); // Requires at least one child node
+        assertThrows(IIOInvalidTreeException.class, () -> metadata.setFromTree(nativeFormat, new IIOMetadataNode(nativeFormat))); // Requires at least one child nod
     }
 
     @Test
@@ -594,26 +594,26 @@ public class TIFFImageMetadataTest {
             Element field = (Element) fields.item(i);
 
             if (tagNumber.equals(field.getAttribute("number"))) {
-                assertFalse("Duplicate tag " + tagNumber + " found", foundTag);
+                assertFalse(foundTag, "Duplicate tag " + tagNumber + " found");
 
                 assertEquals(1, field.getChildNodes().getLength());
                 Node containerNode = field.getFirstChild();
                 assertEquals("TIFF" + typeName + "s", containerNode.getNodeName());
 
                 NodeList valueNodes = containerNode.getChildNodes();
-                assertEquals("Unexpected number of values for tag " + tagNumber, expectedValue.length, valueNodes.getLength());
+                assertEquals(expectedValue.length, valueNodes.getLength(), "Unexpected number of values for tag " + tagNumber);
 
                 for (int j = 0; j < expectedValue.length; j++) {
                     Element valueNode = (Element) valueNodes.item(j);
                     assertEquals("TIFF" + typeName, valueNode.getNodeName());
-                    assertEquals("Unexpected tag " + tagNumber + " value", expectedValue[j], valueNode.getAttribute("value"));
+                    assertEquals(expectedValue[j], valueNode.getAttribute("value"), "Unexpected tag " + tagNumber + " value");
                 }
 
                 foundTag = true;
             }
         }
 
-        assertTrue("No tag " + tagNumber + " found", foundTag);
+        assertTrue(foundTag, "No tag " + tagNumber + " found");
     }
 
     static void createTIFFFieldNode(final IIOMetadataNode parentIFDNode, int tag, short type, Object value) {
@@ -662,27 +662,27 @@ public class TIFFImageMetadataTest {
     }
 
     private void assertNodeEquals(final String message, final Node expected, final Node actual) {
-        assertEquals(message + " class differs", expected.getClass(), actual.getClass());
-        assertEquals(message, expected.getNodeValue(), actual.getNodeValue());
+        assertEquals(expected.getClass(), actual.getClass(), message + " class differs");
+        assertEquals(expected.getNodeValue(), actual.getNodeValue(), message);
 
         if (expected instanceof IIOMetadataNode) {
             IIOMetadataNode expectedIIO = (IIOMetadataNode) expected;
             IIOMetadataNode actualIIO = (IIOMetadataNode) actual;
 
-            assertEquals(message, expectedIIO.getUserObject(), actualIIO.getUserObject());
+            assertEquals(expectedIIO.getUserObject(), actualIIO.getUserObject(), message);
         }
 
         NodeList expectedChildNodes = expected.getChildNodes();
         NodeList actualChildNodes = actual.getChildNodes();
 
-        assertEquals(message + " child length differs: " + toString(expectedChildNodes) + " != " + toString(actualChildNodes),
-                expectedChildNodes.getLength(), actualChildNodes.getLength());
+        assertEquals( expectedChildNodes.getLength(), actualChildNodes.getLength(),
+                message + " child length differs: " + toString(expectedChildNodes) + " != " + toString(actualChildNodes));
 
         for (int i = 0; i < expectedChildNodes.getLength(); i++) {
             Node expectedChild = expectedChildNodes.item(i);
             Node actualChild = actualChildNodes.item(i);
 
-            assertEquals(message + " node name differs", expectedChild.getLocalName(), actualChild.getLocalName());
+            assertEquals(expectedChild.getLocalName(), actualChild.getLocalName(), message + " node name differs");
             assertNodeEquals(message + "/" + expectedChild.getLocalName(), expectedChild, actualChild);
         }
     }

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReaderTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReaderTest.java
@@ -33,8 +33,6 @@ package com.twelvemonkeys.imageio.plugins.tiff;
 import com.twelvemonkeys.imageio.color.ColorSpaces;
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.IIOException;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
@@ -56,10 +54,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.Mockito.*;
 
@@ -434,10 +432,10 @@ public class TIFFImageReaderTest extends ImageReaderAbstractTest<TIFFImageReader
             for (int y = 0; y < 8; y++) {
                 for (int x = 0; x < 8; x++) {
                     int argb = image.getRGB(x, y);
-                    assertEquals("Alpha", 0xff, (argb >>> 24) & 0xff);
-                    assertEquals("Red", 0xff, (argb >> 16) & 0xff);
-                    assertEquals("Green", 0xff, (argb >> 8) & 0xff, 13); // Depending on coeffs
-                    assertEquals("Blue", 0xff, argb & 0xff);
+                    assertEquals(0xff, (argb >>> 24) & 0xff , "Alpha");
+                    assertEquals(0xff, (argb >> 16) & 0xff , "Red");
+                    assertEquals(0xff, (argb >> 8) & 0xff, 13, "Green"); // Depending on coeffs
+                    assertEquals(0xff, argb & 0xff , "Blue");
                 }
             }
         }
@@ -465,10 +463,10 @@ public class TIFFImageReaderTest extends ImageReaderAbstractTest<TIFFImageReader
             for (int y = 0; y < 8; y++) {
                 for (int x = 0; x < 8; x++) {
                     int argb = image.getRGB(x, y);
-                    assertEquals("Alpha", 0xff, (argb >>> 24) & 0xff);
-                    assertEquals("Red", 0xff, (argb >> 16) & 0xff);
-                    assertEquals("Green", 0xff, (argb >> 8) & 0xff);
-                    assertEquals("Blue", 0xff, argb & 0xff);
+                    assertEquals(0xff, (argb >>> 24) & 0xff, "Alpha");
+                    assertEquals(0xff, (argb >> 16) & 0xff, "Red");
+                    assertEquals(0xff, (argb >> 8) & 0xff, "Green");
+                    assertEquals(0xff, argb & 0xff, "Blue");
                 }
             }
         }
@@ -640,7 +638,7 @@ public class TIFFImageReaderTest extends ImageReaderAbstractTest<TIFFImageReader
                 });
                 reader.read(0);
             }
-            assertTrue("no correct guess for PhotometricInterpretation: " + results[i], foundWarning.get());
+            assertTrue(foundWarning.get(), "no correct guess for PhotometricInterpretation: " + results[i]);
         }
     }
 
@@ -1024,16 +1022,16 @@ public class TIFFImageReaderTest extends ImageReaderAbstractTest<TIFFImageReader
                     failBecause(String.format("Image %s index %s could not be read: %s", data.getInput(), i, e), e);
                 }
 
-                assertNotNull(String.format("Raster %s index %s was null!", data.getInput(), i), raster);
+                assertNotNull(raster, String.format("Raster %s index %s was null!", data.getInput(), i));
 
                 assertEquals(
-                        String.format("Raster %s index %s has wrong width: %s", data.getInput(), i, raster.getWidth()),
                         data.getDimension(i).width,
-                        raster.getWidth()
+                        raster.getWidth(),
+                        String.format("Raster %s index %s has wrong width: %s", data.getInput(), i, raster.getWidth())
                 );
                 assertEquals(
-                        String.format("Raster %s index %s has wrong height: %s", data.getInput(), i, raster.getHeight()),
-                        data.getDimension(i).height, raster.getHeight()
+                        data.getDimension(i).height, raster.getHeight(),
+                        String.format("Raster %s index %s has wrong height: %s", data.getInput(), i, raster.getHeight())
                 );
             }
         }

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReaderTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageReaderTest.java
@@ -432,10 +432,10 @@ public class TIFFImageReaderTest extends ImageReaderAbstractTest<TIFFImageReader
             for (int y = 0; y < 8; y++) {
                 for (int x = 0; x < 8; x++) {
                     int argb = image.getRGB(x, y);
-                    assertEquals(0xff, (argb >>> 24) & 0xff , "Alpha");
-                    assertEquals(0xff, (argb >> 16) & 0xff , "Red");
+                    assertEquals(0xff, (argb >>> 24) & 0xff, "Alpha");
+                    assertEquals(0xff, (argb >> 16) & 0xff, "Red");
                     assertEquals(0xff, (argb >> 8) & 0xff, 13, "Green"); // Depending on coeffs
-                    assertEquals(0xff, argb & 0xff , "Blue");
+                    assertEquals(0xff, argb & 0xff, "Blue");
                 }
             }
         }

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriterTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriterTest.java
@@ -41,7 +41,6 @@ import com.twelvemonkeys.imageio.util.ImageTypeSpecifiers;
 import com.twelvemonkeys.imageio.util.ImageWriterAbstractTest;
 import com.twelvemonkeys.io.FastByteArrayOutputStream;
 
-import org.junit.Test;
 import org.w3c.dom.NodeList;
 
 import javax.imageio.IIOImage;
@@ -79,8 +78,9 @@ import static com.twelvemonkeys.imageio.metadata.tiff.TIFF.TAG_Y_RESOLUTION;
 import static com.twelvemonkeys.imageio.plugins.tiff.TIFFImageMetadataFormat.SUN_NATIVE_IMAGE_METADATA_FORMAT_NAME;
 import static com.twelvemonkeys.imageio.plugins.tiff.TIFFImageMetadataTest.createTIFFFieldNode;
 import static com.twelvemonkeys.imageio.util.ImageReaderAbstractTest.assertRGBEquals;
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeNotNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.*;
 
 /**
@@ -148,7 +148,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             fail(e.getMessage());
         }
 
-        assertTrue("No image data written", buffer.size() > 0);
+        assertTrue(buffer.size() > 0, "No image data written");
 
         Directory ifds = new TIFFReader().read(new ByteArrayImageInputStream(buffer.toByteArray()));
 
@@ -219,7 +219,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             fail(e.getMessage());
         }
 
-        assertTrue("No image data written", buffer.size() > 0);
+        assertTrue(buffer.size() > 0, "No image data written");
 
         Directory ifds = new TIFFReader().read(new ByteArrayImageInputStream(buffer.toByteArray()));
         Entry software = ifds.getEntryById(TIFF.TAG_SOFTWARE);
@@ -267,7 +267,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             fail(e.getMessage());
         }
 
-        assertTrue("No image data written", buffer.size() > 0);
+        assertTrue(buffer.size() > 0, "No image data written");
 
         Directory ifds = new TIFFReader().read(new ByteArrayImageInputStream(buffer.toByteArray()));
 
@@ -318,7 +318,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             fail(e.getMessage());
         }
 
-        assertTrue("No image data written", buffer.size() > 0);
+        assertTrue(buffer.size() > 0, "No image data written");
 
         Directory ifds = new TIFFReader().read(new ByteArrayImageInputStream(buffer.toByteArray()));
         Entry software = ifds.getEntryById(TIFF.TAG_SOFTWARE);
@@ -326,7 +326,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
         assertEquals(softwareString, software.getValueAsString());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWriteIncompatibleCompression() throws IOException {
         ImageWriter writer = createWriter();
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
@@ -334,44 +334,42 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
         try (ImageOutputStream output = ImageIO.createImageOutputStream(buffer)) {
             writer.setOutput(output);
 
-            try {
-                ImageWriteParam param = writer.getDefaultWriteParam();
-                param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
-                param.setCompressionType("CCITT T.6");
+            ImageWriteParam param = writer.getDefaultWriteParam();
+            param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+            param.setCompressionType("CCITT T.6");
+
+            // Use assertThrows to check for IOException
+            assertThrows(IllegalArgumentException.class, () -> {
                 writer.write(null, new IIOImage(new BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB), null, null), param);
-                fail();
-            }
-            catch (IOException e) {
-                fail(e.getMessage());
-            }
+            });
         }
     }
 
     @Test
     public void testWriterCanWriteSequence() throws IOException {
         ImageWriter writer = createWriter();
-        assertTrue("Writer should support sequence writing", writer.canWriteSequence());
+        assertTrue(writer.canWriteSequence(), "Writer should support sequence writing");
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testWriteSequenceWithoutPrepare() throws IOException {
         ImageWriter writer = createWriter();
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
         try (ImageOutputStream output = ImageIO.createImageOutputStream(buffer)) {
             writer.setOutput(output);
-            writer.writeToSequence(new IIOImage(new BufferedImage(10, 10, BufferedImage.TYPE_3BYTE_BGR), null, null), null);
+            assertThrows(IllegalStateException.class, () -> writer.writeToSequence(new IIOImage(new BufferedImage(10, 10, BufferedImage.TYPE_3BYTE_BGR), null, null), null));
         }
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testEndSequenceWithoutPrepare() throws IOException {
         ImageWriter writer = createWriter();
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
         try (ImageOutputStream output = ImageIO.createImageOutputStream(buffer)) {
             writer.setOutput(output);
-            writer.endWriteSequence();
+            assertThrows(IllegalStateException.class, () -> writer.endWriteSequence());
         }
     }
 
@@ -422,7 +420,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             ImageReader reader = ImageIO.getImageReaders(input).next();
             reader.setInput(input);
 
-            assertEquals("wrong image count", compression.length, reader.getNumImages(true));
+            assertEquals( compression.length, reader.getNumImages(true), "wrong image count");
 
             for (int i = 0; i < reader.getNumImages(true); i++) {
                 assertImageEquals("image " + i + " differs", image, reader.read(i), 5); // Allow room for JPEG compression
@@ -539,7 +537,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             ImageReader reader = ImageIO.getImageReaders(input).next();
             reader.setInput(input);
 
-            assertEquals("wrong image count", images.length, reader.getNumImages(true));
+            assertEquals(images.length, reader.getNumImages(true), "wrong image count");
 
             for (int i = 0; i < reader.getNumImages(true); i++) {
                 assertImageEquals("image " + i + " differs", images[i], reader.read(i), 5); // Allow room for JPEG compression
@@ -609,7 +607,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             TIFFImageMetadata metadata = (TIFFImageMetadata) reader.getImageMetadata(0);
             Directory ifd = metadata.getIFD();
 
-            assertNull("Unexpected ICC profile for default gray", ifd.getEntryById(TIFF.TAG_ICC_PROFILE));
+            assertNull(ifd.getEntryById(TIFF.TAG_ICC_PROFILE), "Unexpected ICC profile for default gray");
         }
     }
 
@@ -649,8 +647,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             original = reader.readAll(0, null);
             reader.dispose();
         }
-
-        assumeNotNull(original);
+        assumeTrue(original != null);
 
         // Write it back, using same compression (copied from metadata)
         FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(32768);
@@ -698,7 +695,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
                 }
             }
 
-            assertTrue("Software metadata not found", softwareFound);
+            assertTrue(softwareFound, "Software metadata not found");
         }
     }
 
@@ -715,7 +712,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             reader.dispose();
         }
 
-        assumeNotNull(original);
+        assumeTrue(original != null);
 
         // Write it back, using deflate compression
         FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(32768);
@@ -762,7 +759,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
                 }
             }
 
-            assertTrue("Software metadata not found", softwareFound);
+            assertTrue(softwareFound, "Software metadata not found");
         }
     }
 
@@ -779,7 +776,8 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             reader.dispose();
         }
 
-        assumeNotNull(original);
+        assumeTrue(original!= null);
+
 
         // Write it back, no compression
         FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(32768);
@@ -827,7 +825,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
                 }
             }
 
-            assertTrue("Software metadata not found", softwareFound);
+            assertTrue(softwareFound, "Software metadata not found");
         }
     }
 
@@ -844,7 +842,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             reader.dispose();
         }
 
-        assumeNotNull(original);
+        assumeTrue(original != null);
 
         // Write it back, using same compression (copied from metadata)
         FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(32768);
@@ -887,7 +885,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
                 }
             }
 
-            assertTrue("Software metadata not found", softwareFound);
+            assertTrue(softwareFound, "Software metadata not found");
         }
     }
 
@@ -904,7 +902,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             reader.dispose();
         }
 
-        assumeNotNull(original);
+        assumeTrue(original != null);
 
         // Write it back, using same compression (copied from metadata)
         FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(32768);
@@ -951,7 +949,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
                 }
             }
 
-            assertTrue("Software metadata not found", softwareFound);
+            assertTrue(softwareFound, "Software metadata not found");
         }
     }
 
@@ -968,7 +966,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             reader.dispose();
         }
 
-        assumeNotNull(original);
+        assumeTrue(original != null);
 
         // Write it back, using same compression (copied from metadata)
         FastByteArrayOutputStream buffer = new FastByteArrayOutputStream(32768);
@@ -1019,7 +1017,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
                 }
             }
 
-            assertTrue("Software metadata not found", softwareFound);
+            assertTrue(softwareFound, "Software metadata not found");
         }
     }
 
@@ -1059,10 +1057,10 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
     }
 
     private void assertImageEquals(final String message, final BufferedImage expected, final BufferedImage actual, final int tolerance) {
-        assertNotNull(message, expected);
-        assertNotNull(message, actual);
-        assertEquals(message + ", widths differ", expected.getWidth(), actual.getWidth());
-        assertEquals(message + ", heights differ", expected.getHeight(), actual.getHeight());
+        assertNotNull(expected, message);
+        assertNotNull(actual, message);
+        assertEquals(expected.getWidth(), actual.getWidth(), message + ", widths differ");
+        assertEquals(expected.getHeight(), actual.getHeight(), message + ", heights differ");
 
         for (int y = 0; y < expected.getHeight(); y++) {
             for (int x = 0; x < expected.getWidth(); x++) {
@@ -1281,7 +1279,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
 
                     int numImages = reader.getNumImages(true);
 
-                    assertEquals("Number of pages differs from original", infos.size(), numImages);
+                    assertEquals(infos.size(), numImages, "Number of pages differs from original");
 
                     for (int i = 0; i < numImages; i++) {
                         IIOImage after = reader.readAll(i, null);
@@ -1293,14 +1291,14 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
 
                         if (info.compression == TIFFExtension.COMPRESSION_OLD_JPEG) {
                             // Should rewrite this from old-style to new style
-                            assertEquals("Old JPEG compression not rewritten as JPEG", TIFFExtension.COMPRESSION_JPEG, ((Number) afterCompressionEntry.getValue()).intValue());
+                            assertEquals(TIFFExtension.COMPRESSION_JPEG, ((Number) afterCompressionEntry.getValue()).intValue(), "Old JPEG compression not rewritten as JPEG");
                         }
                         else {
-                            assertEquals("Compression differs from original", info.compression, ((Number) afterCompressionEntry.getValue()).intValue());
+                            assertEquals(info.compression, ((Number) afterCompressionEntry.getValue()).intValue(), "Compression differs from original");
                         }
 
-                        assertEquals("Image width differs from original", info.width, after.getRenderedImage().getWidth());
-                        assertEquals("Image height differs from original", info.height, after.getRenderedImage().getHeight());
+                        assertEquals(info.width, after.getRenderedImage().getWidth(), "Image width differs from original");
+                        assertEquals(info.height, after.getRenderedImage().getHeight(), "Image height differs from original");
                     }
                 }
             }

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriterTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFImageWriterTest.java
@@ -420,7 +420,7 @@ public class TIFFImageWriterTest extends ImageWriterAbstractTest<TIFFImageWriter
             ImageReader reader = ImageIO.getImageReaders(input).next();
             reader.setInput(input);
 
-            assertEquals( compression.length, reader.getNumImages(true), "wrong image count");
+            assertEquals(compression.length, reader.getNumImages(true), "wrong image count");
 
             for (int i = 0; i < reader.getNumImages(true); i++) {
                 assertImageEquals("image " + i + " differs", image, reader.read(i), 5); // Allow room for JPEG compression

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFStreamMetadataTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/TIFFStreamMetadataTest.java
@@ -30,7 +30,6 @@
 
 package com.twelvemonkeys.imageio.plugins.tiff;
 
-import org.junit.Test;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -46,7 +45,9 @@ import static java.nio.ByteOrder.BIG_ENDIAN;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
 import static org.mockito.Mockito.*;
 
 /**
@@ -55,9 +56,9 @@ import static org.mockito.Mockito.*;
 public class TIFFStreamMetadataTest {
     // Test that we configure byte order of stream correctly (MM + II)
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConfigureStreamNullStream() throws IIOInvalidTreeException {
-        TIFFStreamMetadata.configureStreamByteOrder(new TIFFStreamMetadata(), null);
+        assertThrows(IllegalArgumentException.class, () -> TIFFStreamMetadata.configureStreamByteOrder(new TIFFStreamMetadata(), null));
     }
 
     @Test
@@ -123,14 +124,14 @@ public class TIFFStreamMetadataTest {
     }
 
     // Test that we merge correctly with "forreign" metadata class, as long as format names are the same (MM + II)
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMergeNull() throws IIOInvalidTreeException {
-        new TIFFStreamMetadata().mergeTree(SUN_NATIVE_STREAM_METADATA_FORMAT_NAME, null);
+        assertThrows(IllegalArgumentException.class, () -> new TIFFStreamMetadata().mergeTree(SUN_NATIVE_STREAM_METADATA_FORMAT_NAME, null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testMergeIllegal() throws IIOInvalidTreeException {
-        new TIFFStreamMetadata().mergeTree("com.foo.bar", createForeignTree(BIG_ENDIAN));
+        assertThrows(IllegalArgumentException.class, () -> new TIFFStreamMetadata().mergeTree("com.foo.bar", createForeignTree(BIG_ENDIAN)));
     }
 
     @Test
@@ -148,14 +149,14 @@ public class TIFFStreamMetadataTest {
         assertEquals(BIG_ENDIAN, metadata.byteOrder);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetAsTreeNull() {
-        new TIFFStreamMetadata().getAsTree(null);
+        assertThrows(IllegalArgumentException.class, () -> new TIFFStreamMetadata().getAsTree(null));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetAsTreeIllegal() {
-        new TIFFStreamMetadata().getAsTree("com.foo.bar");
+        assertThrows(IllegalArgumentException.class, () -> new TIFFStreamMetadata().getAsTree("com.foo.bar"));
     }
 
     @Test

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/YCbCr16UpsamplerStreamTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/YCbCr16UpsamplerStreamTest.java
@@ -31,7 +31,6 @@
 package com.twelvemonkeys.imageio.plugins.tiff;
 
 import com.twelvemonkeys.io.LittleEndianDataInputStream;
-import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -39,9 +38,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * YCbCr16UpsamplerStreamTest
@@ -51,24 +49,24 @@ import static org.junit.Assert.assertEquals;
  * @version $Id: YCbCr16UpsamplerStreamTest.java,v 1.0 31.01.13 14:35 haraldk Exp$
  */
 public class YCbCr16UpsamplerStreamTest {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullStream() {
-        new YCbCr16UpsamplerStream(null, new int[2], 7, 5, ByteOrder.LITTLE_ENDIAN);
+        assertThrows(IllegalArgumentException.class, () -> new YCbCr16UpsamplerStream(null, new int[2], 7, 5, ByteOrder.LITTLE_ENDIAN));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullChroma() {
-        new YCbCr16UpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[3], 7, 5, ByteOrder.LITTLE_ENDIAN);
+        assertThrows(IllegalArgumentException.class, () -> new YCbCr16UpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[3], 7, 5, ByteOrder.LITTLE_ENDIAN));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateShortChroma() {
-        new YCbCr16UpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[1], 7, 5, ByteOrder.LITTLE_ENDIAN);
+        assertThrows(IllegalArgumentException.class, () -> new YCbCr16UpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[1], 7, 5, ByteOrder.LITTLE_ENDIAN));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNoByteOrder() {
-        new YCbCr16UpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[] {2, 2}, 7, 5, null);
+        assertThrows(IllegalArgumentException.class, () -> new YCbCr16UpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[] {2, 2}, 7, 5, null));
     }
 
     // TODO: The expected values seems bogus...

--- a/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/YCbCrUpsamplerStreamTest.java
+++ b/imageio/imageio-tiff/src/test/java/com/twelvemonkeys/imageio/plugins/tiff/YCbCrUpsamplerStreamTest.java
@@ -30,15 +30,13 @@
 
 package com.twelvemonkeys.imageio.plugins.tiff;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * YCbCrUpsamplerStreamTest
@@ -48,19 +46,19 @@ import static org.junit.Assert.assertEquals;
  * @version $Id: YCbCrUpsamplerStreamTest.java,v 1.0 31.01.13 14:35 haraldk Exp$
  */
 public class YCbCrUpsamplerStreamTest  {
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullStream() {
-        new YCbCrUpsamplerStream(null, new int[2], 7, 5);
+        assertThrows(IllegalArgumentException.class, () -> new YCbCrUpsamplerStream(null, new int[2], 7, 5));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateNullChroma() {
-        new YCbCrUpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[3], 7, 5);
+        assertThrows(IllegalArgumentException.class, () -> new YCbCrUpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[3], 7, 5));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCreateShortChroma() {
-        new YCbCrUpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[1], 7, 5);
+        assertThrows(IllegalArgumentException.class, () -> new YCbCrUpsamplerStream(new ByteArrayInputStream(new byte[0]), new int[1], 7, 5));
     }
 
     @Test

--- a/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/LSBBitReaderTest.java
+++ b/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/LSBBitReaderTest.java
@@ -2,13 +2,12 @@ package com.twelvemonkeys.imageio.plugins.webp;
 
 import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 
-import org.junit.Test;
-
 import javax.imageio.stream.ImageInputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * LSBBitReaderTest.

--- a/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageMetadataTest.java
+++ b/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageMetadataTest.java
@@ -1,9 +1,6 @@
 package com.twelvemonkeys.imageio.plugins.webp;
 
 import com.twelvemonkeys.imageio.util.ImageTypeSpecifiers;
-
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -13,7 +10,8 @@ import javax.imageio.metadata.IIOMetadataFormatImpl;
 import javax.imageio.metadata.IIOMetadataNode;
 import java.awt.image.*;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * WebPImageMetadataTest.
@@ -41,21 +39,11 @@ public class WebPImageMetadataTest {
         // Other formats
         assertNull(metadata.getNativeMetadataFormatName());
         assertNull(metadata.getExtraMetadataFormatNames());
-        assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-            @Override
-            public void run() {
-                metadata.getAsTree("com_foo_bar_1.0");
-            }
-        });
+        assertThrows(IllegalArgumentException.class, () -> metadata.getAsTree("com_foo_bar_1.0"));
 
         // Read-only
         assertTrue(metadata.isReadOnly());
-        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
-            @Override
-            public void run() throws Throwable {
-                metadata.mergeTree(IIOMetadataFormatImpl.standardMetadataFormatName, new IIOMetadataNode(IIOMetadataFormatImpl.standardMetadataFormatName));
-            }
-        });
+        assertThrows(IllegalStateException.class, () -> metadata.mergeTree(IIOMetadataFormatImpl.standardMetadataFormatName, new IIOMetadataNode(IIOMetadataFormatImpl.standardMetadataFormatName)));
     }
 
     @Test

--- a/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageReaderTest.java
+++ b/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageReaderTest.java
@@ -2,8 +2,6 @@ package com.twelvemonkeys.imageio.plugins.webp;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
-import org.junit.Test;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.ImageTypeSpecifier;
@@ -16,7 +14,8 @@ import java.io.IOException;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * WebPImageReaderTest

--- a/imageio/pom.xml
+++ b/imageio/pom.xml
@@ -95,11 +95,16 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
 

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -21,14 +21,12 @@
             <version>2.5</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -23,6 +23,12 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>5.11.3</version>
             <scope>test</scope>

--- a/servlet/src/test/java/com/twelvemonkeys/servlet/image/IIOProviderContextListenerTest.java
+++ b/servlet/src/test/java/com/twelvemonkeys/servlet/image/IIOProviderContextListenerTest.java
@@ -30,8 +30,6 @@
 
 package com.twelvemonkeys.servlet.image;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.Locale;
@@ -43,7 +41,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * IIOProviderContextListenerTest


### PR DESCRIPTION
Adding unit test in junit5 is more readable. 
This pull request contains the changes required for upgrading to junit5 from junit4.
[Junit 5 Documentation](https://junit.org/junit5/docs/current/user-guide/)

Some of the major change, that was relevant to this project was as follows.

- assertEquals signature change, previously the first argument was the assertMessage, now it was moved as the last parameter
- Asserting exception, previously we used the attribute excepted along with the Test annotation, that was deprecated and now we can use assertThrows()
- Timeout the testcase, the old attribute was deprecated, now we can use assertTimeout
- Ignore annotation was deprecated, now we can use “Disabled” annotation instead.
- Before and After annotations was also changed to BeforeEach and AfterEach respectively
- RunWith annotation was replaced as ExtendedWith
- Some of the “assume” methods are deprecated, eg: assumeNotNull, 
Here we need to use assumeTrue with parameters contains the not null check
