### PR TITLE
Avoid full-frame VP8 macroblock allocation for subsampled WebP reads

### DIFF
--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/VP8Frame.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/VP8Frame.java
@@ -164,9 +164,7 @@ public final class VP8Frame {
         currentMacroBlockRowIndex = -1;
         lastNonBPredMacroBlockByColumn = new MacroBlock[macroBlockCols + 2];
 
-        for (int mbCol = 0; mbCol < macroBlockCols + 2; mbCol++) {
-            lastNonBPredMacroBlockByColumn[mbCol] = topMacroBlockRow[mbCol];
-        }
+        System.arraycopy(topMacroBlockRow, 0, lastNonBPredMacroBlockByColumn, 0, macroBlockCols + 2);
     }
 
     private static int ySubBlockModeIndex(final int subX, final int subY) {
@@ -1172,10 +1170,10 @@ public final class VP8Frame {
 
                 skipCoeffs[mb_row][mb_col] = macroBlockNoCoeffSkip > 0 ? bc.readBool(prob_skip_false) : 0;
 
-                int y_mode = readYMode(bc);
-                yModes[mb_row][mb_col] = y_mode;
+                int yMode = readYMode(bc);
+                yModes[mb_row][mb_col] = yMode;
 
-                if (y_mode == Globals.B_PRED) {
+                if (yMode == Globals.B_PRED) {
                     for (int subY = 0; subY < 4; subY++) {
                         for (int subX = 0; subX < 4; subX++) {
                             int aboveMode = getAboveYSubBlockMode(mb_row, mb_col, subX, subY);
@@ -1193,7 +1191,7 @@ public final class VP8Frame {
                 else {
                     int blockMode;
 
-                    switch (y_mode) {
+                    switch (yMode) {
                         case Globals.V_PRED:
                             blockMode = Globals.B_VE_PRED;
                             break;

--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/VP8Frame.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/VP8Frame.java
@@ -67,6 +67,18 @@ public final class VP8Frame {
     private int macroBlockRows;
 
     private MacroBlock[][] macroBlocks;
+    private MacroBlock[] currentMacroBlockRow;
+    private int currentMacroBlockRowIndex;
+    private int[][] filterLevels;
+    private MacroBlock[] lastNonBPredMacroBlockByColumn;
+    private int[][] segmentIds;
+    private int[][] skipCoeffs;
+    private int[][] uvModes;
+    private int[][][] ySubBlockModes;
+    private int[][] yModes;
+    private MacroBlock[] previousMacroBlockRow;
+    private MacroBlock[] topMacroBlockRow;
+    private boolean windowedDecode;
     private int macroBlockSegementAbsoluteDelta;
     private int[] macroBlockSegmentTreeProbs;
     private final int[] modeLoopFilterDeltas = new int[MAX_MODE_LF_DELTAS];
@@ -108,6 +120,81 @@ public final class VP8Frame {
                 macroBlocks[y][x] = new MacroBlock(x, y, debug);
             }
         }
+    }
+
+    private void createMacroBlockMetadata() {
+        segmentIds = new int[macroBlockRows][macroBlockCols];
+        filterLevels = new int[macroBlockRows][macroBlockCols];
+        skipCoeffs = new int[macroBlockRows][macroBlockCols];
+        yModes = new int[macroBlockRows][macroBlockCols];
+        uvModes = new int[macroBlockRows][macroBlockCols];
+        ySubBlockModes = new int[macroBlockRows][macroBlockCols][16];
+    }
+
+    private MacroBlock[] createMacroBlockRow(final int mbRow) {
+        MacroBlock[] row = new MacroBlock[macroBlockCols + 2];
+
+        for (int mbCol = 0; mbCol < macroBlockCols + 2; mbCol++) {
+            row[mbCol] = new MacroBlock(mbCol, mbRow + 1, debug);
+        }
+
+        return row;
+    }
+
+    private void populateMacroBlock(final MacroBlock macroBlock, final int mbRow, final int mbCol) {
+        macroBlock.setSegmentId(segmentIds[mbRow][mbCol]);
+        macroBlock.setFilterLevel(filterLevels[mbRow][mbCol]);
+        macroBlock.setSkipCoeff(skipCoeffs[mbRow][mbCol]);
+        macroBlock.setYMode(yModes[mbRow][mbCol]);
+        macroBlock.setUvMode(uvModes[mbRow][mbCol]);
+
+        int[] modes = ySubBlockModes[mbRow][mbCol];
+        for (int y = 0; y < 4; y++) {
+            for (int x = 0; x < 4; x++) {
+                macroBlock.getYSubBlock(x, y).setMode(modes[y * 4 + x]);
+            }
+        }
+    }
+
+    private void initializeWindowedDecodeState() {
+        createMacroBlockMetadata();
+        topMacroBlockRow = createMacroBlockRow(-1);
+        previousMacroBlockRow = topMacroBlockRow;
+        currentMacroBlockRow = null;
+        currentMacroBlockRowIndex = -1;
+        lastNonBPredMacroBlockByColumn = new MacroBlock[macroBlockCols + 2];
+
+        for (int mbCol = 0; mbCol < macroBlockCols + 2; mbCol++) {
+            lastNonBPredMacroBlockByColumn[mbCol] = topMacroBlockRow[mbCol];
+        }
+    }
+
+    private static int ySubBlockModeIndex(final int subX, final int subY) {
+        return subY * 4 + subX;
+    }
+
+    private int getYSubBlockMode(final int mbRow, final int mbCol, final int subX, final int subY) {
+        if (mbRow < 0 || mbCol < 0 || mbRow >= macroBlockRows || mbCol >= macroBlockCols) {
+            return 0;
+        }
+
+        return ySubBlockModes[mbRow][mbCol][ySubBlockModeIndex(subX, subY)];
+    }
+
+    private int getAboveYSubBlockMode(final int mbRow, final int mbCol, final int subX, final int subY) {
+        if (subY > 0) {
+            return getYSubBlockMode(mbRow, mbCol, subX, subY - 1);
+        }
+
+        return getYSubBlockMode(mbRow - 1, mbCol, subX, 3);
+    }
+
+    private int getLeftYSubBlockMode(final int mbRow, final int mbCol, final int subX, final int subY) {
+        if (subX > 0) {
+            return getYSubBlockMode(mbRow, mbCol, subX - 1, subY);
+        }
+
+        return getYSubBlockMode(mbRow, mbCol - 1, 3, subY);
     }
 
     public boolean decode(final WritableRaster raster, final ImageReadParam param) throws IOException {
@@ -177,7 +264,14 @@ public final class VP8Frame {
 //        logger.log("macroBlockCols: " + macroBlockCols);
 //        logger.log("macroBlockRows: " + macroBlockRows);
 
-        createMacroBlocks();
+        windowedDecode = !debug;
+
+        if (windowedDecode) {
+            initializeWindowedDecodeState();
+        }
+        else {
+            createMacroBlocks();
+        }
 
         offset = frame.getStreamPosition();
 
@@ -332,20 +426,46 @@ public final class VP8Frame {
         int sourceXSubsampling = param != null ? param.getSourceXSubsampling() : 1;
         int sourceYSubsampling = param != null ? param.getSourceYSubsampling() : 1;
 
-        for (int row = 0; row < macroBlockRows; row++) {
-            if (parts > 1) {
-                tokenBoolDecoder = tokenBoolDecoders.get(ibc);
-                tokenBoolDecoder.seek();
+        if (windowedDecode) {
+            for (int row = 0; row < macroBlockRows; row++) {
+                if (parts > 1) {
+                    tokenBoolDecoder = tokenBoolDecoders.get(ibc);
+                    tokenBoolDecoder.seek();
 
-                ibc++;
-                if (ibc == parts) {
-                    ibc = 0;
+                    ibc++;
+                    if (ibc == parts) {
+                        ibc = 0;
+                    }
                 }
+
+                currentMacroBlockRow = createMacroBlockRow(row);
+                currentMacroBlockRowIndex = row;
+
+                decodeMacroBlockRow(row, raster, region, sourceXSubsampling, sourceYSubsampling);
+
+                previousMacroBlockRow = currentMacroBlockRow;
+                currentMacroBlockRow = null;
+                currentMacroBlockRowIndex = -1;
+
+                fireProgressUpdate(row);
             }
+        }
+        else {
+            for (int row = 0; row < macroBlockRows; row++) {
+                if (parts > 1) {
+                    tokenBoolDecoder = tokenBoolDecoders.get(ibc);
+                    tokenBoolDecoder.seek();
 
-            decodeMacroBlockRow(row, raster, region, sourceXSubsampling, sourceYSubsampling);
+                    ibc++;
+                    if (ibc == parts) {
+                        ibc = 0;
+                    }
+                }
 
-            fireProgressUpdate(row);
+                decodeMacroBlockRow(row, raster, region, sourceXSubsampling, sourceYSubsampling);
+
+                fireProgressUpdate(row);
+            }
         }
 
         return true;
@@ -356,11 +476,15 @@ public final class VP8Frame {
         final boolean filter = filterLevel != 0;
 
         MacroBlock left = null;
-        MacroBlock[] prevRow = macroBlocks[mbRow];
-        MacroBlock[] currRow = macroBlocks[mbRow + 1];
+        MacroBlock[] prevRow = windowedDecode ? previousMacroBlockRow : macroBlocks[mbRow];
+        MacroBlock[] currRow = windowedDecode ? currentMacroBlockRow : macroBlocks[mbRow + 1];
 
         for (int mbCol = 0; mbCol < macroBlockCols; mbCol++) {
             MacroBlock mb = currRow[mbCol + 1];
+
+            if (windowedDecode) {
+                populateMacroBlock(mb, mbRow, mbCol);
+            }
 
             mb.decodeMacroBlock(this);
             mb.dequantMacroBlock(this);
@@ -371,6 +495,10 @@ public final class VP8Frame {
             }
 
             copyBlock(mb, raster, region, xSubsampling, ySubsampling);
+
+            if (windowedDecode && mb.getYMode() != Globals.B_PRED) {
+                lastNonBPredMacroBlockByColumn[mbCol + 1] = mb;
+            }
 
             left = mb;
         }
@@ -448,6 +576,11 @@ public final class VP8Frame {
             MacroBlock mb2 = getMacroBlock(mb.getX(), mb.getY() - 1);
             //TODO: SPLIT
             while (plane == SubBlock.Plane.Y2 && mb2.getYMode() == Globals.B_PRED) {
+                if (windowedDecode) {
+                    mb2 = lastNonBPredMacroBlockByColumn[mb.getX() + 1];
+                    break;
+                }
+
                 mb2 = getMacroBlock(mb2.getX(), mb2.getY() - 1);
             }
 
@@ -806,8 +939,31 @@ public final class VP8Frame {
     }
 
     public MacroBlock getMacroBlock(int mbCol, int mbRow) {
-//         return macroBlocks[mbCol + 1][mbRow + 1];
-        return macroBlocks[mbRow + 1][mbCol + 1];
+        if (!windowedDecode) {
+            return macroBlocks[mbRow + 1][mbCol + 1];
+        }
+
+        if (mbRow == currentMacroBlockRowIndex && currentMacroBlockRow != null) {
+            return currentMacroBlockRow[mbCol + 1];
+        }
+
+        if (mbRow == currentMacroBlockRowIndex - 1 && previousMacroBlockRow != null) {
+            return previousMacroBlockRow[mbCol + 1];
+        }
+
+        if (mbRow < currentMacroBlockRowIndex - 1 && mbRow >= -1) {
+            if (mbCol < 0 || mbCol >= macroBlockCols) {
+                return topMacroBlockRow[mbCol + 1];
+            }
+
+            return lastNonBPredMacroBlockByColumn[mbCol + 1];
+        }
+
+        if (mbRow < 0 || mbRow >= macroBlockRows || mbCol < 0 || mbCol >= macroBlockCols) {
+            return topMacroBlockRow[mbCol + 1];
+        }
+
+        return topMacroBlockRow[mbCol + 1];
     }
 
     public int getMacroBlockCols() {
@@ -925,85 +1081,142 @@ public final class VP8Frame {
         while (++mb_row < macroBlockRows) {
             int mb_col = -1;
             while (++mb_col < macroBlockCols) {
-                //if (this.segmentation_enabled > 0) {
-                //	logger.log(Level.SEVERE, "TODO:");
-                //	throw new IllegalArgumentException("bad input: segmentation_enabled()");
-                //}
-                // Read the macroblock coeff skip flag if this feature is in
-                // use, else default to 0
-                MacroBlock mb = getMacroBlock(mb_col, mb_row);
+                if (!windowedDecode) {
+                    MacroBlock mb = getMacroBlock(mb_col, mb_row);
+
+                    if ((segmentationIsEnabled > 0) && (updateMacroBlockSegmentationMap > 0)) {
+                        int value = bc.readTree(Globals.macroBlockSegmentTree, this.macroBlockSegmentTreeProbs, 0);
+                        mb.setSegmentId(value);
+                    }
+
+                    if (modeRefLoopFilterDeltaEnabled > 0) {
+                        int level = filterLevel;
+                        level = level + refLoopFilterDeltas[0];
+                        level = (level < 0) ? 0 : Math.min(level, 63);
+                        mb.setFilterLevel(level);
+                    }
+                    else {
+                        mb.setFilterLevel(segmentQuants.getSegQuants()[mb.getSegmentId()].getFilterStrength());
+                    }
+
+                    int mb_skip_coeff = macroBlockNoCoeffSkip > 0 ? bc.readBool(prob_skip_false) : 0;
+
+                    mb.setSkipCoeff(mb_skip_coeff);
+
+                    int y_mode = readYMode(bc);
+
+                    mb.setYMode(y_mode);
+
+                    if (y_mode == Globals.B_PRED) {
+                        for (int i = 0; i < 4; i++) {
+                            for (int j = 0; j < 4; j++) {
+                                SubBlock sb = mb.getYSubBlock(j, i);
+                                SubBlock A = getAboveSubBlock(sb, SubBlock.Plane.Y1);
+                                SubBlock L = getLeftSubBlock(sb, SubBlock.Plane.Y1);
+
+                                int mode = readSubBlockMode(bc, A.getMode(), L.getMode());
+
+                                sb.setMode(mode);
+                            }
+                        }
+
+                        if (modeRefLoopFilterDeltaEnabled > 0) {
+                            int level = mb.getFilterLevel();
+                            level = level + this.modeLoopFilterDeltas[0];
+                            level = (level < 0) ? 0 : Math.min(level, 63);
+                            mb.setFilterLevel(level);
+                        }
+                    }
+                    else {
+                        int BMode;
+
+                        switch (y_mode) {
+                            case Globals.V_PRED:
+                                BMode = Globals.B_VE_PRED;
+                                break;
+                            case Globals.H_PRED:
+                                BMode = Globals.B_HE_PRED;
+                                break;
+                            case Globals.TM_PRED:
+                                BMode = Globals.B_TM_PRED;
+                                break;
+                            case Globals.DC_PRED:
+                            default:
+                                BMode = Globals.B_DC_PRED;
+                                break;
+                        }
+
+                        for (int x = 0; x < 4; x++) {
+                            for (int y = 0; y < 4; y++) {
+                                SubBlock sb = mb.getYSubBlock(x, y);
+                                sb.setMode(BMode);
+                            }
+                        }
+                    }
+                    int mode = readUvMode(bc);
+                    mb.setUvMode(mode);
+                    continue;
+                }
 
                 if ((segmentationIsEnabled > 0) && (updateMacroBlockSegmentationMap > 0)) {
-                    int value = bc.readTree(Globals.macroBlockSegmentTree, this.macroBlockSegmentTreeProbs, 0);
-                    mb.setSegmentId(value);
+                    segmentIds[mb_row][mb_col] = bc.readTree(Globals.macroBlockSegmentTree, this.macroBlockSegmentTreeProbs, 0);
                 }
 
                 if (modeRefLoopFilterDeltaEnabled > 0) {
-                    int level = filterLevel;
-                    level = level + refLoopFilterDeltas[0];
-                    level = (level < 0) ? 0 : Math.min(level, 63);
-                    mb.setFilterLevel(level);
+                    int level = filterLevel + refLoopFilterDeltas[0];
+                    filterLevels[mb_row][mb_col] = (level < 0) ? 0 : Math.min(level, 63);
                 }
                 else {
-                    mb.setFilterLevel(segmentQuants.getSegQuants()[mb.getSegmentId()].getFilterStrength());
+                    filterLevels[mb_row][mb_col] = segmentQuants.getSegQuants()[segmentIds[mb_row][mb_col]].getFilterStrength();
                 }
 
-                int mb_skip_coeff = macroBlockNoCoeffSkip > 0 ? bc.readBool(prob_skip_false) : 0;
-
-                mb.setSkipCoeff(mb_skip_coeff);
+                skipCoeffs[mb_row][mb_col] = macroBlockNoCoeffSkip > 0 ? bc.readBool(prob_skip_false) : 0;
 
                 int y_mode = readYMode(bc);
-
-                mb.setYMode(y_mode);
+                yModes[mb_row][mb_col] = y_mode;
 
                 if (y_mode == Globals.B_PRED) {
-                    for (int i = 0; i < 4; i++) {
-                        for (int j = 0; j < 4; j++) {
-                            SubBlock sb = mb.getYSubBlock(j, i);
-                            SubBlock A = getAboveSubBlock(sb, SubBlock.Plane.Y1);
-                            SubBlock L = getLeftSubBlock(sb, SubBlock.Plane.Y1);
-
-                            int mode = readSubBlockMode(bc, A.getMode(), L.getMode());
-
-                            sb.setMode(mode);
+                    for (int subY = 0; subY < 4; subY++) {
+                        for (int subX = 0; subX < 4; subX++) {
+                            int aboveMode = getAboveYSubBlockMode(mb_row, mb_col, subX, subY);
+                            int leftMode = getLeftYSubBlockMode(mb_row, mb_col, subX, subY);
+                            int mode = readSubBlockMode(bc, aboveMode, leftMode);
+                            ySubBlockModes[mb_row][mb_col][ySubBlockModeIndex(subX, subY)] = mode;
                         }
                     }
 
                     if (modeRefLoopFilterDeltaEnabled > 0) {
-                        int level = mb.getFilterLevel();
-                        level = level + this.modeLoopFilterDeltas[0];
-                        level = (level < 0) ? 0 : Math.min(level, 63);
-                        mb.setFilterLevel(level);
+                        int level = filterLevels[mb_row][mb_col] + this.modeLoopFilterDeltas[0];
+                        filterLevels[mb_row][mb_col] = (level < 0) ? 0 : Math.min(level, 63);
                     }
                 }
                 else {
-                    int BMode;
+                    int blockMode;
 
                     switch (y_mode) {
                         case Globals.V_PRED:
-                            BMode = Globals.B_VE_PRED;
+                            blockMode = Globals.B_VE_PRED;
                             break;
                         case Globals.H_PRED:
-                            BMode = Globals.B_HE_PRED;
+                            blockMode = Globals.B_HE_PRED;
                             break;
                         case Globals.TM_PRED:
-                            BMode = Globals.B_TM_PRED;
+                            blockMode = Globals.B_TM_PRED;
                             break;
                         case Globals.DC_PRED:
                         default:
-                            BMode = Globals.B_DC_PRED;
+                            blockMode = Globals.B_DC_PRED;
                             break;
                     }
 
-                    for (int x = 0; x < 4; x++) {
-                        for (int y = 0; y < 4; y++) {
-                            SubBlock sb = mb.getYSubBlock(x, y);
-                            sb.setMode(BMode);
+                    for (int subY = 0; subY < 4; subY++) {
+                        for (int subX = 0; subX < 4; subX++) {
+                            ySubBlockModes[mb_row][mb_col][ySubBlockModeIndex(subX, subY)] = blockMode;
                         }
                     }
                 }
-                int mode = readUvMode(bc);
-                mb.setUvMode(mode);
+
+                uvModes[mb_row][mb_col] = readUvMode(bc);
             }
         }
     }

--- a/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageReaderTest.java
+++ b/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageReaderTest.java
@@ -270,6 +270,29 @@ public class WebPImageReaderTest extends ImageReaderAbstractTest<WebPImageReader
         }
     }
 
+    @Test
+    public void testSubsampleLargeVP8FromRepositorySample() throws IOException {
+        WebPImageReader reader = createReader();
+
+        try (ImageInputStream stream = ImageIO.createImageInputStream(getClassLoaderResource("/webp/alpha_filter.webp"))) {
+            reader.setInput(stream);
+
+            ImageReadParam param = reader.getDefaultReadParam();
+            param.setSourceSubsampling(8, 8, 0, 0);
+
+            BufferedImage image = reader.read(0, param);
+
+            assertEquals(200, image.getWidth());
+            assertEquals(200, image.getHeight());
+            assertEquals(Transparency.TRANSLUCENT, image.getTransparency());
+            assertRGBEquals("Expected transparent area to stay transparent after subsampling", 0x00000000, image.getRGB(25, 66) & 0xFF000000, 8);
+            assertRGBEquals("Expected opaque area to stay opaque after subsampling", 0xFF000000, image.getRGB(166, 111) & 0xFF000000, 8);
+        }
+        finally {
+            reader.dispose();
+        }
+    }
+
     /**
      * This test compares alpha channel information that is decoded by the WebPImageReader with the known "good" alpha 
      * channel information. To generate the known "good" alpha channel information, we use the command line and libwebp,

--- a/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageReaderTest.java
+++ b/imageio/imageio-webp/src/test/java/com/twelvemonkeys/imageio/plugins/webp/WebPImageReaderTest.java
@@ -271,7 +271,7 @@ public class WebPImageReaderTest extends ImageReaderAbstractTest<WebPImageReader
     }
 
     @Test
-    public void testSubsampleLargeVP8FromRepositorySample() throws IOException {
+    void testSubsampleLargeVP8FromRepositorySample() throws IOException {
         WebPImageReader reader = createReader();
 
         try (ImageInputStream stream = ImageIO.createImageInputStream(getClassLoaderResource("/webp/alpha_filter.webp"))) {


### PR DESCRIPTION
  **What is fixed**

  Fixes excessive memory use when reading very large lossy WebP images with source subsampling, which could result in
  `OutOfMemoryError`.

  **Why is this change proposed**

  The VP8 decoder allocated macroblock state for the full frame up front, even when only a subsampled result was
  requested. For large images this caused unnecessary memory pressure and could make the read fail before the reduced
  output was produced.

  **What is changed**

  * Changed `VP8Frame` to decode with a bounded row-window working set instead of a full-frame macroblock allocation
  * Preserved the VP8 neighbor/context behavior needed for correct decoding
  * Added a repository-safe regression test for subsampled decode using the checked-in `alpha_filter.webp` sample