### PR TITLE
validate ICC_PROFILE chunk index in getEmbeddedICCProfile

### DIFF
--- a/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReader.java
+++ b/imageio/imageio-jpeg/src/main/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReader.java
@@ -975,16 +975,15 @@ public final class JPEGImageReader extends ImageReaderBase {
                 }
             }
 
-            if (!badICC && chunkNumber < 1) {
-                // Anything else is just ignored
-                processWarningOccurred(String.format("Invalid 'ICC_PROFILE' chunk index: %d. Ignoring ICC profile.", chunkNumber));
+            int count = badICC ? segments.size() : chunkCount;
 
-                if (!allowBadIndexes) {
-                    return null;
-                }
+            if (!badICC && (chunkNumber < 1 || chunkNumber > count)) {
+                // Anything else is just ignored
+                processWarningOccurred(String.format("Invalid 'ICC_PROFILE' chunk index: %d of %d. Ignoring ICC profile.", chunkNumber, chunkCount));
+
+                return null;
             }
 
-            int count = badICC ? segments.size() : chunkCount;
             InputStream[] streams = new InputStream[count];
             streams[badICC ? 0 : chunkNumber - 1] = stream;
 
@@ -999,6 +998,12 @@ public final class JPEGImageReader extends ImageReaderBase {
                 }
 
                 int index = badICC ? i : chunkNumber - 1;
+                if (index < 0 || index >= count) {
+                    processWarningOccurred(String.format("Invalid 'ICC_PROFILE' chunk index: %d of %d. Ignoring ICC profile.", chunkNumber, chunkCount));
+
+                    return null;
+                }
+
                 streams[index] = stream;
             }
 

--- a/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
+++ b/imageio/imageio-jpeg/src/test/java/com/twelvemonkeys/imageio/plugins/jpeg/JPEGImageReaderTest.java
@@ -57,6 +57,7 @@ import java.awt.image.BufferedImage;
 import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.*;
@@ -237,6 +238,56 @@ public class JPEGImageReaderTest extends ImageReaderAbstractTest<JPEGImageReader
         finally {
             reader.dispose();
         }
+    }
+
+    @Test
+    public void testICCChunkIndexOutOfBounds() throws IOException {
+        // Crafted file with two 'ICC_PROFILE' APP2 segments, where the first segment claims to be
+        // chunk 200 of 2. The bogus chunk index must not be used to index the chunk array
+        // (was: ArrayIndexOutOfBoundsException from getEmbeddedICCProfile).
+        byte[] data = jpegWithICCChunks(new int[] {200, 2}, new int[] {2, 2});
+
+        JPEGImageReader reader = createReader();
+        try (ImageInputStream stream = ImageIO.createImageInputStream(new ByteArrayInputStream(data))) {
+            reader.setInput(stream);
+
+            BufferedImage image = reader.read(0);
+
+            assertNotNull(image);
+            assertEquals(16, image.getWidth());
+            assertEquals(16, image.getHeight());
+        }
+        finally {
+            reader.dispose();
+        }
+    }
+
+    private static byte[] jpegWithICCChunks(final int[] chunkNumbers, final int[] chunkCounts) throws IOException {
+        ByteArrayOutputStream base = new ByteArrayOutputStream();
+        assertTrue(ImageIO.write(new BufferedImage(16, 16, BufferedImage.TYPE_3BYTE_BGR), "JPEG", base));
+        byte[] bytes = base.toByteArray();
+
+        byte[] identifier = "ICC_PROFILE".getBytes(StandardCharsets.US_ASCII);
+
+        ByteArrayOutputStream merged = new ByteArrayOutputStream();
+        merged.write(bytes, 0, 2); // SOI
+
+        for (int i = 0; i < chunkNumbers.length; i++) {
+            int length = identifier.length + 1 /* null-terminator */ + 2 /* chunk number + count */ + 1 /* one byte profile data */ + 2 /* length field */;
+            merged.write(0xFF);
+            merged.write(0xE2); // APP2
+            merged.write((length >> 8) & 0xFF);
+            merged.write(length & 0xFF);
+            merged.write(identifier);
+            merged.write(0x00); // null-terminator
+            merged.write(chunkNumbers[i] & 0xFF);
+            merged.write(chunkCounts[i] & 0xFF);
+            merged.write(0x00);
+        }
+
+        merged.write(bytes, 2, bytes.length - 2); // Rest of the JPEG
+
+        return merged.toByteArray();
     }
 
     @Test


### PR DESCRIPTION
A JPEG with two or more APP2 'ICC_PROFILE' segments whose first chunk reports an index past the chunk count makes getEmbeddedICCProfile index the streams array out of range, throwing ArrayIndexOutOfBoundsException from read() before any pixels are decoded. The chunk number was only checked for being below 1, never against the count. Reject indexes outside 1..count and ignore the profile, matching the existing handling for other malformed ICC segments. The test builds such a file in memory.