### PR TITLE
clamp x delta to row bounds in BMP RLE8 decoder

### DIFF
--- a/imageio/imageio-bmp/src/main/java/com/twelvemonkeys/imageio/plugins/bmp/RLE8Decoder.java
+++ b/imageio/imageio-bmp/src/main/java/com/twelvemonkeys/imageio/plugins/bmp/RLE8Decoder.java
@@ -75,7 +75,9 @@ final class RLE8Decoder extends AbstractRLEDecoder {
 
                     case 0x02:
                         // Delta
-                        deltaX = srcX + stream.read();
+                        // The x displacement comes straight from the stream; clamp it to the
+                        // row bounds so the fill and reposition below can't write past the row
+                        deltaX = Math.min(srcX + checkEOF(stream.read()), row.length);
                         deltaY = srcY + checkEOF(stream.read());
 
                         Arrays.fill(row, srcX, deltaX, (byte) 0);

--- a/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/RLE8DecoderTest.java
+++ b/imageio/imageio-bmp/src/test/java/com/twelvemonkeys/imageio/plugins/bmp/RLE8DecoderTest.java
@@ -127,6 +127,22 @@ public class RLE8DecoderTest {
         assertArrayEquals(DECODED, Arrays.copyOfRange(buffer.array(), 0, count));
     }
 
+    @Test
+    public void decodeDeltaBeyondRowDoesNotOverrun() {
+        // Delta opcode (00 02 dx dy) with an x displacement that runs past the row,
+        // followed by end-of-bitmap. The stream-supplied displacement must not
+        // write past the decoded row (previously threw ArrayIndexOutOfBoundsException).
+        byte[] rle = {
+                0x00, 0x02, (byte) 0xFF, 0x00, // delta dx=255, dy=0
+                0x00, 0x01,                    // end of bitmap
+        };
+
+        Decoder decoder = new RLE8Decoder(4); // row length 4 bytes
+        ByteBuffer buffer = ByteBuffer.allocate(64);
+
+        assertDoesNotThrow(() -> decoder.decode(new ByteArrayInputStream(rle), buffer));
+    }
+
 //    @Test
 //    public void decodeExampleW28to31() throws IOException {
 //        for (int i = 28; i < 32; i++) {


### PR DESCRIPTION
**What is fixed** The BMP RLE8 decoder writes out of bounds when a delta escape carries an x displacement larger than the row. `RLE8Decoder.decodeRow` computed `deltaX = srcX + stream.read()` from a raw stream byte and passed it as the `toIndex` of `Arrays.fill(row, srcX, deltaX, 0)` with no bound, so a crafted RLE8 bitmap (e.g. `00 02 FF 00` on a 4-byte row) throws `ArrayIndexOutOfBoundsException` out of the read path instead of failing as a normal `IIOException`.

**Why is this change proposed** The delta displacement crosses a trust boundary but is used unchecked, while every other opcode in the same method already guards its writes with `srcX < row.length`. The first displacement byte was also not passed through `checkEOF`, so a truncated stream produced a negative `toIndex` (`IllegalArgumentException`) rather than a clean EOF.

**What is changed**

* Clamp `deltaX` to `row.length` so the fill and the later reposition stay within the row
* Route the x displacement read through `checkEOF` so a truncated delta ends as `EOFException`
* Regression test in `RLE8DecoderTest` for an out-of-range delta

Valid RLE8 input is unaffected (a well-formed delta never moves x past the row), and the existing decoder tests still pass.