### PR TITLE
quote namespace prefix before regex match in SVGImageReaderSpi

### DIFF
--- a/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
+++ b/imageio/imageio-batik/src/main/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpi.java
@@ -41,6 +41,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import static com.twelvemonkeys.imageio.util.IIOUtil.deregisterProvider;
 
@@ -166,8 +167,12 @@ public final class SVGImageReaderSpi extends ImageReaderSpiBase {
                         readBuffer(input, attrBuf, output -> output.size() < MAX_ATTR_SCAN, bb -> bb == '>');
 
                         // If the tag contains the SVG namespace, it's SVG.
+                        // The prefix comes straight from the input, so quote it to keep it a
+                        // literal, otherwise a crafted prefix is compiled as a regex and can
+                        // hang canDecodeInput with catastrophic backtracking
+                        String prefix = Pattern.quote(name.split(":")[0]);
                         if (attrBuf.toString("US-ASCII").matches(
-                            ".*xmlns:" + name.split(":")[0] + "\\s*=\\s*\"http://www.w3.org/2000/svg\".*")) {
+                            ".*xmlns:" + prefix + "\\s*=\\s*\"http://www.w3.org/2000/svg\".*")) {
                             return true;
                         }
                     }

--- a/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
+++ b/imageio/imageio-batik/src/test/java/com/twelvemonkeys/imageio/plugins/svg/SVGImageReaderSpiTest.java
@@ -73,7 +73,19 @@ public class SVGImageReaderSpiTest {
         "<ns0:svg>", // namespace prefix undefined
         "<ns0:svg xmlns:ns0=\"foo\">", // not the official svg namespace
         "<ns0:svg xmlns:ns1=\"http://www.w3.org/2000/svg\">", // mismatching prefix
+        // Prefix is used to build a regex, a crafted one must not cause catastrophic backtracking
+        "<(a{0,100}){0,100}:svg xmlns:" + repeat("a", 900) + "=>",
+        "<(a*){50}:svg xmlns:" + repeat("a", 900) + "=>",
+        "<((((a*)*)*)*)*:svg xmlns:" + repeat("a", 900) + "=>",
     };
+
+    private static String repeat(String s, int count) {
+        StringBuilder builder = new StringBuilder(s.length() * count);
+        for (int i = 0; i < count; i++) {
+            builder.append(s);
+        }
+        return builder.toString();
+    }
 
     static {
         IIORegistry.getDefaultInstance().registerServiceProvider(new URLImageInputStreamSpi());


### PR DESCRIPTION
**What is fixed** `SVGImageReaderSpi.canDecodeInput` builds a regex from the tag name it reads off the input stream: `name.split(":")[0]` (up to 256 bytes of arbitrary input) is concatenated straight into the pattern passed to `String.matches`, and matched against a second attacker-controlled buffer. A prefix using nested bounded quantifiers, e.g. `<(a{0,100}){0,100}:svg xmlns:aaaa…=>`, compiles to a pattern with catastrophic backtracking, so a ~1 KB non-SVG input pins a CPU for many seconds inside the format sniff.

**Why is this change proposed** `canDecodeInput` runs for every registered provider on any stream handed to `ImageIO.read` / `getImageReaders`, before a reader is instantiated, so with imageio-batik on the classpath a single small upload wedges the calling thread. The prefix crosses a trust boundary but was used as a live pattern. `Pattern.quote` matches it as a literal, which also removes the `PatternSyntaxException` that an unbalanced prefix like `(` could throw out of `canDecodeInput`.

**What is changed**

* Wrap the namespace prefix in `Pattern.quote` before splicing it into the match pattern
* Add three crafted-prefix cases to `SVGImageReaderSpiTest` (they run under the existing 5s timeout guard, and hang before the fix)

Valid SVG detection is unchanged, and the existing batik tests still pass.