### PR TITLE
create temp cache files with owner-only permissions

### DIFF
--- a/common/common-io/src/main/java/com/twelvemonkeys/io/FileCacheSeekableStream.java
+++ b/common/common-io/src/main/java/com/twelvemonkeys/io/FileCacheSeekableStream.java
@@ -33,17 +33,18 @@ package com.twelvemonkeys.io;
 import com.twelvemonkeys.lang.Validate;
 
 import java.io.*;
+import java.nio.file.Files;
 
 /**
  * A {@code SeekableInputStream} implementation that caches data in a temporary {@code File}.
  * <p>
- * Temporary files are created as specified in {@link File#createTempFile(String, String, java.io.File)}.
+ * Temporary files are created as specified in {@code Files.createTempFile}, and are readable by the owner only.
  * </p>
  *
  * @see MemoryCacheSeekableStream
  * @see FileSeekableStream
  *
- * @see File#createTempFile(String, String)
+ * @see Files
  * @see RandomAccessFile
  *
  * @author <a href="mailto:harald.kuhr@gmail.com">Harald Kuhr</a>
@@ -101,7 +102,11 @@ public final class FileCacheSeekableStream extends AbstractCachedSeekableStream 
     /*protected*/ static File createTempFile(String pTempBaseName, File pTempDir) throws IOException {
         Validate.notNull(pTempBaseName, "tempBaseName");
 
-        File file = File.createTempFile(pTempBaseName, null, pTempDir);
+        // NOTE: Files.createTempFile creates the file with owner-only permissions,
+        // unlike File.createTempFile which uses the process umask (typically world-readable)
+        File file = (pTempDir == null
+                     ? Files.createTempFile(pTempBaseName, null)
+                     : Files.createTempFile(pTempDir.toPath(), pTempBaseName, null)).toFile();
         file.deleteOnExit();
 
         return file;

--- a/common/common-io/src/test/java/com/twelvemonkeys/io/FileCacheSeekableStreamTest.java
+++ b/common/common-io/src/test/java/com/twelvemonkeys/io/FileCacheSeekableStreamTest.java
@@ -30,8 +30,18 @@
 
 package com.twelvemonkeys.io;
 
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * FileCacheSeekableStreamTestCase
@@ -47,6 +57,41 @@ public class FileCacheSeekableStreamTest extends SeekableInputStreamAbstractTest
         }
         catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testTempFileNotReadableByOthers() throws IOException {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+
+        File file = FileCacheSeekableStream.createTempFile("iocache", null);
+
+        try {
+            assertEquals(EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+                    Files.getPosixFilePermissions(file.toPath()));
+        }
+        finally {
+            //noinspection ResultOfMethodCallIgnored
+            file.delete();
+        }
+    }
+
+    @Test
+    public void testTempFileInDirNotReadableByOthers() throws IOException {
+        assumeTrue(FileSystems.getDefault().supportedFileAttributeViews().contains("posix"));
+
+        File dir = Files.createTempDirectory("iocache").toFile();
+        File file = FileCacheSeekableStream.createTempFile("iocache", dir);
+
+        try {
+            assertEquals(EnumSet.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+                    Files.getPosixFilePermissions(file.toPath()));
+        }
+        finally {
+            //noinspection ResultOfMethodCallIgnored
+            file.delete();
+            //noinspection ResultOfMethodCallIgnored
+            dir.delete();
         }
     }
 }

--- a/imageio/imageio-icns/src/main/java/com/twelvemonkeys/imageio/plugins/icns/SipsJP2Reader.java
+++ b/imageio/imageio-icns/src/main/java/com/twelvemonkeys/imageio/plugins/icns/SipsJP2Reader.java
@@ -45,6 +45,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.util.Iterator;
 
 /**
@@ -160,7 +161,9 @@ final class SipsJP2Reader {
     }
 
     private static File dumpToFile(final ImageInputStream stream) throws IOException {
-        File tempFile = File.createTempFile("imageio-icns-", ".png");
+        // NOTE: Files.createTempFile creates the file with owner-only permissions,
+        // unlike File.createTempFile which uses the process umask (typically world-readable)
+        File tempFile = Files.createTempFile("imageio-icns-", ".png").toFile();
         tempFile.deleteOnExit();
 
         try (FileOutputStream out = new FileOutputStream(tempFile)) {


### PR DESCRIPTION
**What is fixed** No open issue; found while reading the stream caching code.

**Why is this change proposed** `File.createTempFile` opens with mode 0666 masked by the process umask, so with the common 022 umask the cache file lands as `rw-r--r--` in the shared temp directory. Both call sites write the full bytes of the stream being decoded, so on a multi-user host any local user can read the image data of everything that passes through `FileCacheSeekableStream`, or through the ICNS reader's `sips` JPEG 2000 conversion, for as long as the file exists. `Files.createTempFile` creates with `rw-------` instead, and `imageio-core`'s `FileCache` already uses it, so this just brings the two remaining helpers in line.

**What is changed**

* `FileCacheSeekableStream.createTempFile` and `SipsJP2Reader.dumpToFile` now create the temp file via `Files.createTempFile`
* Added two tests asserting owner-only permissions for the default and explicit-directory forms, skipped where POSIX attributes are unavailable
* Corrected the `FileCacheSeekableStream` class doc, which pointed at `File.createTempFile`
