### PR TITLE
reject bit-plane counts over 8 in PCX planar row read

### DIFF
--- a/imageio/imageio-pcx/src/main/java/com/twelvemonkeys/imageio/plugins/pcx/PCXImageReader.java
+++ b/imageio/imageio-pcx/src/main/java/com/twelvemonkeys/imageio/plugins/pcx/PCXImageReader.java
@@ -199,6 +199,13 @@ public final class PCXImageReader extends ImageReaderBase {
 
         if (rawType.getColorModel() instanceof IndexColorModel && header.getChannels() > 1) {
             // Bit planes!
+            // The plane buffer and BitRotator both assume at most 8 planes, but getChannels() is an
+            // unsigned byte from the header, so a value of 9-16 (still a valid IndexColorModel) would
+            // make the readRowByte fill length exceed planeData and overrun the buffer.
+            if (header.getChannels() > 8) {
+                throw new IIOException("Unsupported number of bit planes for PCX: " + header.getChannels());
+            }
+
             // Create raster from a default 8 bit layout
             int planeWidth = header.getBytesPerLine();
             int rowWidth = planeWidth * 8; // bitsPerPixel == 1

--- a/imageio/imageio-pcx/src/test/java/com/twelvemonkeys/imageio/plugins/pcx/PCXImageReaderTest.java
+++ b/imageio/imageio-pcx/src/test/java/com/twelvemonkeys/imageio/plugins/pcx/PCXImageReaderTest.java
@@ -32,13 +32,17 @@ package com.twelvemonkeys.imageio.plugins.pcx;
 
 import com.twelvemonkeys.imageio.util.ImageReaderAbstractTest;
 
+import javax.imageio.IIOException;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReadParam;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -138,6 +142,35 @@ public class PCXImageReaderTest extends ImageReaderAbstractTest<PCXImageReader> 
 
             assertRGBEquals("Should have white background", 0xffffffff, image.getRGB(0, 0), 0);
             assertRGBEquals("Should have black skull", 0xff000000, image.getRGB(64, 10), 0);
+        }
+    }
+
+    @Test
+    public void testReadTooManyBitPlanesThrowsIIOException() throws IOException {
+        // A header with 1 bit/pixel and more than 8 channels (bit planes) still builds a valid
+        // IndexColorModel (bits 9-16), but the planar row buffer holds only 8 planes. The row read
+        // must fail with an IIOException, not an IndexOutOfBoundsException from the buffer overrun.
+        byte[] pcx = new byte[PCX.HEADER_SIZE + 64];
+        ByteBuffer header = ByteBuffer.wrap(pcx).order(ByteOrder.LITTLE_ENDIAN);
+        header.put((byte) 0x0a);     // Magic
+        header.put((byte) 5);        // Version
+        header.put((byte) 0);        // Compression: none
+        header.put((byte) 1);        // Bits per pixel
+        header.putShort((short) 0);  // xMin
+        header.putShort((short) 0);  // yMin
+        header.putShort((short) 7);  // xMax -> width 8
+        header.putShort((short) 1);  // yMax -> height 2
+        header.putShort((short) 72); // hDPI
+        header.putShort((short) 72); // vDPI
+        header.position(65);         // Skip palette + reserved byte
+        header.put((byte) 16);       // Channels/bit planes (> 8)
+        header.putShort((short) 2);  // Bytes per line
+
+        try (ImageInputStream input = ImageIO.createImageInputStream(new ByteArrayInputStream(pcx))) {
+            PCXImageReader reader = createReader();
+            reader.setInput(input);
+
+            assertThrows(IIOException.class, () -> reader.read(0));
         }
     }
 


### PR DESCRIPTION
**What is fixed** No open issue; hardening the PCX reader against a crafted header.

**Why is this change proposed** In the planar (bit-plane) branch of `PCXImageReader.read`, the row buffer is sized for exactly 8 planes (`planeWidth * 8`) and `BitRotator` always combines 8 planes, but the per-row fill length passed to `readRowByte` is `planeWidth * header.getChannels()`, where `channels` is an unsigned byte from the header. With `bitsPerPixel == 1` a channel count of 9-16 still builds a valid `IndexColorModel` (bit depth <= 16), so the branch runs and the fill length overruns the 8-plane buffer, leaking an `IndexOutOfBoundsException` out of `read()` instead of an `IOException` on a crafted file.

**What is changed**
* Reject bit-plane counts above 8 (the reader's fixed plane limit) with an `IIOException` before the planar row read; valid 2-8 plane PCX images decode unchanged.
* Added a regression test asserting `IIOException` for a 16-channel header.