### PR TITLE
Fix Webp green tint vp8 intra prediction and tm pred

### DIFF
--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/MacroBlock.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/MacroBlock.java
@@ -577,11 +577,12 @@ final class MacroBlock {
             case Globals.TM_PRED:
                 // TODO:
                 // System.out.println("UV TM_PRED MB");
+                boolean aboveRowAvailableUV = this.y > 0;
                 MacroBlock ALMb = frame.getMacroBlock(x - 1, y - 1);
                 SubBlock ALUSb = ALMb.getUSubBlock(1, 1);
-                int alu = ALUSb.getRecon()[3][3];
+                int alu = ALUSb.getReconAboveLeft(aboveRowAvailableUV)[3][3];
                 SubBlock ALVSb = ALMb.getVSubBlock(1, 1);
-                int alv = ALVSb.getRecon()[3][3];
+                int alv = ALVSb.getReconAboveLeft(aboveRowAvailableUV)[3][3];
 
                 aboveUSb = new SubBlock[2];
                 leftUSb = new SubBlock[2];
@@ -599,13 +600,13 @@ final class MacroBlock {
                         for (int d = 0; d < 2; d++) {
                             for (int c = 0; c < 4; c++) {
 
-                                int upred = leftUSb[b].getRecon()[3][a]
-                                        + aboveUSb[d].getRecon()[c][3] - alu;
+                                int upred = leftUSb[b].getReconLeft()[3][a]
+                                        + aboveUSb[d].getReconAbove()[c][3] - alu;
                                 upred = Globals.clamp(upred, 255);
                                 uSubBlocks[d][b].setPixel(c, a, upred);
 
-                                int vpred = leftVSb[b].getRecon()[3][a]
-                                        + aboveVSb[d].getRecon()[c][3] - alv;
+                                int vpred = leftVSb[b].getReconLeft()[3][a]
+                                        + aboveVSb[d].getReconAbove()[c][3] - alv;
                                 vpred = Globals.clamp(vpred, 255);
                                 vSubBlocks[d][b].setPixel(c, a, vpred);
                             }
@@ -740,9 +741,10 @@ final class MacroBlock {
                 break;
             case Globals.TM_PRED:
                 // System.out.println("TM_PRED MB");
+                boolean aboveRowAvailableY = this.y > 0;
                 MacroBlock ALMb = frame.getMacroBlock(x - 1, y - 1);
                 SubBlock ALSb = ALMb.getYSubBlock(3, 3);
-                int al = ALSb.getRecon()[3][3];
+                int al = ALSb.getReconAboveLeft(aboveRowAvailableY)[3][3];
 
                 aboveYSb = new SubBlock[4];
                 leftYSb = new SubBlock[4];
@@ -759,8 +761,8 @@ final class MacroBlock {
 
                         for (int d = 0; d < 4; d++) {
                             for (int c = 0; c < 4; c++) {
-                                int pred = leftYSb[b].getRecon()[3][a]
-                                        + aboveYSb[d].getRecon()[c][3] - al;
+                                int pred = leftYSb[b].getReconLeft()[3][a]
+                                        + aboveYSb[d].getReconAbove()[c][3] - al;
 
                                 ySubBlocks[d][b].setPixel(c, a,
                                         Globals.clamp(pred, 255));

--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/MacroBlock.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/MacroBlock.java
@@ -456,8 +456,8 @@ final class MacroBlock {
                             SubBlock usb = aboveMb.getUSubBlock(j, 1);
                             SubBlock vsb = aboveMb.getVSubBlock(j, 1);
                             for (int i = 0; i < 4; i++) {
-                                Uaverage += usb.getDest()[i][3];
-                                Vaverage += vsb.getDest()[i][3];
+                                Uaverage += usb.getRecon()[i][3];
+                                Vaverage += vsb.getRecon()[i][3];
                             }
                         }
                     }
@@ -467,8 +467,8 @@ final class MacroBlock {
                             SubBlock usb = leftMb.getUSubBlock(1, j);
                             SubBlock vsb = leftMb.getVSubBlock(1, j);
                             for (int i = 0; i < 4; i++) {
-                                Uaverage += usb.getDest()[3][i];
-                                Vaverage += vsb.getDest()[3][i];
+                                Uaverage += usb.getRecon()[3][i];
+                                Vaverage += vsb.getRecon()[3][i];
                             }
                         }
                     }
@@ -532,9 +532,9 @@ final class MacroBlock {
                         for (int j = 0; j < 4; j++) {
                             for (int i = 0; i < 4; i++) {
                                 ublock[j][i] = aboveUSb[y]
-                                        .getMacroBlockPredict(Globals.V_PRED)[j][3];
+                                        .getMacroBlockReconPredict(Globals.V_PRED)[j][3];
                                 vblock[j][i] = aboveVSb[y]
-                                        .getMacroBlockPredict(Globals.V_PRED)[j][3];
+                                        .getMacroBlockReconPredict(Globals.V_PRED)[j][3];
                             }
                         }
                         usb.setPredict(ublock);
@@ -563,9 +563,9 @@ final class MacroBlock {
                         for (int j = 0; j < 4; j++) {
                             for (int i = 0; i < 4; i++) {
                                 ublock[i][j] = leftUSb[y]
-                                        .getMacroBlockPredict(Globals.H_PRED)[3][j];
+                                        .getMacroBlockReconPredict(Globals.H_PRED)[3][j];
                                 vblock[i][j] = leftVSb[y]
-                                        .getMacroBlockPredict(Globals.H_PRED)[3][j];
+                                        .getMacroBlockReconPredict(Globals.H_PRED)[3][j];
                             }
                         }
                         usb.setPredict(ublock);
@@ -579,9 +579,9 @@ final class MacroBlock {
                 // System.out.println("UV TM_PRED MB");
                 MacroBlock ALMb = frame.getMacroBlock(x - 1, y - 1);
                 SubBlock ALUSb = ALMb.getUSubBlock(1, 1);
-                int alu = ALUSb.getDest()[3][3];
+                int alu = ALUSb.getRecon()[3][3];
                 SubBlock ALVSb = ALMb.getVSubBlock(1, 1);
-                int alv = ALVSb.getDest()[3][3];
+                int alv = ALVSb.getRecon()[3][3];
 
                 aboveUSb = new SubBlock[2];
                 leftUSb = new SubBlock[2];
@@ -599,13 +599,13 @@ final class MacroBlock {
                         for (int d = 0; d < 2; d++) {
                             for (int c = 0; c < 4; c++) {
 
-                                int upred = leftUSb[b].getDest()[3][a]
-                                        + aboveUSb[d].getDest()[c][3] - alu;
+                                int upred = leftUSb[b].getRecon()[3][a]
+                                        + aboveUSb[d].getRecon()[c][3] - alu;
                                 upred = Globals.clamp(upred, 255);
                                 uSubBlocks[d][b].setPixel(c, a, upred);
 
-                                int vpred = leftVSb[b].getDest()[3][a]
-                                        + aboveVSb[d].getDest()[c][3] - alv;
+                                int vpred = leftVSb[b].getRecon()[3][a]
+                                        + aboveVSb[d].getRecon()[c][3] - alv;
                                 vpred = Globals.clamp(vpred, 255);
                                 vSubBlocks[d][b].setPixel(c, a, vpred);
                             }
@@ -644,7 +644,7 @@ final class MacroBlock {
                         for (int j = 0; j < 4; j++) {
                             SubBlock sb = aboveMb.getYSubBlock(j, 3);
                             for (int i = 0; i < 4; i++) {
-                                average += sb.getDest()[i][3];
+                                average += sb.getRecon()[i][3];
                             }
                         }
                     }
@@ -653,7 +653,7 @@ final class MacroBlock {
                         for (int j = 0; j < 4; j++) {
                             SubBlock sb = leftMb.getYSubBlock(3, j);
                             for (int i = 0; i < 4; i++) {
-                                average += sb.getDest()[3][i];
+                                average += sb.getRecon()[3][i];
                             }
                         }
                     }
@@ -700,7 +700,7 @@ final class MacroBlock {
                         int[][] block = new int[4][4];
                         for (int j = 0; j < 4; j++) {
                             for (int i = 0; i < 4; i++) {
-                                block[i][j] = aboveYSb[x].getPredict(
+                                block[i][j] = aboveYSb[x].getReconPredict(
                                         Globals.B_VE_PRED, false)[i][3];
                             }
                         }
@@ -724,7 +724,7 @@ final class MacroBlock {
                         int[][] block = new int[4][4];
                         for (int j = 0; j < 4; j++) {
                             for (int i = 0; i < 4; i++) {
-                                block[i][j] = leftYSb[y].getPredict(
+                                block[i][j] = leftYSb[y].getReconPredict(
                                         Globals.B_DC_PRED, true)[3][j];
                             }
                         }
@@ -742,7 +742,7 @@ final class MacroBlock {
                 // System.out.println("TM_PRED MB");
                 MacroBlock ALMb = frame.getMacroBlock(x - 1, y - 1);
                 SubBlock ALSb = ALMb.getYSubBlock(3, 3);
-                int al = ALSb.getDest()[3][3];
+                int al = ALSb.getRecon()[3][3];
 
                 aboveYSb = new SubBlock[4];
                 leftYSb = new SubBlock[4];
@@ -759,8 +759,8 @@ final class MacroBlock {
 
                         for (int d = 0; d < 4; d++) {
                             for (int c = 0; c < 4; c++) {
-                                int pred = leftYSb[b].getDest()[3][a]
-                                        + aboveYSb[d].getDest()[c][3] - al;
+                                int pred = leftYSb[b].getRecon()[3][a]
+                                        + aboveYSb[d].getRecon()[c][3] - al;
 
                                 ySubBlocks[d][b].setPixel(c, a,
                                         Globals.clamp(pred, 255));

--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/SubBlock.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/SubBlock.java
@@ -41,6 +41,18 @@ final class SubBlock {
     private final SubBlock above;
 
     private int[][] dest;
+    /**
+     * Snapshot of {@link #dest} as it was immediately after reconstruction, i.e.
+     * *before* the loop filter modified it.
+     * <p>
+     * RFC 6386 applies the loop filter to the entire frame only after every
+     * macroblock has been reconstructed, so intra prediction must always see
+     * unfiltered neighbour samples. As this decoder interleaves reconstruction
+     * and filtering macroblock by macroblock (to avoid buffering the whole
+     * frame), the unfiltered samples have to be retained separately -- the same
+     * approach libwebp takes with its saved top/left sample rows.
+     */
+    private int[][] recon;
     private int[][] diff;
     private boolean hasNoZeroToken;
     private final SubBlock left;
@@ -271,6 +283,80 @@ final class SubBlock {
         return macroBlock;
     }
 
+    /**
+     * The unfiltered reconstruction of this sub block, for use as intra
+     * prediction context by neighbouring blocks. See {@link #recon}.
+     */
+    public int[][] getRecon() {
+        if (recon != null) {
+            return recon;
+        }
+
+        return new int[4][4];
+    }
+
+    /**
+     * Whether this sub block has been reconstructed.
+     */
+    public boolean hasRecon() {
+        return recon != null;
+    }
+
+    /**
+     * As {@link #getMacroBlockPredict(int)}, but returning the unfiltered
+     * reconstruction. Use this when reading a *neighbouring* macroblock as
+     * prediction context.
+     */
+    public int[][] getMacroBlockReconPredict(int intra_mode) {
+        if (recon != null) {
+            return recon;
+        }
+
+        return borderSamples(intra_mode == Globals.H_PRED);
+    }
+
+    /**
+     * As {@link #getPredict(int, boolean)}, but returning the unfiltered
+     * reconstruction. Use this when reading a *neighbouring* sub block as
+     * prediction context.
+     */
+    public int[][] getReconPredict(int intra_bmode, boolean left) {
+        if (recon != null) {
+            return recon;
+        }
+        if (predict != null) {
+            return predict;
+        }
+
+        return borderSamples(left && isLeftBorder129(intra_bmode));
+    }
+
+    private static boolean isLeftBorder129(int intra_bmode) {
+        return intra_bmode == Globals.B_TM_PRED
+                || intra_bmode == Globals.B_DC_PRED
+                || intra_bmode == Globals.B_VE_PRED
+                || intra_bmode == Globals.B_HE_PRED
+                || intra_bmode == Globals.B_VR_PRED
+                || intra_bmode == Globals.B_RD_PRED
+                || intra_bmode == Globals.B_HD_PRED;
+    }
+
+    /**
+     * Off-frame border samples: 129 to the left of the frame, 127 above it.
+     */
+    private static int[][] borderSamples(boolean leftOfFrame) {
+        int rv = leftOfFrame ? 129 : 127;
+
+        int[][] r = new int[4][4];
+        for (int j = 0; j < 4; j++) {
+            for (int i = 0; i < 4; i++) {
+                r[i][j] = rv;
+            }
+        }
+
+        return r;
+    }
+
     public int[][] getMacroBlockPredict(int intra_mode) {
         if (dest != null) {
             return dest;
@@ -355,36 +441,36 @@ final class SubBlock {
         int[] above = new int[4];
         int[] left = new int[4];
 
-        above[0] = aboveSb.getPredict(sb.getMode(), false)[0][3];
-        above[1] = aboveSb.getPredict(sb.getMode(), false)[1][3];
-        above[2] = aboveSb.getPredict(sb.getMode(), false)[2][3];
-        above[3] = aboveSb.getPredict(sb.getMode(), false)[3][3];
-        left[0] = leftSb.getPredict(sb.getMode(), true)[3][0];
-        left[1] = leftSb.getPredict(sb.getMode(), true)[3][1];
-        left[2] = leftSb.getPredict(sb.getMode(), true)[3][2];
-        left[3] = leftSb.getPredict(sb.getMode(), true)[3][3];
+        above[0] = aboveSb.getReconPredict(sb.getMode(), false)[0][3];
+        above[1] = aboveSb.getReconPredict(sb.getMode(), false)[1][3];
+        above[2] = aboveSb.getReconPredict(sb.getMode(), false)[2][3];
+        above[3] = aboveSb.getReconPredict(sb.getMode(), false)[3][3];
+        left[0] = leftSb.getReconPredict(sb.getMode(), true)[3][0];
+        left[1] = leftSb.getReconPredict(sb.getMode(), true)[3][1];
+        left[2] = leftSb.getReconPredict(sb.getMode(), true)[3][2];
+        left[3] = leftSb.getReconPredict(sb.getMode(), true)[3][3];
         SubBlock AL = frame.getLeftSubBlock(aboveSb, sb.getPlane());
 
         // for above left if left and above is null use left (129?) else use
         // above (127?)
         int al;
-        if (!leftSb.isDest() && !aboveSb.isDest()) {
+        if (!leftSb.hasRecon() && !aboveSb.hasRecon()) {
 
-            al = AL.getPredict(sb.getMode(), false)[3][3];
+            al = AL.getReconPredict(sb.getMode(), false)[3][3];
         }
-        else if (!aboveSb.isDest()) {
+        else if (!aboveSb.hasRecon()) {
 
-            al = AL.getPredict(sb.getMode(), false)[3][3];
+            al = AL.getReconPredict(sb.getMode(), false)[3][3];
         }
         else {
-            al = AL.getPredict(sb.getMode(), true)[3][3];
+            al = AL.getReconPredict(sb.getMode(), true)[3][3];
         }
         SubBlock AR = frame.getAboveRightSubBlock(sb, sb.plane);
         int[] ar = new int[4];
-        ar[0] = AR.getPredict(sb.getMode(), false)[0][3];
-        ar[1] = AR.getPredict(sb.getMode(), false)[1][3];
-        ar[2] = AR.getPredict(sb.getMode(), false)[2][3];
-        ar[3] = AR.getPredict(sb.getMode(), false)[3][3];
+        ar[0] = AR.getReconPredict(sb.getMode(), false)[0][3];
+        ar[1] = AR.getReconPredict(sb.getMode(), false)[1][3];
+        ar[2] = AR.getReconPredict(sb.getMode(), false)[2][3];
+        ar[3] = AR.getReconPredict(sb.getMode(), false)[3][3];
         int[][] p = new int[4][4];
         int[] pp;
         switch (sb.getMode()) {
@@ -613,6 +699,14 @@ final class SubBlock {
 
     public void setDest(int[][] dest) {
         this.dest = dest;
+
+        // Keep an unfiltered copy for intra prediction, see #recon.
+        this.recon = new int[][] {
+                {dest[0][0], dest[0][1], dest[0][2], dest[0][3]},
+                {dest[1][0], dest[1][1], dest[1][2], dest[1][3]},
+                {dest[2][0], dest[2][1], dest[2][2], dest[2][3]},
+                {dest[3][0], dest[3][1], dest[3][2], dest[3][3]},
+        };
     }
 
     public void setDiff(int[][] diff) {

--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/SubBlock.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/SubBlock.java
@@ -303,6 +303,48 @@ final class SubBlock {
     }
 
     /**
+     * The unfiltered reconstruction, for use as the *above* prediction context.
+     * Outside the frame the above row reads as 127 (RFC 6386, 12.2).
+     */
+    public int[][] getReconAbove() {
+        if (recon != null) {
+            return recon;
+        }
+
+        return borderSamples(false);
+    }
+
+    /**
+     * The unfiltered reconstruction, for use as the *left* prediction context.
+     * Outside the frame the left column reads as 129 (RFC 6386, 12.2).
+     */
+    public int[][] getReconLeft() {
+        if (recon != null) {
+            return recon;
+        }
+
+        return borderSamples(true);
+    }
+
+    /**
+     * The unfiltered reconstruction, for use as the *above-left* prediction
+     * context. Outside the frame this reads as 127 when the above row is also
+     * outside the frame, and as 129 otherwise -- matching libwebp, which fills
+     * the row above the first macroblock row (including its left-hand corner
+     * sample) with 127, and the column left of the first macroblock column
+     * (including its top corner sample) with 129.
+     *
+     * @param aboveRowAvailable whether the macroblock row above is inside the frame
+     */
+    public int[][] getReconAboveLeft(boolean aboveRowAvailable) {
+        if (recon != null) {
+            return recon;
+        }
+
+        return borderSamples(aboveRowAvailable);
+    }
+
+    /**
      * As {@link #getMacroBlockPredict(int)}, but returning the unfiltered
      * reconstruction. Use this when reading a *neighbouring* macroblock as
      * prediction context.

--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/SubBlock.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/SubBlock.java
@@ -349,12 +349,12 @@ final class SubBlock {
      * reconstruction. Use this when reading a *neighbouring* macroblock as
      * prediction context.
      */
-    public int[][] getMacroBlockReconPredict(int intra_mode) {
+    public int[][] getMacroBlockReconPredict(int intraMode) {
         if (recon != null) {
             return recon;
         }
 
-        return borderSamples(intra_mode == Globals.H_PRED);
+        return borderSamples(intraMode == Globals.H_PRED);
     }
 
     /**
@@ -362,7 +362,7 @@ final class SubBlock {
      * reconstruction. Use this when reading a *neighbouring* sub block as
      * prediction context.
      */
-    public int[][] getReconPredict(int intra_bmode, boolean left) {
+    public int[][] getReconPredict(int intraBMode, boolean left) {
         if (recon != null) {
             return recon;
         }
@@ -370,17 +370,17 @@ final class SubBlock {
             return predict;
         }
 
-        return borderSamples(left && isLeftBorder129(intra_bmode));
+        return borderSamples(left && isLeftBorder129(intraBMode));
     }
 
-    private static boolean isLeftBorder129(int intra_bmode) {
-        return intra_bmode == Globals.B_TM_PRED
-                || intra_bmode == Globals.B_DC_PRED
-                || intra_bmode == Globals.B_VE_PRED
-                || intra_bmode == Globals.B_HE_PRED
-                || intra_bmode == Globals.B_VR_PRED
-                || intra_bmode == Globals.B_RD_PRED
-                || intra_bmode == Globals.B_HD_PRED;
+    private static boolean isLeftBorder129(int intraBMode) {
+        return intraBMode == Globals.B_TM_PRED
+                || intraBMode == Globals.B_DC_PRED
+                || intraBMode == Globals.B_VE_PRED
+                || intraBMode == Globals.B_HE_PRED
+                || intraBMode == Globals.B_VR_PRED
+                || intraBMode == Globals.B_RD_PRED
+                || intraBMode == Globals.B_HD_PRED;
     }
 
     /**

--- a/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/VP8Frame.java
+++ b/imageio/imageio-webp/src/main/java/com/twelvemonkeys/imageio/plugins/webp/vp8/VP8Frame.java
@@ -499,7 +499,7 @@ public final class VP8Frame {
                                 dest[a][b] = 127;
                             }
                             else {
-                                dest[a][b] = this.getMacroBlock(mb.getX(), mb.getY() - 1).getSubBlock(SubBlock.Plane.Y1, 3, 3).getDest()[3][3];
+                                dest[a][b] = this.getMacroBlock(mb.getX(), mb.getY() - 1).getSubBlock(SubBlock.Plane.Y1, 3, 3).getRecon()[3][3];
                             }
                         }
                     }


### PR DESCRIPTION
Hi Harald,

I let Claude analyze and fix the green tint WebP issues and it managed to pin it down to two root causes described below:

**What is fixed.** Fixes #734, #1102, #864, #785. Also fixes the remaining colour error on the sample attached to #730 (the out-of-memory issue itself was already fixed on trunk before this PR). Two defects in TwelveMonkeys' lossy VP8 decoder (`imageio-webp`) that both produce a green/yellow tint on decode.

**What is changed.**
- *Fix 1:* Intra prediction read `dest`, the same buffer the loop filter had already modified in place. Since VP8 key frames are entirely intra-coded, every filtered pixel fed into prediction of macroblocks below/right, so the error compounded down the frame — clean at the top, increasingly green/yellow toward the bottom. Fixed by adding an unfiltered snapshot per sub-block (`SubBlock.recon`, captured in `setDest()` before the loop filter runs) and new accessors (`getRecon()`, `getReconPredict()`, `getMacroBlockReconPredict()`) so neighbour reads for prediction use the unfiltered copy, not `dest`.
- *Fix 2:* `TM_PRED` read an accessor returning an all-zero array for a non-existent (out-of-frame) neighbour, instead of the spec's border constants. At macroblock (0,0) this gives `0+0-0=0` instead of `129+127-127=129`, a constant -129 offset across the whole frame; chroma clamps to 0 and `(Y,0,0)` renders as pure green. Fixed by adding `getReconAbove()`, `getReconLeft()`, `getReconAboveLeft()`, returning unfiltered `recon` when the neighbour exists and 127/129 otherwise (with the above-left corner resolved per the spec's parenthetical). `TM_PRED`'s luma/chroma loops in `MacroBlock` switched to these. Builds on fix 1's `recon` machinery — the two ship as one PR.

**Where the correct behaviour was derived from.** RFC 6386 (the VP8 spec): section 5/15 establish that loop-filtered samples feed only inter prediction of later frames, never intra prediction within the same frame; section 12.2 specifies the 127 (above)/129 (left) border constants for out-of-bounds neighbours and that `TM_PRED`, unlike `DC_PRED`, must use them. Both fixes are corroborated by matching libwebp's reference implementation: it saves each row's bottom-edge samples before filtering for prediction, and pre-fills the borders with the same 127/129 constants and corner rule.

**How it was verified.** Each commit tested in isolation (clean worktrees off `41aaf3b1`) and combined, against 7 sample files from the related GitHub issues (compared to `dwebp -nofancy`) and the 131-file libwebp conformance corpus. Combined result: zero regressions across all 131 conformance files; mean error/channel on the issue samples drops from double digits (up to 114.17) to under 0.5. `mvn test -pl imageio/imageio-webp -am` on OpenJDK 26: 115 tests, 0 failures/errors, matching trunk on the same JDK — I have not yet run the full-reactor suite across the JDK 8/11/17/21/25 matrix this repo's CI uses, so that is still to be confirmed by CI itself.

**Which issue needs which commit.**
- #734 needs both commits: the green-tint sample needs commit 1; the fully-green `001e.webp` sample needs commit 2 as well
- #1102, #864, #785, #730 are fixed by commit 1 alone (mean error/channel: 5.75->0.41, 5.04->0.37, 21.30->0.18, 14.75->0.30 respectively)