### PR TITLE
add missing return after flat read in RGBE.readPixelsRawRLE

### DIFF
--- a/imageio/imageio-hdr/src/main/java/com/twelvemonkeys/imageio/plugins/hdr/RGBE.java
+++ b/imageio/imageio-hdr/src/main/java/com/twelvemonkeys/imageio/plugins/hdr/RGBE.java
@@ -219,6 +219,7 @@ final class RGBE {
         if ((scanline_width < 8) || (scanline_width > 0x7fff)) {
             // run length encoding is not allowed so read flat
             readPixelsRaw(in, data, offset, scanline_width * num_scanlines);
+            return;
         }
 
         // read in each successive scanline
@@ -232,6 +233,7 @@ final class RGBE {
                 data[offset++] = rgbe[2];
                 data[offset++] = rgbe[3];
                 readPixelsRaw(in, data, offset, scanline_width * num_scanlines - 1);
+                return;
             }
 
             if ((((rgbe[2] & 0xFF) << 8) | (rgbe[3] & 0xFF)) != scanline_width) {

--- a/imageio/imageio-hdr/src/test/java/com/twelvemonkeys/imageio/plugins/hdr/RGBETest.java
+++ b/imageio/imageio-hdr/src/test/java/com/twelvemonkeys/imageio/plugins/hdr/RGBETest.java
@@ -1,0 +1,73 @@
+package com.twelvemonkeys.imageio.plugins.hdr;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class RGBETest {
+
+    // A scanline whose leading 4 bytes mark it as "not run length encoded" must be read flat and
+    // must not fall through into the RLE path, which decodes a second time past the output array.
+    @Test
+    public void testNonRLEScanlineDoesNotOverflow() throws Exception {
+        int width = 8;
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+
+        // Leading quad: first byte != 2 selects the non-RLE branch, last two bytes match the width
+        bytes.write(new byte[] {1, 0, 0, (byte) width});
+        // Flat pixel data for the remaining (width - 1) pixels
+        for (int i = 0; i < (width - 1) * 4; i++) {
+            bytes.write(0x11);
+        }
+        // Well-formed RLE channel data that the buggy fall-through would decode on top of the row
+        for (int c = 0; c < 4; c++) {
+            bytes.write(width);
+            bytes.write(0x22);
+            for (int i = 0; i < width - 1; i++) {
+                bytes.write(0x33);
+            }
+        }
+
+        byte[] row = new byte[width * 4];
+        DataInput input = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+
+        assertDoesNotThrow(() -> RGBE.readPixelsRawRLE(input, row, 0, width, 1));
+
+        byte[] expected = new byte[width * 4];
+        expected[0] = 1;
+        expected[1] = 0;
+        expected[2] = 0;
+        expected[3] = (byte) width;
+        for (int i = 4; i < expected.length; i++) {
+            expected[i] = 0x11;
+        }
+        assertArrayEquals(expected, row);
+    }
+
+    // Widths below the RLE minimum are read flat and must likewise not continue into the RLE path.
+    @Test
+    public void testSubMinimumWidthDoesNotOverflow() throws Exception {
+        int width = 4;
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        for (int i = 0; i < width * 4; i++) {
+            bytes.write(0x44);
+        }
+
+        byte[] row = new byte[width * 4];
+        DataInput input = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+
+        assertDoesNotThrow(() -> RGBE.readPixelsRawRLE(input, row, 0, width, 1));
+
+        byte[] expected = new byte[width * 4];
+        for (int i = 0; i < expected.length; i++) {
+            expected[i] = 0x44;
+        }
+        assertArrayEquals(expected, row);
+    }
+}


### PR DESCRIPTION
**What is fixed** Out-of-bounds write in the HDR/RGBE scanline decoder when reading a crafted file.

**Why is this change proposed** `RGBE.readPixelsRawRLE` drops the two `return` statements the reference decoder has after its flat-read fallbacks, so once a scanline is read flat it falls through and decodes the same scanline again through the RLE path. A crafted HDR whose leading scanline quad marks it as non-RLE, with the width echoed in the last two bytes, drives the second pass to write past the `width * 4` row that `HDRImageReader` allocates, throwing `ArrayIndexOutOfBoundsException` at index `4 * width` from `ImageIO.read`. Widths below the RLE minimum reach the same fall-through.

**What is changed**

* Added the missing `return` after each flat read in `readPixelsRawRLE`, matching the reference implementation
* Added regression tests for the non-RLE and sub-minimum-width scanline cases