### PR TITLE
validate item id and bound filename length in thumbs.db catalog

### DIFF
--- a/imageio/imageio-thumbsdb/src/main/java/com/twelvemonkeys/imageio/plugins/thumbsdb/Catalog.java
+++ b/imageio/imageio-thumbsdb/src/main/java/com/twelvemonkeys/imageio/plugins/thumbsdb/Catalog.java
@@ -34,6 +34,7 @@ import com.twelvemonkeys.io.LittleEndianDataInputStream;
 import com.twelvemonkeys.io.ole2.CompoundDocument;
 import com.twelvemonkeys.lang.StringUtil;
 
+import javax.imageio.IIOException;
 import java.io.DataInput;
 import java.io.IOException;
 import java.io.InputStream;
@@ -91,7 +92,11 @@ public final class Catalog implements Iterable<Catalog.CatalogItem> {
         for (int i = 0; i < header.getThumbnailCount(); i++) {
             CatalogItem item = CatalogItem.read(pDataInput);
             //System.out.println("item: " + item);
-            items[item.getItemId() - 1] = item;
+            int index = item.getItemId() - 1;
+            if (index < 0 || index >= items.length) {
+                throw new IIOException("Thumbs.db catalog item id out of range: " + item.getItemId());
+            }
+            items[index] = item;
         }
 
         return new Catalog(header, items);
@@ -225,15 +230,13 @@ public final class Catalog implements Iterable<Catalog.CatalogItem> {
 
             item.mLastModified = CompoundDocument.toJavaTimeInMillis(pDataInput.readLong());
 
-            char[] chars = new char[256];
+            StringBuilder name = new StringBuilder();
             char ch;
-            int len = 0;
             while ((ch = pDataInput.readChar()) != 0) {
-                chars[len++] = ch;
+                name.append(ch);
             }
 
-            String name = new String(chars, 0, len);
-            item.mFilename = StringUtil.getLastElement(name, "\\");
+            item.mFilename = StringUtil.getLastElement(name.toString(), "\\");
 
             item.mReserved2 = pDataInput.readShort();
             return item;

--- a/imageio/imageio-thumbsdb/src/main/java/com/twelvemonkeys/imageio/plugins/thumbsdb/Catalog.java
+++ b/imageio/imageio-thumbsdb/src/main/java/com/twelvemonkeys/imageio/plugins/thumbsdb/Catalog.java
@@ -230,7 +230,7 @@ public final class Catalog implements Iterable<Catalog.CatalogItem> {
 
             item.mLastModified = CompoundDocument.toJavaTimeInMillis(pDataInput.readLong());
 
-            StringBuilder name = new StringBuilder();
+            StringBuilder name = new StringBuilder(256);
             char ch;
             while ((ch = pDataInput.readChar()) != 0) {
                 name.append(ch);

--- a/imageio/imageio-thumbsdb/src/main/java/com/twelvemonkeys/imageio/plugins/thumbsdb/Catalog.java
+++ b/imageio/imageio-thumbsdb/src/main/java/com/twelvemonkeys/imageio/plugins/thumbsdb/Catalog.java
@@ -217,28 +217,37 @@ public final class Catalog implements Iterable<Catalog.CatalogItem> {
     }
 
     public static final class CatalogItem {
-        int mReserved1;
+        int mSize;
         int mItemId; // Reversed stream name
         String mFilename;
-        short mReserved2;
         private long mLastModified;
 
         private static CatalogItem read(final DataInput pDataInput) throws IOException {
             CatalogItem item = new CatalogItem();
-            item.mReserved1 = pDataInput.readInt();
+            item.mSize = pDataInput.readInt();
             item.mItemId = pDataInput.readInt();
 
             item.mLastModified = CompoundDocument.toJavaTimeInMillis(pDataInput.readLong());
 
-            StringBuilder name = new StringBuilder(256);
-            char ch;
-            while ((ch = pDataInput.readChar()) != 0) {
+            // The size covers the entire record. The fields read above are a fixed 16 bytes,
+            // the remainder holds the NUL-terminated UTF-16LE file name plus trailing padding.
+            int nameSize = item.mSize - 16;
+            if (nameSize < 0) {
+                throw new IIOException("Thumbs.db catalog item size too small: " + item.mSize);
+            }
+
+            StringBuilder name = new StringBuilder(nameSize / 2);
+            for (int read = 0; read + 2 <= nameSize; read += 2) {
+                char ch = pDataInput.readChar();
+                if (ch == 0) {
+                    pDataInput.skipBytes(nameSize - read - 2);
+                    break;
+                }
                 name.append(ch);
             }
 
             item.mFilename = StringUtil.getLastElement(name.toString(), "\\");
 
-            item.mReserved2 = pDataInput.readShort();
             return item;
         }
 
@@ -257,8 +266,8 @@ public final class Catalog implements Iterable<Catalog.CatalogItem> {
         @Override
         public String toString() {
             return String.format(
-                    "%s: %d itemId: %d lastModified: %s fileName: %s %s",
-                    getClass().getSimpleName(), mReserved1, mItemId, new Date(mLastModified), mFilename, mReserved2
+                    "%s: size: %d itemId: %d lastModified: %s fileName: %s",
+                    getClass().getSimpleName(), mSize, mItemId, new Date(mLastModified), mFilename
             );
         }
     }

--- a/imageio/imageio-thumbsdb/src/test/java/com/twelvemonkeys/imageio/plugins/thumbsdb/CatalogTest.java
+++ b/imageio/imageio-thumbsdb/src/test/java/com/twelvemonkeys/imageio/plugins/thumbsdb/CatalogTest.java
@@ -58,14 +58,16 @@ public class CatalogTest {
     }
 
     private static void writeItem(final LittleEndianDataOutputStream out, final int itemId, final String name) throws IOException {
-        out.writeInt(0); // reserved1
+        // 16 byte fixed part (size + itemId + timestamp) + UTF-16LE name + NUL + 2 byte padding
+        int size = 16 + (name.length() + 1) * 2 + 2;
+        out.writeInt(size);
         out.writeInt(itemId);
         out.writeLong(0L); // last modified
         for (int i = 0; i < name.length(); i++) {
             out.writeChar(name.charAt(i));
         }
         out.writeChar(0); // NUL terminator
-        out.writeShort(0); // reserved2
+        out.writeShort(0); // padding
     }
 
     private static DataInput catalogWith(final int itemId, final String name) throws IOException {
@@ -88,7 +90,7 @@ public class CatalogTest {
 
     @Test
     public void testFilenameLongerThanBuffer() throws IOException {
-        // Filename length is taken from the stream and was filled into a fixed 256 char buffer
+        // Filename length is taken from the stream and was filled into a fixed 256 char buffer before
         StringBuilder name = new StringBuilder();
         for (int i = 0; i < 400; i++) {
             name.append('a');

--- a/imageio/imageio-thumbsdb/src/test/java/com/twelvemonkeys/imageio/plugins/thumbsdb/CatalogTest.java
+++ b/imageio/imageio-thumbsdb/src/test/java/com/twelvemonkeys/imageio/plugins/thumbsdb/CatalogTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008, Harald Kuhr
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.twelvemonkeys.imageio.plugins.thumbsdb;
+
+import com.twelvemonkeys.io.LittleEndianDataInputStream;
+import com.twelvemonkeys.io.LittleEndianDataOutputStream;
+
+import javax.imageio.IIOException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * CatalogTest
+ *
+ * @author <a href="mailto:harald.kuhr@gmail.com">Harald Kuhr</a>
+ */
+public class CatalogTest {
+
+    private static void writeHeader(final LittleEndianDataOutputStream out, final int thumbCount) throws IOException {
+        out.writeShort(0); // reserved1
+        out.writeShort(0); // reserved2
+        out.writeInt(thumbCount);
+        out.writeInt(96); // max width
+        out.writeInt(96); // max height
+    }
+
+    private static void writeItem(final LittleEndianDataOutputStream out, final int itemId, final String name) throws IOException {
+        out.writeInt(0); // reserved1
+        out.writeInt(itemId);
+        out.writeLong(0L); // last modified
+        for (int i = 0; i < name.length(); i++) {
+            out.writeChar(name.charAt(i));
+        }
+        out.writeChar(0); // NUL terminator
+        out.writeShort(0); // reserved2
+    }
+
+    private static DataInput catalogWith(final int itemId, final String name) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        LittleEndianDataOutputStream out = new LittleEndianDataOutputStream(bytes);
+        writeHeader(out, 1);
+        writeItem(out, itemId, name);
+        out.flush();
+
+        return new LittleEndianDataInputStream(new ByteArrayInputStream(bytes.toByteArray()));
+    }
+
+    @Test
+    public void testReadValidItem() throws IOException {
+        Catalog catalog = Catalog.read(catalogWith(1, "3\\folder\\image.jpg"));
+
+        assertEquals(1, catalog.getThumbnailCount());
+        assertEquals("image.jpg", catalog.getItem(0).getName());
+    }
+
+    @Test
+    public void testFilenameLongerThanBuffer() throws IOException {
+        // Filename length is taken from the stream and was filled into a fixed 256 char buffer
+        StringBuilder name = new StringBuilder();
+        for (int i = 0; i < 400; i++) {
+            name.append('a');
+        }
+
+        Catalog catalog = Catalog.read(catalogWith(1, name.toString()));
+
+        assertEquals(name.toString(), catalog.getItem(0).getName());
+    }
+
+    @Test
+    public void testItemIdBelowRange() throws IOException {
+        // itemId is used as items[itemId - 1] without a bounds check
+        assertThrows(IIOException.class, () -> Catalog.read(catalogWith(0, "image.jpg")));
+    }
+
+    @Test
+    public void testItemIdAboveRange() throws IOException {
+        assertThrows(IIOException.class, () -> Catalog.read(catalogWith(9, "image.jpg")));
+    }
+}


### PR DESCRIPTION
**What is fixed** No open issue; hardening the Thumbs.db catalog reader. `Catalog.read` turns two values read straight from the OLE2 catalog stream into array positions without a bounds check, so a crafted Thumbs.db throws `ArrayIndexOutOfBoundsException` out of `ImageReader.read` instead of failing as an `IIOException`.

**Why is this change proposed** Both sites cross a trust boundary but use the stream value unchecked. In `CatalogItem.read` the item name is filled into a fixed 256 char buffer, so a name of 256 or more UTF-16 units before the terminator overruns it. In `Catalog.read` each item is stored at `items[item.getItemId() - 1]`, where `itemId` is a raw stream int, so an id of 0 (index -1) or one larger than the thumbnail count writes past the array. The surrounding reader already reports malformed input as `IIOException`.

**What is changed**

* Collect the filename into a `StringBuilder` instead of a fixed `char[256]`, so any length is read without overrun
* Validate the item id maps to a slot inside the catalog before the write, throwing `IIOException` when it does not
* Regression tests in `CatalogTest` for the long filename and out-of-range id, plus a valid catalog

Valid Thumbs.db files decode unchanged, and the existing reader tests still pass.