### PR TITLE
validate QuickTime RAW data size against pixel geometry

### DIFF
--- a/imageio/imageio-pict/src/main/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressor.java
+++ b/imageio/imageio-pict/src/main/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressor.java
@@ -67,6 +67,17 @@ final class QTRAWDecompressor extends QTDecompressor {
             dataStream.readFully(data, 0, description.dataSize);
         }
 
+        // Width, height and dataSize are independent fields from the 'idsc' Atom, so a crafted stream may
+        // declare a data size smaller than width * height * bytesPerPixel. Validate before indexing the buffer
+        // by pixel geometry below. Note width and height are 16 bit, so the product must be computed as long.
+        int bytesPerPixel = description.depth == 24 ? 3 : description.depth == 32 ? 4 : 1;
+        if (description.width <= 0 || description.height <= 0
+                || (long) description.width * description.height * bytesPerPixel > data.length) {
+            throw new IIOException(String.format(
+                    "Corrupt QuickTime RAW: data size %d too small for %dx%d at depth %d",
+                    data.length, description.width, description.height, description.depth));
+        }
+
         DataBuffer buffer = new DataBufferByte(data, data.length);
 
         WritableRaster raster;

--- a/imageio/imageio-pict/src/main/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressor.java
+++ b/imageio/imageio-pict/src/main/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressor.java
@@ -61,21 +61,22 @@ final class QTRAWDecompressor extends QTDecompressor {
     }
 
     public BufferedImage decompress(final ImageDesc description, final InputStream stream) throws IOException {
+        // Width, height and dataSize are independent fields from the 'idsc' Atom, so a crafted stream may
+        // declare a data size smaller than width * height * bytesPerPixel. Validate before allocating and
+        // indexing the buffer by pixel geometry below. Note width and height are unsigned 16 bit, so the
+        // product must be computed as long.
+        int bytesPerPixel = description.depth == 24 ? 3 : description.depth == 32 ? 4 : 1;
+        if (description.width <= 0 || description.height <= 0
+                || (long) description.width * description.height * bytesPerPixel > description.dataSize) {
+            throw new IIOException(String.format(
+                    "Corrupt QuickTime RAW: data size %d too small for %dx%d at depth %d",
+                    description.dataSize, description.width, description.height, description.depth));
+        }
+
         byte[] data = new byte[description.dataSize];
 
         try (DataInputStream dataStream = new DataInputStream(stream)) {
             dataStream.readFully(data, 0, description.dataSize);
-        }
-
-        // Width, height and dataSize are independent fields from the 'idsc' Atom, so a crafted stream may
-        // declare a data size smaller than width * height * bytesPerPixel. Validate before indexing the buffer
-        // by pixel geometry below. Note width and height are 16 bit, so the product must be computed as long.
-        int bytesPerPixel = description.depth == 24 ? 3 : description.depth == 32 ? 4 : 1;
-        if (description.width <= 0 || description.height <= 0
-                || (long) description.width * description.height * bytesPerPixel > data.length) {
-            throw new IIOException(String.format(
-                    "Corrupt QuickTime RAW: data size %d too small for %dx%d at depth %d",
-                    data.length, description.width, description.height, description.depth));
         }
 
         DataBuffer buffer = new DataBufferByte(data, data.length);

--- a/imageio/imageio-pict/src/main/java/com/twelvemonkeys/imageio/plugins/pict/QuickTime.java
+++ b/imageio/imageio-pict/src/main/java/com/twelvemonkeys/imageio/plugins/pict/QuickTime.java
@@ -211,8 +211,8 @@ final class QuickTime {
             description.temporalQuality = pStream.readInt(); // Temporal quality, 0 means "no temporal compression"
             description.spatialQuality = pStream.readInt(); // Spatial quality, 0x0000 0200 is codecNormalQuality
 
-            description.width = pStream.readShort(); // Width (short)
-            description.height = pStream.readShort(); // Height (short)
+            description.width = pStream.readUnsignedShort(); // Width (unsigned short)
+            description.height = pStream.readUnsignedShort(); // Height (unsigned short)
 
             description.horizontalRes = PICTUtil.readFixedPoint(pStream); // Horizontal resolution, FP, 0x0048 0000 means 72 DPI
             description.verticalRes = PICTUtil.readFixedPoint(pStream); // Vertical resolution, FP, 0x0048 0000 means 72 DPI

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressorTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressorTest.java
@@ -3,6 +3,10 @@ package com.twelvemonkeys.imageio.plugins.pict;
 import com.twelvemonkeys.imageio.plugins.pict.QuickTime.ImageDesc;
 
 import org.junit.jupiter.api.Test;
+
+import javax.imageio.IIOException;
+import java.io.ByteArrayInputStream;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -41,5 +45,42 @@ public class QTRAWDecompressorTest {
         QTDecompressor decompressor = new QTRAWDecompressor();
 
         assertTrue(decompressor.canDecompress(createDescription(40)));
+    }
+
+    @Test
+    public void decompressRGBADataSizeTooSmall() {
+        // width * height * 4 (256) is larger than the declared data size (16)
+        ImageDesc description = createDescription(32);
+        description.width = 8;
+        description.height = 8;
+        description.dataSize = 16;
+
+        QTDecompressor decompressor = new QTRAWDecompressor();
+        assertThrows(IIOException.class,
+                () -> decompressor.decompress(description, new ByteArrayInputStream(new byte[description.dataSize])));
+    }
+
+    @Test
+    public void decompressRGBDataSizeTooSmall() {
+        ImageDesc description = createDescription(24);
+        description.width = 8;
+        description.height = 8;
+        description.dataSize = 16;
+
+        QTDecompressor decompressor = new QTRAWDecompressor();
+        assertThrows(IIOException.class,
+                () -> decompressor.decompress(description, new ByteArrayInputStream(new byte[description.dataSize])));
+    }
+
+    @Test
+    public void decompressGrayDataSizeTooSmall() {
+        ImageDesc description = createDescription(40);
+        description.width = 8;
+        description.height = 8;
+        description.dataSize = 16;
+
+        QTDecompressor decompressor = new QTRAWDecompressor();
+        assertThrows(IIOException.class,
+                () -> decompressor.decompress(description, new ByteArrayInputStream(new byte[description.dataSize])));
     }
 }

--- a/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressorTest.java
+++ b/imageio/imageio-pict/src/test/java/com/twelvemonkeys/imageio/plugins/pict/QTRAWDecompressorTest.java
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author last modified by $Author: haraldk$
  * @version $Id: QTBMPDecompressorTest.java,v 1.0 24/03/2021 haraldk Exp$
  */
-public class QTRAWDecompressorTest {
+class QTRAWDecompressorTest {
     private ImageDesc createDescription(int bitDepth) {
         ImageDesc description = new ImageDesc();
         description.compressorVendor = QuickTime.VENDOR_APPLE;
@@ -27,7 +27,7 @@ public class QTRAWDecompressorTest {
     }
 
     @Test
-    public void canDecompressRGB() {
+    void canDecompressRGB() {
         QTDecompressor decompressor = new QTRAWDecompressor();
 
         assertTrue(decompressor.canDecompress(createDescription(24)));
@@ -48,7 +48,7 @@ public class QTRAWDecompressorTest {
     }
 
     @Test
-    public void decompressRGBADataSizeTooSmall() {
+    void decompressRGBADataSizeTooSmall() {
         // width * height * 4 (256) is larger than the declared data size (16)
         ImageDesc description = createDescription(32);
         description.width = 8;
@@ -61,7 +61,7 @@ public class QTRAWDecompressorTest {
     }
 
     @Test
-    public void decompressRGBDataSizeTooSmall() {
+    void decompressRGBDataSizeTooSmall() {
         ImageDesc description = createDescription(24);
         description.width = 8;
         description.height = 8;
@@ -73,7 +73,7 @@ public class QTRAWDecompressorTest {
     }
 
     @Test
-    public void decompressGrayDataSizeTooSmall() {
+    void decompressGrayDataSizeTooSmall() {
         ImageDesc description = createDescription(40);
         description.width = 8;
         description.height = 8;


### PR DESCRIPTION
**What is fixed** No open issue; hardening the PICT reader against a crafted CompressedQuickTime opcode.

**Why is this change proposed** In `QTRAWDecompressor.decompress` the pixel buffer is sized from the `idsc` Atom `dataSize` field, but the 32-bit branch then swaps bytes at `4 * y * width + x * 4`, where `width`/`height` come from separate 16-bit header fields. A file where `dataSize` is smaller than `width * height * 4` overruns the buffer (`ArrayIndexOutOfBoundsException` out of `ImageIO.read` rather than an `IIOException`); the 24- and 40-bit branches hit the same mismatch as a `RasterFormatException`.

**What is changed**

* Validate `width`/`height` are positive and that the declared data length covers `width * height * bytesPerPixel` before indexing, throwing `IIOException` on malformed input. The product is computed as `long` since the 16-bit dimensions can overflow `int` at depth 32.
* Added regression tests for the undersized-data case at depth 24, 32 and 40.