### PR TITLE
Fix #1019: don't add alpha channel in createRotated for quadrant rotations

### DIFF
--- a/common/common-image/src/main/java/com/twelvemonkeys/image/ImageUtil.java
+++ b/common/common-image/src/main/java/com/twelvemonkeys/image/ImageUtil.java
@@ -721,8 +721,17 @@ public final class ImageUtil {
         AffineTransform transform = AffineTransform.getTranslateInstance((newW - w) / 2.0, (newH - h) / 2.0);
         transform.rotate(pAngle, w / 2.0, h / 2.0);
 
-        // TODO: Figure out if this is correct
-        BufferedImage dest = createTransparent(newW, newH);
+        // A quadrant rotation is completely covered by source pixels,
+        // so the destination can keep the source's color model.
+        // Other angles leave uncovered corners, which should be transparent.
+        BufferedImage dest;
+        if (fast) {
+            ColorModel cm = pSource.getColorModel();
+            dest = new BufferedImage(cm, cm.createCompatibleWritableRaster(newW, newH), cm.isAlphaPremultiplied(), null);
+        }
+        else {
+            dest = createTransparent(newW, newH);
+        }
 
         // See: http://weblogs.java.net/blog/campbell/archive/2007/03/java_2d_tricker_1.html
         Graphics2D g = dest.createGraphics();

--- a/common/common-image/src/test/java/com/twelvemonkeys/image/ImageUtilTest.java
+++ b/common/common-image/src/test/java/com/twelvemonkeys/image/ImageUtilTest.java
@@ -532,4 +532,47 @@ class ImageUtilTest {
         assertNotNull(image, "Image was null");
         assertInstanceOf(IndexColorModel.class, image.getColorModel());
     }
+
+    // Issue #1019
+    @Test
+    void testCreateRotatedQuadrantPreservesNoAlpha() {
+        BufferedImage source = createImage(100, 50, BufferedImage.TYPE_INT_RGB);
+        assertFalse(source.getColorModel().hasAlpha());
+
+        BufferedImage result = ImageUtil.createRotated(source, 90);
+
+        assertEquals(50, result.getWidth());
+        assertEquals(100, result.getHeight());
+        assertFalse(result.getColorModel().hasAlpha(), "Quadrant rotation of an opaque image should not add alpha");
+
+        // Rotating 90 degrees CW, the bottom-left corner of the source becomes the top-left corner
+        assertEquals(source.getRGB(0, 49), result.getRGB(0, 0));
+        assertEquals(source.getRGB(0, 0), result.getRGB(49, 0));
+        assertEquals(source.getRGB(99, 49), result.getRGB(0, 99));
+    }
+
+    // Issue #1019
+    @Test
+    void testCreateRotatedQuadrantPreservesAlpha() {
+        BufferedImage source = createImage(100, 50, BufferedImage.TYPE_INT_ARGB);
+        assertTrue(source.getColorModel().hasAlpha());
+
+        BufferedImage result = ImageUtil.createRotated(source, 180);
+
+        assertEquals(100, result.getWidth());
+        assertEquals(50, result.getHeight());
+        assertTrue(result.getColorModel().hasAlpha());
+        assertEquals(source.getRGB(0, 0), result.getRGB(99, 49));
+    }
+
+    @Test
+    void testCreateRotatedNonQuadrantHasAlpha() {
+        BufferedImage source = createImage(100, 50, BufferedImage.TYPE_INT_RGB);
+
+        BufferedImage result = ImageUtil.createRotated(source, Math.toRadians(45));
+
+        // Corners are not covered by source pixels, and should be transparent
+        assertTrue(result.getColorModel().hasAlpha(), "Non-quadrant rotation needs alpha for uncovered corners");
+        assertEquals(0, result.getRGB(0, 0) >>> 24, "Corner should be transparent");
+    }
 }


### PR DESCRIPTION
A quadrant rotation (90/180/270 degrees) covers every destination pixel with source pixels, so the destination now keeps the source's color model instead of always being created as TYPE_INT_ARGB. Non-quadrant rotations still get a transparent destination, as the uncovered corners need alpha.